### PR TITLE
Fix DATA_SOURCE_NAME building and running example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Supported MySQL versions: 5.1 and up.
 ## Building and running
 
     make
-    export DATA_SOURCE_NAME="login:password@host/dbname"
+    export DATA_SOURCE_NAME="login:password@(hostname:port)/dbname"
     ./mysqld_exporter <flags>
 
 ### Flags


### PR DESCRIPTION
A little fix for the README example after testing this exporter in a docker container with a linked mysql one.
I was getting this error :
```
 Default addr for network 'bdd' unknown
```

When using this `DATA_SOURCE_NAME`
```
login:password@bdd/dbname
```

The right way was :
```
login:password@(bdd:3306)/dbname
```