### PR TITLE
Fix regex bug that caused numbers to be truncated.

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -209,7 +209,7 @@ func (e *Exporter) collectMetrics(metrics chan<- prometheus.Metric) {
 }
 
 func parseStatus(data []byte) string {
-	logRexp := regexp.MustCompile(".([0-9]+$)")
+	logRexp := regexp.MustCompile(`\.([0-9]+$)`)
 	logNum := logRexp.Find(data)
 
 	switch {


### PR DESCRIPTION
Bugfix: Fix regex pattern, so that it no longer catches anything other than logs.

This got through all the testing we did here somehow.  Sorry about that.