### PR TITLE
Add support for Percona userstats output.

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -27,23 +27,23 @@ var (
 		"Path under which to expose metrics.",
 	)
 	autoIncrementColumns = flag.Bool(
-		"collect.auto_increment.columns", true,
+		"collect.auto_increment.columns", false,
 		"Collect auto_increment columns and max values from information_schema",
 	)
 	perfTableIOWaits = flag.Bool(
-		"collect.perf_schema.tableiowaits", true,
+		"collect.perf_schema.tableiowaits", false,
 		"Collect metrics from performance_schema.table_io_waits_summary_by_table",
 	)
 	perfTableIOWaitsTime = flag.Bool(
-		"collect.perf_schema.tableiowaitstime", true,
+		"collect.perf_schema.tableiowaitstime", false,
 		"Collect time metrics from performance_schema.table_io_waits_summary_by_table",
 	)
 	perfIndexIOWaits = flag.Bool(
-		"collect.perf_schema.indexiowaits", true,
+		"collect.perf_schema.indexiowaits", false,
 		"Collect metrics from performance_schema.table_io_waits_summary_by_index_usage",
 	)
 	perfIndexIOWaitsTime = flag.Bool(
-		"collect.perf_schema.indexiowaitstime", true,
+		"collect.perf_schema.indexiowaitstime", false,
 		"Collect time metrics from performance_schema.table_io_waits_summary_by_index_usage",
 	)
 	userStat = flag.Bool("collect.info_schema.userstats", false,

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -149,27 +149,90 @@ var (
 		vtype prometheus.ValueType
 		desc  *prometheus.Desc
 	}{
-		"TOTAL_CONNECTIONS":      {prometheus.CounterValue, prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_total_connections"), "The number of connections created for this user.", []string{"user"}, nil)},
-		"CONCURRENT_CONNECTIONS": {prometheus.GaugeValue, prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_concurrent_connections"), "The number of concurrent connections for this user.", []string{"user"}, nil)},
-		"CONNECTED_TIME":         {prometheus.CounterValue, prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_connected_time"), "The cumulative number of seconds elapsed while there were connections from this user.", []string{"user"}, nil)},
-		"BUSY_TIME":              {prometheus.CounterValue, prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_busy_time"), "The cumulative number of seconds there was activity on connections from this user.", []string{"user"}, nil)},
-		"CPU_TIME":               {prometheus.CounterValue, prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_cpu_time"), "The cumulative CPU time elapsed, in seconds, while servicing this user's connections.", []string{"user"}, nil)},
-		"BYTES_RECEIVED":         {prometheus.CounterValue, prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_bytes_received"), "The number of bytes received from this user’s connections.", []string{"user"}, nil)},
-		"BYTES_SENT":             {prometheus.CounterValue, prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_bytes_sent"), "The number of bytes sent to this user’s connections.", []string{"user"}, nil)},
-		"BINLOG_BYTES_WRITTEN":   {prometheus.CounterValue, prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_binlog_bytes_written"), "The number of bytes written to the binary log from this user’s connections.", []string{"user"}, nil)},
-		"ROWS_FETCHED":           {prometheus.CounterValue, prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_rows_fetched"), "The number of rows fetched by this user’s connections.", []string{"user"}, nil)},
-		"ROWS_UPDATED":           {prometheus.CounterValue, prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_rows_updated"), "The number of rows updated by this user’s connections.", []string{"user"}, nil)},
-		"TABLE_ROWS_READ":        {prometheus.CounterValue, prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_table_rows_read"), "The number of rows read from tables by this user’s connections. (It may be different from ROWS_FETCHED.)", []string{"user"}, nil)},
-		"SELECT_COMMANDS":        {prometheus.CounterValue, prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_select_commands"), "The number of SELECT commands executed from this user’s connections.", []string{"user"}, nil)},
-		"UPDATE_COMMANDS":        {prometheus.CounterValue, prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_update_commands"), "The number of UPDATE commands executed from this user’s connections.", []string{"user"}, nil)},
-		"OTHER_COMMANDS":         {prometheus.CounterValue, prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_other_commands"), "The number of other commands executed from this user’s connections.", []string{"user"}, nil)},
-		"COMMIT_TRANSACTIONS":    {prometheus.CounterValue, prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_commit_transactions"), "The number of COMMIT commands issued by this user’s connections.", []string{"user"}, nil)},
-		"ROLLBACK_TRANSACTIONS":  {prometheus.CounterValue, prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_rollback_transactions"), "The number of ROLLBACK commands issued by this user’s connections.", []string{"user"}, nil)},
-		"DENIED_CONNECTIONS":     {prometheus.CounterValue, prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_denied_connections"), "The number of connections denied to this user.", []string{"user"}, nil)},
-		"LOST_CONNECTIONS":       {prometheus.CounterValue, prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_lost_connections"), "The number of this user’s connections that were terminated uncleanly.", []string{"user"}, nil)},
-		"ACCESS_DENIED":          {prometheus.CounterValue, prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_access_denied"), "The number of times this user’s connections issued commands that were denied.", []string{"user"}, nil)},
-		"EMPTY_QUERIES":          {prometheus.CounterValue, prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_empty_queries"), "The number of times this user’s connections sent empty queries to the server.", []string{"user"}, nil)},
-		"TOTAL_SSL_CONNECTIONS":  {prometheus.CounterValue, prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_total_ssl_connections"), "The number of times this user’s connections connected using SSL to the server.", []string{"user"}, nil)},
+		"TOTAL_CONNECTIONS": {prometheus.CounterValue,
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_total_connections"),
+				"The number of connections created for this user.",
+				[]string{"user"}, nil)},
+		"CONCURRENT_CONNECTIONS": {prometheus.GaugeValue,
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_concurrent_connections"),
+				"The number of concurrent connections for this user.",
+				[]string{"user"}, nil)},
+		"CONNECTED_TIME": {prometheus.CounterValue,
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_connected_time"),
+				"The cumulative number of seconds elapsed while there were connections from this user.",
+				[]string{"user"}, nil)},
+		"BUSY_TIME": {prometheus.CounterValue,
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_busy_time"),
+				"The cumulative number of seconds there was activity on connections from this user.",
+				[]string{"user"}, nil)},
+		"CPU_TIME": {prometheus.CounterValue,
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_cpu_time"),
+				"The cumulative CPU time elapsed, in seconds, while servicing this user's connections.",
+				[]string{"user"}, nil)},
+		"BYTES_RECEIVED": {prometheus.CounterValue,
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_bytes_received"),
+				"The number of bytes received from this user’s connections.",
+				[]string{"user"}, nil)},
+		"BYTES_SENT": {prometheus.CounterValue,
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_bytes_sent"),
+				"The number of bytes sent to this user’s connections.",
+				[]string{"user"}, nil)},
+		"BINLOG_BYTES_WRITTEN": {prometheus.CounterValue,
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_binlog_bytes_written"),
+				"The number of bytes written to the binary log from this user’s connections.",
+				[]string{"user"}, nil)},
+		"ROWS_FETCHED": {prometheus.CounterValue,
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_rows_fetched"),
+				"The number of rows fetched by this user’s connections.",
+				[]string{"user"}, nil)},
+		"ROWS_UPDATED": {prometheus.CounterValue,
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_rows_updated"),
+				"The number of rows updated by this user’s connections.",
+				[]string{"user"}, nil)},
+		"TABLE_ROWS_READ": {prometheus.CounterValue,
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_table_rows_read"),
+				"The number of rows read from tables by this user’s connections. (It may be different from ROWS_FETCHED.)",
+				[]string{"user"}, nil)},
+		"SELECT_COMMANDS": {prometheus.CounterValue,
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_select_commands"),
+				"The number of SELECT commands executed from this user’s connections.",
+				[]string{"user"}, nil)},
+		"UPDATE_COMMANDS": {prometheus.CounterValue,
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_update_commands"),
+				"The number of UPDATE commands executed from this user’s connections.",
+				[]string{"user"}, nil)},
+		"OTHER_COMMANDS": {prometheus.CounterValue,
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_other_commands"),
+				"The number of other commands executed from this user’s connections.",
+				[]string{"user"}, nil)},
+		"COMMIT_TRANSACTIONS": {prometheus.CounterValue,
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_commit_transactions"),
+				"The number of COMMIT commands issued by this user’s connections.",
+				[]string{"user"}, nil)},
+		"ROLLBACK_TRANSACTIONS": {prometheus.CounterValue,
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_rollback_transactions"),
+				"The number of ROLLBACK commands issued by this user’s connections.",
+				[]string{"user"}, nil)},
+		"DENIED_CONNECTIONS": {prometheus.CounterValue,
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_denied_connections"),
+				"The number of connections denied to this user.",
+				[]string{"user"}, nil)},
+		"LOST_CONNECTIONS": {prometheus.CounterValue,
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_lost_connections"),
+				"The number of this user’s connections that were terminated uncleanly.",
+				[]string{"user"}, nil)},
+		"ACCESS_DENIED": {prometheus.CounterValue,
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_access_denied"),
+				"The number of times this user’s connections issued commands that were denied.",
+				[]string{"user"}, nil)},
+		"EMPTY_QUERIES": {prometheus.CounterValue,
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_empty_queries"),
+				"The number of times this user’s connections sent empty queries to the server.",
+				[]string{"user"}, nil)},
+		"TOTAL_SSL_CONNECTIONS": {prometheus.CounterValue,
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, informationSchema, "user_statistics_total_ssl_connections"),
+				"The number of times this user’s connections connected using SSL to the server.",
+				[]string{"user"}, nil)},
 	}
 )
 
@@ -642,6 +705,10 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 		}
 		defer informationSchemaUserStatisticsRows.Close()
 
+		// The user column is assumed to be column[0], while all other data is assumed to be coerceable to float64.
+		// Because of the user column, userStatData[0] maps to columnNames[1] when reading off the metrics
+		// (because userStatScanArgs is mapped as [ &user, &userData[0], &userData[1] ... &userdata[n] ]
+		// To map metrics to names therefore we always range over columnNames[1:]
 		var columnNames []string
 		columnNames, err = informationSchemaUserStatisticsRows.Columns()
 		if err != nil {
@@ -650,8 +717,8 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 			return
 		}
 
-		var user string // Holds the username, which should be in column 0
-		var userStatData = make([]float64, len(columnNames))
+		var user string                                        // Holds the username, which should be in column 0
+		var userStatData = make([]float64, len(columnNames)-1) // 1 less because of the user column
 		var userStatScanArgs = make([]interface{}, len(columnNames))
 		userStatScanArgs[0] = &user
 		for i := range userStatData[1:] {


### PR DESCRIPTION
This commit adds support for dumping Percona userstats. These metrics are per
user counters are are exported as such to enable detection of resets by
Prometheus.

The new functionality, being limited to Percona, is enabled by invoking with
-collector.userstats=true