### PR TITLE
Add SHOW PROCESSLIST based counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ collect.perf_schema.tableiowaits           | Collect metrics from performance_sc
 collect.perf_schema.tableiowaitstime       | Collect time metrics from performance_schema.table_io_waits_summary_by_table.
 collect.perf_schema.tablelocks             | Collect metrics from performance_schema.table_lock_waits_summary_by_table.
 collect.perf_schema.tablelockstime         | Collect time metrics from performance_schema.events_statements_summary_by_digest.
+collect.info_schema.processlist            | Collect thread state counts from information_schema.processlist.
 log.level                                  | Logging verbosity (default: info)
 web.listen-address                         | Address to listen on for web interface and telemetry.
 web.telemetry-path                         | Path under which to expose metrics.


### PR DESCRIPTION
The new processlist flag enables "SHOW PROCESSLIST" and will generate a
simple connection counter that can be drilled down based on
- user
- source host
- query status / connection state

This is useful to find out more about concurrency problems
of a server (e.g. connection piling up, certain clients making
excessive use of lock, .....)

This is my first attempt at golang & prometheus. Expect some extra bugs and please give me some extra pointers to docs if anything is completely insane.