### PR TITLE
Add a collect.binlog_size flag that enables an aggregated binlog size gauge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ NOTE: Not all collection methods are support on MySQL < 5.6
 Name                                       | Description
 -------------------------------------------|------------------------------------------------------------------------------------
 collect.auto_increment.columns             | Collect auto_increment columns and max values from information_schema.
+collect.binlog_size                        | Compute the size of all binlog files combined (as specified by "SHOW MASTER LOGS")
 collect.info_schema.userstats              | If running with userstat=1, set to true to collect user statistics.
 collect.perf_schema.eventsstatements       | Collect time metrics from performance_schema.events_statements_summary_by_digest.
 collect.perf_schema.eventsstatements.limit | Limit the number of events statements digests by response time. (default: 250)


### PR DESCRIPTION
SHOW MASTER LOGS or SHOW BINARY LOGS can be used to retrieve a
list of all binary logs (including size). Summing up the sizes
gives a rough counter for the current binlog size.

See https://dev.mysql.com/doc/refman/5.7/en/show-binary-logs.html
for details.

This gauge simply sums the File_size column. (Note that the total size will grow/shrink as new binlogs are written and old ones are purged)

Required mysql permission: SUPER or REPLICATION CLIENT