### PR TITLE
Add metrics for table locks

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -46,6 +46,14 @@ var (
 		"collect.perf_schema.indexiowaitstime", false,
 		"Collect time metrics from performance_schema.table_io_waits_summary_by_index_usage",
 	)
+	perfTableLockWaits = flag.Bool(
+		"collect.perf_schema.tablelocks", false,
+		"Collect metrics from performance_schema.table_lock_waits_summary_by_table",
+	)
+	perfTableLockWaitsTime = flag.Bool(
+		"collect.perf_schema.tablelockstime", false,
+		"Collect time metrics from performance_schema.table_lock_waits_summary_by_table",
+	)
 	perfEventsStatements = flag.Bool(
 		"collect.perf_schema.eventsstatements", false,
 		"Collect time metrics from performance_schema.events_statements_summary_by_digest",
@@ -117,6 +125,42 @@ const (
 		SELECT OBJECT_SCHEMA, OBJECT_NAME, ifnull(INDEX_NAME, 'NONE') as INDEX_NAME, SUM_TIMER_FETCH, SUM_TIMER_INSERT, SUM_TIMER_UPDATE, SUM_TIMER_DELETE
 		  FROM performance_schema.table_io_waits_summary_by_index_usage
 		  WHERE OBJECT_SCHEMA NOT IN ('mysql', 'performance_schema')
+		`
+	perfTableLockWaitsQuery = `
+		SELECT
+		    OBJECT_SCHEMA,
+		    OBJECT_NAME,
+		    COUNT_READ_NORMAL,
+		    COUNT_READ_WITH_SHARED_LOCKS,
+		    COUNT_READ_HIGH_PRIORITY,
+		    COUNT_READ_NO_INSERT,
+		    COUNT_WRITE_NORMAL,
+		    COUNT_WRITE_ALLOW_WRITE,
+		    COUNT_WRITE_CONCURRENT_INSERT,
+		    COUNT_WRITE_DELAYED,
+		    COUNT_WRITE_LOW_PRIORITY,
+		    COUNT_READ_EXTERNAL,
+		    COUNT_WRITE_EXTERNAL
+		  FROM performance_schema.table_lock_waits_summary_by_table
+		  WHERE OBJECT_SCHEMA NOT IN ('mysql', 'performance_schema', 'information_schema')
+		`
+	perfTableLockWaitsTimeQuery = `
+		SELECT
+		    OBJECT_SCHEMA,
+		    OBJECT_NAME,
+		    SUM_TIMER_READ_NORMAL,
+		    SUM_TIMER_READ_WITH_SHARED_LOCKS,
+		    SUM_TIMER_READ_HIGH_PRIORITY,
+		    SUM_TIMER_READ_NO_INSERT,
+		    SUM_TIMER_WRITE_NORMAL,
+		    SUM_TIMER_WRITE_ALLOW_WRITE,
+		    SUM_TIMER_WRITE_CONCURRENT_INSERT,
+		    SUM_TIMER_WRITE_DELAYED,
+		    SUM_TIMER_WRITE_LOW_PRIORITY,
+		    SUM_TIMER_READ_EXTERNAL,
+		    SUM_TIMER_WRITE_EXTERNAL
+		  FROM performance_schema.table_lock_waits_summary_by_table
+		  WHERE OBJECT_SCHEMA NOT IN ('mysql', 'performance_schema', 'information_schema')
 		`
 	perfEventsStatementsQuery = `
 		SELECT
@@ -203,6 +247,26 @@ var (
 		prometheus.BuildFQName(namespace, performanceSchema, "index_io_waits_seconds_total"),
 		"The total time of index I/O wait events for each index and operation.",
 		[]string{"schema", "name", "index", "operation"}, nil,
+	)
+	performanceSchemaSQLTableLockWaitsDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "sql_lock_waits_total"),
+		"The total number of SQL lock wait events for each table and operation.",
+		[]string{"schema", "name", "operation"}, nil,
+	)
+	performanceSchemaExternalTableLockWaitsDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "external_lock_waits_total"),
+		"The total number of external lock wait events for each table and operation.",
+		[]string{"schema", "name", "operation"}, nil,
+	)
+	performanceSchemaSQLTableLockWaitsTimeDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "sql_lock_waits_seconds_total"),
+		"The total time of SQL lock wait events for each table and operation.",
+		[]string{"schema", "name", "operation"}, nil,
+	)
+	performanceSchemaExternalTableLockWaitsTimeDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "external_lock_waits_seconds_total"),
+		"The total time of external lock wait events for each table and operation.",
+		[]string{"schema", "name", "operation"}, nil,
 	)
 	performanceSchemaEventsStatementsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_total"),
@@ -481,14 +545,24 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 			log.Println("Error scraping performance schema:", err)
 			return
 		}
-
 	}
 	if *perfIndexIOWaitsTime {
 		if err = scrapePerfIndexIOWaitsTime(db, ch); err != nil {
 			log.Println("Error scraping performance schema:", err)
 			return
 		}
-
+	}
+	if *perfTableLockWaits {
+		if err = scrapePerfTableLockWaits(db, ch); err != nil {
+			log.Println("Error scraping performance schema:", err)
+			return
+		}
+	}
+	if *perfTableLockWaitsTime {
+		if err = scrapePerfTableLockWaitsTime(db, ch); err != nil {
+			log.Println("Error scraping performance schema:", err)
+			return
+		}
 	}
 	if *perfEventsStatements {
 		if err = scrapePerfEventsStatements(db, ch); err != nil {
@@ -806,6 +880,155 @@ func scrapePerfIndexIOWaitsTime(db *sql.DB, ch chan<- prometheus.Metric) error {
 				objectSchema, objectName, indexName, "delete",
 			)
 		}
+	}
+	return nil
+}
+
+func scrapePerfTableLockWaits(db *sql.DB, ch chan<- prometheus.Metric) error {
+	perfSchemaTableLockWaitsRows, err := db.Query(perfTableLockWaitsQuery)
+	if err != nil {
+		return err
+	}
+	defer perfSchemaTableLockWaitsRows.Close()
+
+	var (
+		objectSchema, objectName                      string
+		countReadNormal, countReadWithSharedLocks     uint64
+		countReadHighPriority, countReadNoInsert      uint64
+		countWriteNormal, countWriteAllowWrite        uint64
+		countWriteConcurrentInsert, countWriteDelayed uint64
+		countWriteLowPriority                         uint64
+		countReadExternal, countWriteExternal         uint64
+	)
+
+	for perfSchemaTableLockWaitsRows.Next() {
+		if err := perfSchemaTableLockWaitsRows.Scan(
+			&objectSchema, &objectName, &countReadNormal, &countReadWithSharedLocks,
+			&countReadHighPriority, &countReadNoInsert, &countWriteNormal,
+			&countWriteAllowWrite, &countWriteConcurrentInsert, &countWriteDelayed,
+			&countWriteLowPriority, &countReadExternal, &countWriteExternal,
+		); err != nil {
+			return err
+		}
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaSQLTableLockWaitsDesc, prometheus.CounterValue, float64(countReadNormal),
+			objectSchema, objectName, "read_normal",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaSQLTableLockWaitsDesc, prometheus.CounterValue, float64(countReadWithSharedLocks),
+			objectSchema, objectName, "read_with_shared_locks",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaSQLTableLockWaitsDesc, prometheus.CounterValue, float64(countReadHighPriority),
+			objectSchema, objectName, "read_high_priority",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaSQLTableLockWaitsDesc, prometheus.CounterValue, float64(countReadNoInsert),
+			objectSchema, objectName, "read_no_insert",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaSQLTableLockWaitsDesc, prometheus.CounterValue, float64(countWriteNormal),
+			objectSchema, objectName, "write_normal",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaSQLTableLockWaitsDesc, prometheus.CounterValue, float64(countWriteAllowWrite),
+			objectSchema, objectName, "write_allow_write",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaSQLTableLockWaitsDesc, prometheus.CounterValue, float64(countWriteConcurrentInsert),
+			objectSchema, objectName, "write_concurrent_insert",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaSQLTableLockWaitsDesc, prometheus.CounterValue, float64(countWriteDelayed),
+			objectSchema, objectName, "write_delayed",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaSQLTableLockWaitsDesc, prometheus.CounterValue, float64(countWriteLowPriority),
+			objectSchema, objectName, "write_low_priority",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaExternalTableLockWaitsDesc, prometheus.CounterValue, float64(countReadExternal),
+			objectSchema, objectName, "read",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaExternalTableLockWaitsDesc, prometheus.CounterValue, float64(countWriteExternal),
+			objectSchema, objectName, "write",
+		)
+	}
+	return nil
+}
+
+func scrapePerfTableLockWaitsTime(db *sql.DB, ch chan<- prometheus.Metric) error {
+	// Timers here are returned in picoseconds.
+	perfSchemaTableWaitsTimeRows, err := db.Query(perfTableLockWaitsTimeQuery)
+	if err != nil {
+		return err
+	}
+	defer perfSchemaTableWaitsTimeRows.Close()
+
+	var (
+		objectSchema, objectName                    string
+		timeReadNormal, timeReadWithSharedLocks     uint64
+		timeReadHighPriority, timeReadNoInsert      uint64
+		timeWriteNormal, timeWriteAllowWrite        uint64
+		timeWriteConcurrentInsert, timeWriteDelayed uint64
+		timeWriteLowPriority                        uint64
+		timeReadExternal, timeWriteExternal         uint64
+	)
+
+	for perfSchemaTableWaitsTimeRows.Next() {
+		if err := perfSchemaTableWaitsTimeRows.Scan(
+			&objectSchema, &objectName, &timeReadNormal, &timeReadWithSharedLocks,
+			&timeReadHighPriority, &timeReadNoInsert, &timeWriteNormal,
+			&timeWriteAllowWrite, &timeWriteConcurrentInsert, &timeWriteDelayed,
+			&timeWriteLowPriority, &timeReadExternal, &timeWriteExternal,
+		); err != nil {
+			return err
+		}
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaSQLTableLockWaitsTimeDesc, prometheus.CounterValue, float64(timeReadNormal)/picoSeconds,
+			objectSchema, objectName, "read_normal",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaSQLTableLockWaitsTimeDesc, prometheus.CounterValue, float64(timeReadWithSharedLocks)/picoSeconds,
+			objectSchema, objectName, "read_with_shared_locks",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaSQLTableLockWaitsTimeDesc, prometheus.CounterValue, float64(timeReadHighPriority)/picoSeconds,
+			objectSchema, objectName, "read_high_priority",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaSQLTableLockWaitsTimeDesc, prometheus.CounterValue, float64(timeReadNoInsert)/picoSeconds,
+			objectSchema, objectName, "read_no_insert",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaSQLTableLockWaitsTimeDesc, prometheus.CounterValue, float64(timeWriteNormal)/picoSeconds,
+			objectSchema, objectName, "write_normal",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaSQLTableLockWaitsTimeDesc, prometheus.CounterValue, float64(timeWriteAllowWrite)/picoSeconds,
+			objectSchema, objectName, "write_allow_write",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaSQLTableLockWaitsTimeDesc, prometheus.CounterValue, float64(timeWriteConcurrentInsert)/picoSeconds,
+			objectSchema, objectName, "write_concurrent_insert",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaSQLTableLockWaitsTimeDesc, prometheus.CounterValue, float64(timeWriteDelayed)/picoSeconds,
+			objectSchema, objectName, "write_delayed",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaSQLTableLockWaitsTimeDesc, prometheus.CounterValue, float64(timeWriteLowPriority)/picoSeconds,
+			objectSchema, objectName, "write_low_priority",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaExternalTableLockWaitsTimeDesc, prometheus.CounterValue, float64(timeReadExternal)/picoSeconds,
+			objectSchema, objectName, "read",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaExternalTableLockWaitsTimeDesc, prometheus.CounterValue, float64(timeWriteExternal)/picoSeconds,
+			objectSchema, objectName, "write",
+		)
 	}
 	return nil
 }


### PR DESCRIPTION
Gather counter and time metrics from
`performance_schema.table_lock_waits_summary_by_table`[0]

Separate out SQL and External locks

[0]: https://dev.mysql.com/doc/refman/5.6/en/table-waits-summary-tables.html#table-lock-waits-summary-by-table-table