### PR TITLE
Consolidate performance_schema metrics flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,12 @@ Name                                       | Description
 collect.auto_increment.columns             | Collect auto_increment columns and max values from information_schema.
 collect.binlog_size                        | Compute the size of all binlog files combined (as specified by "SHOW MASTER LOGS")
 collect.info_schema.userstats              | If running with userstat=1, set to true to collect user statistics.
-collect.perf_schema.eventsstatements       | Collect time metrics from performance_schema.events_statements_summary_by_digest.
+collect.perf_schema.eventsstatements       | Collect metrics from performance_schema.events_statements_summary_by_digest.
 collect.perf_schema.eventsstatements.limit | Limit the number of events statements digests by response time. (default: 250)
 collect.perf_schema.eventsstatements.digest_text_limit | Maximum length of the normalized statement text. (default: 120)
 collect.perf_schema.indexiowaits           | Collect metrics from performance_schema.table_io_waits_summary_by_index_usage.
-collect.perf_schema.indexiowaitstime       | Collect time metrics from performance_schema.table_io_waits_summary_by_index_usage.
 collect.perf_schema.tableiowaits           | Collect metrics from performance_schema.table_io_waits_summary_by_table.
-collect.perf_schema.tableiowaitstime       | Collect time metrics from performance_schema.table_io_waits_summary_by_table.
 collect.perf_schema.tablelocks             | Collect metrics from performance_schema.table_lock_waits_summary_by_table.
-collect.perf_schema.tablelockstime         | Collect time metrics from performance_schema.events_statements_summary_by_digest.
 collect.info_schema.processlist            | Collect thread state counts from information_schema.processlist.
 log.level                                  | Logging verbosity (default: info)
 web.listen-address                         | Address to listen on for web interface and telemetry.


### PR DESCRIPTION
Reduce the number of flags needed to enable performance_schema metrics.
* Reduces the number of flags needed to enable collection
* Reduces the number of queries to the server per collection
* Update README

Also fix typo in events_statements flag documentation