### PR TITLE
Add option to automatic ANALYZE TABLE

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"os"
 	"regexp"
@@ -41,6 +42,10 @@ var (
 	tableSchemaAutoAnalyze = flag.Bool(
 		"collect.info_schema.tables.auto_analyze", false,
 		"Automatically run ANALYZE TABLE to update stats",
+	)
+	tableSchemaAutoAnalyzeDuration = flag.Duration(
+		"collect.info_schema.tables.auto_analyze.min_duration", 5*time.Minute,
+		"Minimum seconds between automatic ANALYZE TABLE calls",
 	)
 	collectGlobalStatus = flag.Bool(
 		"collect.global_status", true,
@@ -668,6 +673,9 @@ type Exporter struct {
 	duration, error prometheus.Gauge
 	totalScrapes    prometheus.Counter
 }
+
+// Last run tracking variable for scrapeTableSchema().
+var tableSchemaLastRun = map[string]time.Time{}
 
 // NewExporter returns a new MySQL exporter for the provided DSN.
 func NewExporter(dsn string) *Exporter {
@@ -1656,8 +1664,12 @@ func scrapeTableSchema(db *sql.DB, ch chan<- prometheus.Metric) error {
 	}
 
 	for _, database := range dbList {
-		if *tableSchemaAutoAnalyze {
+		random := 1 + rand.Float64() * 0.25
+		nextRun := time.Duration(float64(*tableSchemaAutoAnalyzeDuration)*random)
+		if *tableSchemaAutoAnalyze && time.Since(tableSchemaLastRun[database]) > nextRun {
 			tablesRows, err := db.Query(fmt.Sprintf(tableListQuery, database))
+			tableSchemaLastRun[database] = time.Now()
+			log.Debugf("Ran AutoAnalyze on %s", database)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
MySQL >= 5.6 does not automatically update table statistics due to
performance impact.

This allows the mysqld_exporter scrapes to trigger stats updates on
demand.  This could have a load impact on MySQL so best to use in an
out-of-band MySQL server.  For example a hot-backup slave.