### PR TITLE
Added collecting of table statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Name                                       | Description
 collect.auto_increment.columns             | Collect auto_increment columns and max values from information_schema.
 collect.binlog_size                        | Compute the size of all binlog files combined (as specified by "SHOW MASTER LOGS")
 collect.info_schema.userstats              | If running with userstat=1, set to true to collect user statistics.
+collect.info_schema.tablestats             | If running with userstat=1, set to true to collect table statistics.
 collect.info_schema.tables                 | Collect metrics from information_schema.tables.
 collect.info_schema.tables.databases       | The list of databases to collect table stats for, or '`*`' for all.
 collect.perf_schema.eventsstatements       | Collect metrics from performance_schema.events_statements_summary_by_digest.


### PR DESCRIPTION
Added collecting of table stats (information_schema.TABLE_STATISTICS) similar to the existing user stats (information_schema.USER_STATISTICS).

Docs https://www.percona.com/doc/percona-server/5.5/diagnostics/user_stats.html#TABLE_STATISTICS Also the option `userstat` presents in MariaDB.

This allows to get the metrics of how many rows read/changed in the tables to find busiest or unused tables.

```
# HELP mysql_info_schema_table_statistics_rows_changed_total The number of rows changed in the table.
# TYPE mysql_info_schema_table_statistics_rows_changed_total counter
mysql_info_schema_table_statistics_rows_changed_total{schema="test",table="checksums"} 77
mysql_info_schema_table_statistics_rows_changed_total{schema="test",table="heartbeat"} 0
# HELP mysql_info_schema_table_statistics_rows_changed_x_indexes_total The number of rows changed in the table, multiplied by the number of indexes changed.
# TYPE mysql_info_schema_table_statistics_rows_changed_x_indexes_total counter
mysql_info_schema_table_statistics_rows_changed_x_indexes_total{schema="test",table="checksums"} 154
mysql_info_schema_table_statistics_rows_changed_x_indexes_total{schema="test",table="heartbeat"} 0
# HELP mysql_info_schema_table_statistics_rows_read_total The number of rows read from the table.
# TYPE mysql_info_schema_table_statistics_rows_read_total counter
mysql_info_schema_table_statistics_rows_read_total{schema="test",table="checksums"} 308
mysql_info_schema_table_statistics_rows_read_total{schema="test",table="heartbeat"} 6
```