### PR TITLE
Create mysql_version_info metric to report MySQL version and distro

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -887,6 +887,7 @@ func scrapeGlobalVariables(db *sql.DB, ch chan<- prometheus.Metric) error {
 	var key string
 	var val sql.RawBytes
 	var mysqlVersion = map[string]string {
+		"innodb_version": "",
 		"version": "",
 		"version_comment": "",
 	}
@@ -907,11 +908,11 @@ func scrapeGlobalVariables(db *sql.DB, ch chan<- prometheus.Metric) error {
 			mysqlVersion[key] = string(val)
 		}
 	}
-	// Create mysql_version_info metric with version, version_comment labels
+	// Create mysql_version_info metric
 	ch <- prometheus.MustNewConstMetric(
 		prometheus.NewDesc(prometheus.BuildFQName(namespace, "version", "info"), "MySQL version and distribution.",
-		[]string{"version", "version_comment"}, nil),
-		prometheus.GaugeValue, 1, mysqlVersion["version"], mysqlVersion["version_comment"],
+		[]string{"innodb_version", "version", "version_comment"}, nil),
+		prometheus.GaugeValue, 1, mysqlVersion["innodb_version"], mysqlVersion["version"], mysqlVersion["version_comment"],
 	)
 	return nil
 }


### PR DESCRIPTION
It would be great to display MySQL version and distribution on the dashboards having a simple metric to report this, similar to `node_uname_info` from node_exporter.

When the existing option `-collect.global_variables` is enabled, it will create the following metric:
```
# HELP mysql_version_info MySQL version and distribution.
# TYPE mysql_version_info gauge
mysql_version_info{version="5.5.44",version_comment="Source distribution"} 1
```