### PR TITLE
Early abort slave status

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -1074,35 +1074,37 @@ func scrapeSlaveStatus(db *sql.DB, ch chan<- prometheus.Metric) error {
 	}
 	defer slaveStatusRows.Close()
 
-	if slaveStatusRows.Next() {
-		// There is either no row in SHOW SLAVE STATUS (if this is not a
-		// slave server), or exactly one. In case of multi-source
-		// replication, things work very much differently. This code
-		// cannot deal with that case.
-		slaveCols, err := slaveStatusRows.Columns()
-		if err != nil {
-			return err
-		}
+	// There is either no row in SHOW SLAVE STATUS (if this is not a
+	// slave server), or exactly one. In case of multi-source
+	// replication, things work very much differently. This code
+	// cannot deal with that case.
+	if !slaveStatusRows.Next() {
+		return nil
+	}
 
-		// As the number of columns varies with mysqld versions,
-		// and sql.Scan requires []interface{}, we need to create a
-		// slice of pointers to the elements of slaveData.
-		scanArgs := make([]interface{}, len(slaveCols))
-		for i := range scanArgs {
-			scanArgs[i] = &sql.RawBytes{}
-		}
+	slaveCols, err := slaveStatusRows.Columns()
+	if err != nil {
+		return err
+	}
 
-		if err := slaveStatusRows.Scan(scanArgs...); err != nil {
-			return err
-		}
-		for i, col := range slaveCols {
-			if value, ok := parseStatus(*scanArgs[i].(*sql.RawBytes)); ok { // Silently skip unparsable values.
-				ch <- prometheus.MustNewConstMetric(
-					newDesc(slaveStatus, strings.ToLower(col), "Generic metric from SHOW SLAVE STATUS."),
-					prometheus.UntypedValue,
-					value,
-				)
-			}
+	// As the number of columns varies with mysqld versions,
+	// and sql.Scan requires []interface{}, we need to create a
+	// slice of pointers to the elements of slaveData.
+	scanArgs := make([]interface{}, len(slaveCols))
+	for i := range scanArgs {
+		scanArgs[i] = &sql.RawBytes{}
+	}
+
+	if err := slaveStatusRows.Scan(scanArgs...); err != nil {
+		return err
+	}
+	for i, col := range slaveCols {
+		if value, ok := parseStatus(*scanArgs[i].(*sql.RawBytes)); ok { // Silently skip unparsable values.
+			ch <- prometheus.MustNewConstMetric(
+				newDesc(slaveStatus, strings.ToLower(col), "Generic metric from SHOW SLAVE STATUS."),
+				prometheus.UntypedValue,
+				value,
+			)
 		}
 	}
 	return nil


### PR DESCRIPTION
Early abort scrapeSlaveStatus() when there is no output from
`SHOW SLAVE STATUS`