### PR TITLE
Fixing the return of the function and logging the error

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -745,7 +745,8 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 	if *slowLogFilter {
 		sessionSettingsRows, err := db.Query(sessionSettingsQuery)
 		if err != nil {
-			return err
+			log.Println("Error setting log_slow_filter:", err)
+			return
 		}
 		sessionSettingsRows.Close()
 	}


### PR DESCRIPTION
Compiling with default settings I got:

./mysqld_exporter.go:748: too many arguments to return
