### PR TITLE
Check log_bin before running SHOW BINARY LOGS

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -127,6 +127,7 @@ const (
 	globalVariablesQuery       = `SHOW GLOBAL VARIABLES`
 	slaveStatusQuery           = `SHOW SLAVE STATUS`
 	binlogQuery                = `SHOW BINARY LOGS`
+	logbinQuery                = `SELECT @@log_bin`
 	infoSchemaProcesslistQuery = `
 		SELECT COALESCE(command,''),COALESCE(state,''),count(*)
 		FROM information_schema.processlist
@@ -1012,8 +1013,8 @@ func scrapeInformationSchema(db *sql.DB, ch chan<- prometheus.Metric) error {
 }
 
 func scrapeBinlogSize(db *sql.DB, ch chan<- prometheus.Metric) error {
-	var logBin int8
-	err := db.QueryRow("SELECT @@log_bin").Scan(&logBin)
+	var logBin uint8
+	err := db.QueryRow(logbinQuery).Scan(&logBin)
 	if err != nil {
 		return err
 	}

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -1012,6 +1012,16 @@ func scrapeInformationSchema(db *sql.DB, ch chan<- prometheus.Metric) error {
 }
 
 func scrapeBinlogSize(db *sql.DB, ch chan<- prometheus.Metric) error {
+	var logBin int8
+	err := db.QueryRow("SELECT @@log_bin").Scan(&logBin)
+	if err != nil {
+		return err
+	}
+	// If log_bin is OFF, do not run SHOW BINARY LOGS which explicitly produces MySQL error
+	if logBin == 0 {
+		return nil
+	}
+
 	masterLogRows, err := db.Query(binlogQuery)
 	if err != nil {
 		return err


### PR DESCRIPTION
`SHOW BINARY LOGS` unlike other SQL queries produces the error when `log-bin` is OFF:
```
INFO[0000] Error scraping binlog size: Error 1381: You are not using binary logging  file=mysqld_exporter.go line=797
```
This causes all other scrapes coming after `scrapeBinlogSize()` to not execute, in particular all `scrapePerf*` ones. Added a check that prevents running this query when `log_bin` if OFF.