### PR TITLE
Added .my.cnf support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ NOTE: Not all collection methods are support on MySQL < 5.6
     export DATA_SOURCE_NAME="login:password@(hostname:port)/dbname"
     ./mysqld_exporter <flags>
 
+Running using ~/.my.cnf:
+
+    ./mysqld_exporter <flags>
+
 ### Flags
 
 Name                                       | Description
@@ -29,6 +33,7 @@ collect.perf_schema.tablelocks             | Collect metrics from performance_sc
 collect.perf_schema.file_events            | Collect metrics from performance_schema.file_summary_by_event_name.
 collect.perf_schema.eventswaits            | Collect metrics from performance_schema.events_waits_summary_global_by_event_name.
 collect.info_schema.processlist            | Collect thread state counts from information_schema.processlist.
+config.my-cnf                              | Path to .my.cnf file to read MySQL credentials from. (default: `~/.my.cnf`)
 log.level                                  | Logging verbosity (default: info)
 web.listen-address                         | Address to listen on for web interface and telemetry.
 web.telemetry-path                         | Path under which to expose metrics.

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -1796,18 +1796,14 @@ func parseMycnf() (string) {
 		}
 		return in
 	})
-	port := cfg.Section("client").Key("port").Validate(func(in string) string {
-		if len(in) == 0 {
-			return "3306"
-		}
-		return in
-	})
+	host := cfg.Section("client").Key("host").MustString("localhost")
+	port := cfg.Section("client").Key("port").MustUint(3306)
 	socket := cfg.Section("client").Key("socket").String()
 	var dsn string
 	if socket != "" {
 		dsn = fmt.Sprintf("%s:%s@unix(%s)/", user, password, socket)
 	} else {
-		dsn = fmt.Sprintf("%s:%s@tcp(localhost:%s)/", user, password, port)
+		dsn = fmt.Sprintf("%s:%s@tcp(%s:%d)/", user, password, host, port)
 	}
 	log.Debugln(dsn)
 	return dsn

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/log"
+	"gopkg.in/ini.v1"
 )
 
 var (
@@ -25,6 +27,10 @@ var (
 	metricPath = flag.String(
 		"web.telemetry-path", "/metrics",
 		"Path under which to expose metrics.",
+	)
+	configMycnf = flag.String(
+		"config.my-cnf", path.Join(os.Getenv("HOME"), ".my.cnf"),
+		"Path to .my.cnf file to read MySQL credentials from.",
 	)
 	slowLogFilter = flag.Bool(
 		"log_slow_filter", false,
@@ -1773,12 +1779,46 @@ func parseStatus(data sql.RawBytes) (float64, bool) {
 	return value, err == nil
 }
 
+func parseMycnf() (string) {
+	cfg, err := ini.Load(*configMycnf)
+	if err != nil {
+		log.Fatalf("failed reading .my.cnf file: %s", err)
+	}
+	user := cfg.Section("client").Key("user").Validate(func(in string) string {
+		if len(in) == 0 {
+			log.Fatalf("no user specified under [client] in %s", *configMycnf)
+		}
+		return in
+	})
+	password := cfg.Section("client").Key("password").Validate(func(in string) string {
+		if len(in) == 0 {
+			log.Fatalf("no password specified under [client] in %s", *configMycnf)
+		}
+		return in
+	})
+	port := cfg.Section("client").Key("port").Validate(func(in string) string {
+		if len(in) == 0 {
+			return "3306"
+		}
+		return in
+	})
+	socket := cfg.Section("client").Key("socket").String()
+	var dsn string
+	if socket != "" {
+		dsn = fmt.Sprintf("%s:%s@unix(%s)/", user, password, socket)
+	} else {
+		dsn = fmt.Sprintf("%s:%s@tcp(localhost:%s)/", user, password, port)
+	}
+	log.Debugln(dsn)
+	return dsn
+}
+
 func main() {
 	flag.Parse()
 
 	dsn := os.Getenv("DATA_SOURCE_NAME")
 	if len(dsn) == 0 {
-		log.Fatal("couldn't find environment variable DATA_SOURCE_NAME")
+		dsn = parseMycnf()
 	}
 
 	exporter := NewExporter(dsn)


### PR DESCRIPTION
Adding support for reading MySQL credentials from `.my.cnf`. Using environmental variable to pass the DSN is not really flexible from automation point of view.