### PR TITLE
Added query response time distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ collect.info_schema.userstats              | If running with userstat=1, set to 
 collect.info_schema.tablestats             | If running with userstat=1, set to true to collect table statistics.
 collect.info_schema.tables                 | Collect metrics from information_schema.tables.
 collect.info_schema.tables.databases       | The list of databases to collect table stats for, or '`*`' for all.
+collect.info_schema.query_response_time    | Collect query response time distribution if query_response_time_stats is ON.
 collect.perf_schema.eventsstatements       | Collect metrics from performance_schema.events_statements_summary_by_digest.
 collect.perf_schema.eventsstatements.limit | Limit the number of events statements digests by response time. (default: 250)
 collect.perf_schema.eventsstatements.digest_text_limit | Maximum length of the normalized statement text. (default: 120)

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -265,12 +265,13 @@ const (
 		  WHERE SCHEMA_NAME NOT IN ('mysql', 'performance_schema', 'information_schema')
 		`
 	queryResponseCheckQuery = `SELECT @@query_response_time_stats`
-	queryResponseTimeQuery = `
+	queryResponseTimeQuery  = `
 		SELECT
 		    TIME, COUNT, TOTAL
 		  FROM information_schema.query_response_time
 	`
 )
+
 var slaveStatusQuerySuffixes = [3]string{" NONBLOCKING", " NOLOCK", ""}
 
 // landingPage contains the HTML served at '/'.
@@ -975,7 +976,7 @@ func scrapeGlobalVariables(db *sql.DB, ch chan<- prometheus.Metric) error {
 func scrapeSlaveStatus(db *sql.DB, ch chan<- prometheus.Metric) error {
 	var (
 		slaveStatusRows *sql.Rows
-		err error
+		err             error
 	)
 	// Leverage lock-free SHOW SLAVE STATUS by guessing the right suffix
 	for _, suffix := range slaveStatusQuerySuffixes {
@@ -1656,7 +1657,7 @@ func scrapeQueryResponseTime(db *sql.DB, ch chan<- prometheus.Metric) error {
 		total        string
 		histogramCnt uint64
 		histogramSum float64
-		countBuckets = map[float64]uint64 {}
+		countBuckets = map[float64]uint64{}
 	)
 
 	for queryDistributionRows.Next() {
@@ -1867,7 +1868,7 @@ func parseStatus(data sql.RawBytes) (float64, bool) {
 	return value, err == nil
 }
 
-func parseMycnf() (string) {
+func parseMycnf() string {
 	cfg, err := ini.Load(*configMycnf)
 	if err != nil {
 		log.Fatalf("failed reading .my.cnf file: %s", err)

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -110,6 +110,8 @@ var (
 	collectTableStat = flag.Bool("collect.info_schema.tablestats", false,
 		"If running with userstat=1, set to true to collect table statistics",
 	)
+	collectQueryResponseTime = flag.Bool("collect.info_schema.query_response_time", false,
+		"Collect query response time distribution if query_response_time_stats is ON.")
 )
 
 // Metric name parts.
@@ -262,6 +264,12 @@ const (
 		  FROM information_schema.schemata
 		  WHERE SCHEMA_NAME NOT IN ('mysql', 'performance_schema', 'information_schema')
 		`
+	queryResponseCheckQuery = `SELECT @@query_response_time_stats`
+	queryResponseTimeQuery = `
+		SELECT
+		    TIME, COUNT, TOTAL
+		  FROM information_schema.query_response_time
+	`
 )
 var slaveStatusQuerySuffixes = [3]string{" NONBLOCKING", " NOLOCK", ""}
 
@@ -569,6 +577,16 @@ var (
 		"The number of rows changed in the table, multiplied by the number of indexes changed.",
 		[]string{"schema", "table"}, nil,
 	)
+	infoSchemaQueryResponseTimeCountDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, informationSchema, "query_response_time_count"),
+		"The number of queries according to the length of time they took to execute.",
+		[]string{}, nil,
+	)
+	infoSchemaQueryResponseTimeTotalDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, informationSchema, "query_response_time_total"),
+		"Total time of queries according to the length of time they took to execute separately.",
+		[]string{"le"}, nil,
+	)
 )
 
 // Math constants
@@ -851,6 +869,12 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 	if *collectTableStat {
 		if err = scrapeTableStat(db, ch); err != nil {
 			log.Println("Error scraping table stat:", err)
+			return
+		}
+	}
+	if *collectQueryResponseTime {
+		if err = scrapeQueryResponseTime(db, ch); err != nil {
+			log.Println("Error scraping query response time:", err)
 			return
 		}
 	}
@@ -1605,6 +1629,70 @@ func scrapeTableStat(db *sql.DB, ch chan<- prometheus.Metric) error {
 			tableSchema, tableName,
 		)
 	}
+	return nil
+}
+
+func scrapeQueryResponseTime(db *sql.DB, ch chan<- prometheus.Metric) error {
+	var queryStats uint8
+	err := db.QueryRow(queryResponseCheckQuery).Scan(&queryStats)
+	if err != nil {
+		log.Debugln("Query response time distribution is not present.")
+		return nil
+	}
+	if queryStats == 0 {
+		log.Debugln("query_response_time_stats is OFF.")
+		return nil
+	}
+
+	queryDistributionRows, err := db.Query(queryResponseTimeQuery)
+	if err != nil {
+		return err
+	}
+	defer queryDistributionRows.Close()
+
+	var (
+		length       string
+		count        uint64
+		total        string
+		histogramCnt uint64
+		histogramSum float64
+		countBuckets = map[float64]uint64 {}
+	)
+
+	for queryDistributionRows.Next() {
+		err = queryDistributionRows.Scan(
+			&length,
+			&count,
+			&total,
+		)
+		if err != nil {
+			return err
+		}
+
+		length, _ := strconv.ParseFloat(strings.TrimSpace(length), 64)
+		total, _ := strconv.ParseFloat(strings.TrimSpace(total), 64)
+		histogramCnt += count
+		histogramSum += total
+		// Special case for "TOO LONG" row where we take into account the count field which is the only available
+		// and do not add it as a part of histogram or metric
+		if length == 0 {
+			continue
+		}
+		countBuckets[length] = histogramCnt
+		// No histogram with query total times because they are float
+		ch <- prometheus.MustNewConstMetric(
+			infoSchemaQueryResponseTimeTotalDesc, prometheus.CounterValue, histogramSum,
+			fmt.Sprintf("%v", length),
+		)
+	}
+	ch <- prometheus.MustNewConstMetric(
+		infoSchemaQueryResponseTimeTotalDesc, prometheus.CounterValue, histogramSum,
+		"+Inf",
+	)
+	// Create histogram with query counts
+	ch <- prometheus.MustNewConstHistogram(
+		infoSchemaQueryResponseTimeCountDesc, histogramCnt, histogramSum, countBuckets,
+	)
 	return nil
 }
 


### PR DESCRIPTION
https://www.percona.com/doc/percona-server/5.6/diagnostics/response_time_distribution.html
https://mariadb.com/kb/en/mariadb/query_response_time-plugin/

Sample:
```
# HELP mysql_info_schema_query_response_time_count The number of queries according to the length of time they took to execute.
# TYPE mysql_info_schema_query_response_time_count histogram
mysql_info_schema_query_response_time_count_bucket{le="1e-06"} 281
mysql_info_schema_query_response_time_count_bucket{le="1e-05"} 756
mysql_info_schema_query_response_time_count_bucket{le="0.0001"} 8410
mysql_info_schema_query_response_time_count_bucket{le="0.001"} 11247
mysql_info_schema_query_response_time_count_bucket{le="0.01"} 11904
mysql_info_schema_query_response_time_count_bucket{le="0.1"} 11916
mysql_info_schema_query_response_time_count_bucket{le="1"} 11917
mysql_info_schema_query_response_time_count_bucket{le="10"} 11917
mysql_info_schema_query_response_time_count_bucket{le="100"} 11917
mysql_info_schema_query_response_time_count_bucket{le="1000"} 11917
mysql_info_schema_query_response_time_count_bucket{le="10000"} 11917
mysql_info_schema_query_response_time_count_bucket{le="100000"} 11917
mysql_info_schema_query_response_time_count_bucket{le="1e+06"} 11917
mysql_info_schema_query_response_time_count_bucket{le="+Inf"} 11917
mysql_info_schema_query_response_time_count_sum 3.002952
mysql_info_schema_query_response_time_count_count 11917
# HELP mysql_info_schema_query_response_time_total Total time of queries according to the length of time they took to execute separately.
# TYPE mysql_info_schema_query_response_time_total counter
mysql_info_schema_query_response_time_total{le="+Inf"} 3.002952
mysql_info_schema_query_response_time_total{le="0.0001"} 0.288892
mysql_info_schema_query_response_time_total{le="0.001"} 1.119809
mysql_info_schema_query_response_time_total{le="0.01"} 2.380771
mysql_info_schema_query_response_time_total{le="0.1"} 2.735583
mysql_info_schema_query_response_time_total{le="1"} 3.002952
mysql_info_schema_query_response_time_total{le="10"} 3.002952
mysql_info_schema_query_response_time_total{le="100"} 3.002952
mysql_info_schema_query_response_time_total{le="1000"} 3.002952
mysql_info_schema_query_response_time_total{le="10000"} 3.002952
mysql_info_schema_query_response_time_total{le="100000"} 3.002952
mysql_info_schema_query_response_time_total{le="1e+06"} 3.002952
mysql_info_schema_query_response_time_total{le="1e-05"} 0.002272
mysql_info_schema_query_response_time_total{le="1e-06"} 0
```