### PR TITLE
Include index io stats for update and delete

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -1263,21 +1263,21 @@ func scrapePerfIndexIOWaits(db *sql.DB, ch chan<- prometheus.Metric) error {
 			performanceSchemaIndexWaitsDesc, prometheus.CounterValue, float64(countFetch),
 			objectSchema, objectName, indexName, "fetch",
 		)
-		// We only update write columns when indexName is NONE.
+		// We only include the insert column when indexName is NONE.
 		if indexName == "NONE" {
 			ch <- prometheus.MustNewConstMetric(
 				performanceSchemaIndexWaitsDesc, prometheus.CounterValue, float64(countInsert),
 				objectSchema, objectName, indexName, "insert",
 			)
-			ch <- prometheus.MustNewConstMetric(
-				performanceSchemaIndexWaitsDesc, prometheus.CounterValue, float64(countUpdate),
-				objectSchema, objectName, indexName, "update",
-			)
-			ch <- prometheus.MustNewConstMetric(
-				performanceSchemaIndexWaitsDesc, prometheus.CounterValue, float64(countDelete),
-				objectSchema, objectName, indexName, "delete",
-			)
 		}
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaIndexWaitsDesc, prometheus.CounterValue, float64(countUpdate),
+			objectSchema, objectName, indexName, "update",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaIndexWaitsDesc, prometheus.CounterValue, float64(countDelete),
+			objectSchema, objectName, indexName, "delete",
+		)
 		ch <- prometheus.MustNewConstMetric(
 			performanceSchemaIndexWaitsTimeDesc, prometheus.CounterValue, float64(timeFetch)/picoSeconds,
 			objectSchema, objectName, indexName, "fetch",
@@ -1288,15 +1288,15 @@ func scrapePerfIndexIOWaits(db *sql.DB, ch chan<- prometheus.Metric) error {
 				performanceSchemaIndexWaitsTimeDesc, prometheus.CounterValue, float64(timeInsert)/picoSeconds,
 				objectSchema, objectName, indexName, "insert",
 			)
-			ch <- prometheus.MustNewConstMetric(
-				performanceSchemaIndexWaitsTimeDesc, prometheus.CounterValue, float64(timeUpdate)/picoSeconds,
-				objectSchema, objectName, indexName, "update",
-			)
-			ch <- prometheus.MustNewConstMetric(
-				performanceSchemaIndexWaitsTimeDesc, prometheus.CounterValue, float64(timeDelete)/picoSeconds,
-				objectSchema, objectName, indexName, "delete",
-			)
 		}
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaIndexWaitsTimeDesc, prometheus.CounterValue, float64(timeUpdate)/picoSeconds,
+			objectSchema, objectName, indexName, "update",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaIndexWaitsTimeDesc, prometheus.CounterValue, float64(timeDelete)/picoSeconds,
+			objectSchema, objectName, indexName, "delete",
+		)
 	}
 	return nil
 }

--- a/mysqld_exporter_test.go
+++ b/mysqld_exporter_test.go
@@ -38,7 +38,10 @@ func readMetric(m prometheus.Metric) MetricResult {
 }
 
 func sanitizeQuery(q string) string {
-	return strings.Join(strings.Fields(q), " ")
+	q = strings.Join(strings.Fields(q), " ")
+	q = strings.Replace(q, "(", "\\(", -1)
+	q = strings.Replace(q, ")", "\\)", -1)
+	return q
 }
 
 func Test_scrapeTableStat(t *testing.T) {
@@ -377,6 +380,57 @@ func Test_scrapeEngineTokudbStatus(t *testing.T) {
 	}
 	convey.Convey("Metrics comparison", t, func() {
 		for _, expect := range metricsExpected {
+			got := readMetric(<-ch)
+			convey.So(got, convey.ShouldResemble, expect)
+		}
+	})
+
+	// Ensure all SQL queries were executed
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expections: %s", err)
+	}
+}
+
+func Test_scrapePerfIndexIOWaits(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("error opening a stub database connection: %s", err)
+	}
+	defer db.Close()
+
+	columns := []string{"OBJECT_SCHEMA", "OBJECT_NAME", "INDEX_NAME", "COUNT_FETCH", "COUNT_INSERT", "COUNT_UPDATE", "COUNT_DELETE", "SUM_TIMER_FETCH", "SUM_TIMER_INSERT", "SUM_TIMER_UPDATE", "SUM_TIMER_DELETE"}
+	rows := sqlmock.NewRows(columns).
+		// Note, timers are in picoseconds.
+		AddRow("database", "table", "index", "10", "11", "12", "13", "14000000000000", "15000000000000", "16000000000000", "17000000000000").
+		AddRow("database", "table", "NONE", "20", "21", "22", "23", "24000000000000", "25000000000000", "26000000000000", "27000000000000")
+	mock.ExpectQuery(sanitizeQuery(perfIndexIOWaitsQuery)).WillReturnRows(rows)
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		if err = scrapePerfIndexIOWaits(db, ch); err != nil {
+			t.Errorf("error calling function on test: %s", err)
+		}
+		close(ch)
+	}()
+
+	metricExpected := []MetricResult{
+		{labels: LabelMap{"schema": "database", "name": "table", "index": "index", "operation": "fetch"}, value: 10, metricType: dto.MetricType_COUNTER},
+		{labels: LabelMap{"schema": "database", "name": "table", "index": "index", "operation": "update"}, value: 12, metricType: dto.MetricType_COUNTER},
+		{labels: LabelMap{"schema": "database", "name": "table", "index": "index", "operation": "delete"}, value: 13, metricType: dto.MetricType_COUNTER},
+		{labels: LabelMap{"schema": "database", "name": "table", "index": "index", "operation": "fetch"}, value: 14, metricType: dto.MetricType_COUNTER},
+		{labels: LabelMap{"schema": "database", "name": "table", "index": "index", "operation": "update"}, value: 16, metricType: dto.MetricType_COUNTER},
+		{labels: LabelMap{"schema": "database", "name": "table", "index": "index", "operation": "delete"}, value: 17, metricType: dto.MetricType_COUNTER},
+		{labels: LabelMap{"schema": "database", "name": "table", "index": "NONE", "operation": "fetch"}, value: 20, metricType: dto.MetricType_COUNTER},
+		{labels: LabelMap{"schema": "database", "name": "table", "index": "NONE", "operation": "insert"}, value: 21, metricType: dto.MetricType_COUNTER},
+		{labels: LabelMap{"schema": "database", "name": "table", "index": "NONE", "operation": "update"}, value: 22, metricType: dto.MetricType_COUNTER},
+		{labels: LabelMap{"schema": "database", "name": "table", "index": "NONE", "operation": "delete"}, value: 23, metricType: dto.MetricType_COUNTER},
+		{labels: LabelMap{"schema": "database", "name": "table", "index": "NONE", "operation": "fetch"}, value: 24, metricType: dto.MetricType_COUNTER},
+		{labels: LabelMap{"schema": "database", "name": "table", "index": "NONE", "operation": "insert"}, value: 25, metricType: dto.MetricType_COUNTER},
+		{labels: LabelMap{"schema": "database", "name": "table", "index": "NONE", "operation": "update"}, value: 26, metricType: dto.MetricType_COUNTER},
+		{labels: LabelMap{"schema": "database", "name": "table", "index": "NONE", "operation": "delete"}, value: 27, metricType: dto.MetricType_COUNTER},
+	}
+	convey.Convey("Metrics comparison", t, func() {
+		for _, expect := range metricExpected {
 			got := readMetric(<-ch)
 			convey.So(got, convey.ShouldResemble, expect)
 		}


### PR DESCRIPTION
As reported by https://github.com/prometheus/mysqld_exporter/issues/96,
we do need to collect metrics for update and delete index IO waits.