### PR TITLE
Added metrics from SHOW ENGINE TOKUDB STATUS

### DIFF
--- a/mysqld_exporter_test.go
+++ b/mysqld_exporter_test.go
@@ -328,3 +328,62 @@ func Test_scrapeGlobalStatus(t *testing.T) {
 		t.Errorf("there were unfulfilled expections: %s", err)
 	}
 }
+
+func Test_sanitizeTokudbMetric(t *testing.T) {
+	samples := map[string]string{
+		"loader: number of calls to loader->close() that failed": "loader_number_of_calls_to_loader_close_that_failed",
+		"ft: promotion: stopped anyway, after locking the child": "ft_promotion_stopped_anyway_after_locking_the_child",
+		"ft: basement nodes deserialized with fixed-keysize":     "ft_basement_nodes_deserialized_with_fixed_keysize",
+		"memory: number of bytes used (requested + overhead)":    "memory_number_of_bytes_used_requested_and_overhead",
+		"ft: uncompressed / compressed bytes written (overall)":  "ft_uncompressed_and_compressed_bytes_written_overall",
+	}
+	convey.Convey("Replacement tests", t, func() {
+		for metric := range samples {
+			got := sanitizeTokudbMetric(metric)
+			convey.So(got, convey.ShouldEqual, samples[metric])
+		}
+	})
+}
+
+func Test_scrapeEngineTokudbStatus(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("error opening a stub database connection: %s", err)
+	}
+	defer db.Close()
+
+	columns := []string{"Type", "Name", "Status"}
+	rows := sqlmock.NewRows(columns).
+		AddRow("TokuDB", "indexer: number of calls to indexer->build() succeeded", "1").
+		AddRow("TokuDB", "ft: promotion: stopped anyway, after locking the child", "45316247").
+		AddRow("TokuDB", "memory: mallocator version", "3.3.1-0-g9ef9d9e8c271cdf14f664b871a8f98c827714784").
+		AddRow("TokuDB", "filesystem: most recent disk full", "Thu Jan  1 00:00:00 1970").
+		AddRow("TokuDB", "locktree: time spent ending the STO early (seconds)", "9115.904484")
+
+	mock.ExpectQuery(sanitizeQuery(engineTokudbStatusQuery)).WillReturnRows(rows)
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		if err = scrapeEngineTokudbStatus(db, ch); err != nil {
+			t.Errorf("error calling function on test: %s", err)
+		}
+		close(ch)
+	}()
+
+	metricsExpected := []MetricResult{
+		{labels: LabelMap{}, value: 1, metricType: dto.MetricType_UNTYPED},
+		{labels: LabelMap{}, value: 45316247, metricType: dto.MetricType_UNTYPED},
+		{labels: LabelMap{}, value: 9115.904484, metricType: dto.MetricType_UNTYPED},
+	}
+	convey.Convey("Metrics comparison", t, func() {
+		for _, expect := range metricsExpected {
+			got := readMetric(<-ch)
+			convey.So(got, convey.ShouldResemble, expect)
+		}
+	})
+
+	// Ensure all SQL queries were executed
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expections: %s", err)
+	}
+}


### PR DESCRIPTION
Added `SHOW ENGINE TOKUDB STATUS` metrics for Percona Server with TokuDB storage engine. Note, the metrics are set untyped (similar to `GLOBAL STATUS`) because this is a whole mess of different types.

```
# HELP mysql_engine_tokudb_num_open_dbs_now Generic metric from SHOW ENGINE TOKUDB STATUS.
# TYPE mysql_engine_tokudb_num_open_dbs_now untyped
mysql_engine_tokudb_num_open_dbs_now 0
# HELP mysql_engine_tokudb_period_in_ms_that_recovery_log_is_automatically_fsynced Generic metric from SHOW ENGINE TOKUDB STATUS.
# TYPE mysql_engine_tokudb_period_in_ms_that_recovery_log_is_automatically_fsynced untyped
mysql_engine_tokudb_period_in_ms_that_recovery_log_is_automatically_fsynced 0
# HELP mysql_engine_tokudb_txn_aborts Generic metric from SHOW ENGINE TOKUDB STATUS.
# TYPE mysql_engine_tokudb_txn_aborts untyped
mysql_engine_tokudb_txn_aborts 2
# HELP mysql_engine_tokudb_txn_begin Generic metric from SHOW ENGINE TOKUDB STATUS.
# TYPE mysql_engine_tokudb_txn_begin untyped
mysql_engine_tokudb_txn_begin 5
# HELP mysql_engine_tokudb_txn_begin_read_only Generic metric from SHOW ENGINE TOKUDB STATUS.
# TYPE mysql_engine_tokudb_txn_begin_read_only untyped
mysql_engine_tokudb_txn_begin_read_only 0
# HELP mysql_engine_tokudb_txn_successful_commits Generic metric from SHOW ENGINE TOKUDB STATUS.
# TYPE mysql_engine_tokudb_txn_successful_commits untyped
mysql_engine_tokudb_txn_successful_commits 3
```
~300