### PR TITLE
The result of the upQuery should be read or closed

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -821,12 +821,14 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 	}
 	defer db.Close()
 
-	_, err = db.Query(upQuery)
+	isUpRows, err := db.Query(upQuery)
 	if err != nil {
 		log.Errorln("Error pinging mysqld:", err)
 		e.mysqldUp.Set(0)
 		return
 	}
+	isUpRows.Close()
+
 	e.mysqldUp.Set(1)
 
 	if *slowLogFilter {


### PR DESCRIPTION
go-database-sql keeps a stale connection open if the returned rows are not read or closed.
fixed id by calling .Close() on the result

https://github.com/VividCortex/go-database-sql-tutorial/blob/gh-pages/surprises.md#resource-exhaustion