### PR TITLE
Fix collect.info_schema.innodb_tablespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ collect.info_schema.innodb_metrics                     | 5.6           | Collect
 collect.auto_increment.columns                         | 5.1           | Collect auto_increment columns and max values from information_schema.
 collect.engine_tokudb_status                           | 5.6           | Collect from SHOW ENGINE TOKUDB STATUS.
 collect.info_schema.userstats                          | 5.1           | If running with userstat=1, set to true to collect user statistics.
+collect.info_schema.innodb_tablespaces                 | 5.7           | Collect metrics from information_schema.innodb_sys_tablepaces.
 collect.info_schema.tablestats                         | 5.1           | If running with userstat=1, set to true to collect table statistics.
 collect.info_schema.tables                             | 5.1           | Collect metrics from information_schema.tables.
 collect.info_schema.tables.databases                   | 5.1           | The list of databases to collect table stats for, or '`*`' for all.

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -43,7 +43,7 @@ var (
 		"Collect metrics from information_schema.tables",
 	)
 	collectInnodbTablespaces = flag.Bool(
-		"collect.info_schema.innodb_tablespaces", true,
+		"collect.info_schema.innodb_tablespaces", false,
 		"Collect metrics from information_schema.innodb_sys_tablepaces",
 	)
 	innodbMetrics = flag.Bool(


### PR DESCRIPTION
* Disable by default to avoid breaking with old MySQL versions
* Document flag as only compatible with >= 5.7