### PR TITLE
Fix SLAVE STATUS "Connecting"

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -32,6 +32,10 @@ func parseStatus(data sql.RawBytes) (float64, bool) {
 	if bytes.Compare(data, []byte("No")) == 0 || bytes.Compare(data, []byte("OFF")) == 0 {
 		return 0, true
 	}
+	// SHOW SLAVE STATUS Slave_IO_Running can return "Connecting" which is a non-running state.
+	if bytes.Compare(data, []byte("Connecting")) == 0 {
+		return 0, true
+	}
 	if logNum := logRE.Find(data); logNum != nil {
 		value, err := strconv.ParseFloat(string(logNum), 64)
 		return value, err == nil

--- a/collector/slave_status_test.go
+++ b/collector/slave_status_test.go
@@ -1,0 +1,49 @@
+package collector
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/smartystreets/goconvey/convey"
+	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+)
+
+func TestScrapeSlaveStatus(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("error opening a stub database connection: %s", err)
+	}
+	defer db.Close()
+
+	columns := []string{"Master_Host", "Read_Master_Log_Pos", "Slave_IO_Running", "Slave_SQL_Running", "Seconds_Behind_Master"}
+	rows := sqlmock.NewRows(columns).
+		AddRow("127.0.0.1", "1", "Connecting", "Yes", "2")
+	mock.ExpectQuery(sanitizeQuery(slaveStatusQuery)).WillReturnRows(rows)
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		if err = ScrapeSlaveStatus(db, ch); err != nil {
+			t.Errorf("error calling function on test: %s", err)
+		}
+		close(ch)
+	}()
+
+	counterExpected := []MetricResult{
+		{labels: labelMap{}, value: 1, metricType: dto.MetricType_UNTYPED},
+		{labels: labelMap{}, value: 0, metricType: dto.MetricType_UNTYPED},
+		{labels: labelMap{}, value: 1, metricType: dto.MetricType_UNTYPED},
+		{labels: labelMap{}, value: 2, metricType: dto.MetricType_UNTYPED},
+	}
+	convey.Convey("Metrics comparison", t, func() {
+		for _, expect := range counterExpected {
+			got := readMetric(<-ch)
+			convey.So(got, convey.ShouldResemble, expect)
+		}
+	})
+
+	// Ensure all SQL queries were executed
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expections: %s", err)
+	}
+}


### PR DESCRIPTION
Treat `SHOW SLAVE STATUS` "Slave_IO_Running" column status `Connecting`
as not running.