### PR TITLE
scrape slave status for multisource replication

### DIFF
--- a/collector/slave_status_test.go
+++ b/collector/slave_status_test.go
@@ -30,10 +30,10 @@ func TestScrapeSlaveStatus(t *testing.T) {
 	}()
 
 	counterExpected := []MetricResult{
-		{labels: labelMap{}, value: 1, metricType: dto.MetricType_UNTYPED},
-		{labels: labelMap{}, value: 0, metricType: dto.MetricType_UNTYPED},
-		{labels: labelMap{}, value: 1, metricType: dto.MetricType_UNTYPED},
-		{labels: labelMap{}, value: 2, metricType: dto.MetricType_UNTYPED},
+		{labels: labelMap{"channel_name": "", "master_host": "127.0.0.1", "master_uuid": ""}, value: 1, metricType: dto.MetricType_UNTYPED},
+		{labels: labelMap{"channel_name": "", "master_host": "127.0.0.1", "master_uuid": ""}, value: 0, metricType: dto.MetricType_UNTYPED},
+		{labels: labelMap{"channel_name": "", "master_host": "127.0.0.1", "master_uuid": ""}, value: 1, metricType: dto.MetricType_UNTYPED},
+		{labels: labelMap{"channel_name": "", "master_host": "127.0.0.1", "master_uuid": ""}, value: 2, metricType: dto.MetricType_UNTYPED},
 	}
 	convey.Convey("Metrics comparison", t, func() {
 		for _, expect := range counterExpected {


### PR DESCRIPTION
For multi source replication `SHOW SLAVE STATUS` returns following output:

```csv
Slave_IO_State,Master_Host,Master_User,Master_Port,Connect_Retry,Master_Log_File,Read_Master_Log_Pos,Relay_Log_File,Relay_Log_Pos,Relay_Master_Log_File,Slave_IO_Running,Slave_SQL_Running,Replicate_Do_DB,Replicate_Ignore_DB,Replicate_Do_Table,Replicate_Ignore_Table,Replicate_Wild_Do_Table,Replicate_Wild_Ignore_Table,Last_Errno,Last_Error,Skip_Counter,Exec_Master_Log_Pos,Relay_Log_Space,Until_Condition,Until_Log_File,Until_Log_Pos,Master_SSL_Allowed,Master_SSL_CA_File,Master_SSL_CA_Path,Master_SSL_Cert,Master_SSL_Cipher,Master_SSL_Key,Seconds_Behind_Master,Master_SSL_Verify_Server_Cert,Last_IO_Errno,Last_IO_Error,Last_SQL_Errno,Last_SQL_Error,Replicate_Ignore_Server_Ids,Master_Server_Id,Master_UUID,Master_Info_File,SQL_Delay,SQL_Remaining_Delay,Slave_SQL_Running_State,Master_Retry_Count,Master_Bind,Last_IO_Error_Timestamp,Last_SQL_Error_Timestamp,Master_SSL_Crl,Master_SSL_Crlpath,Retrieved_Gtid_Set,Executed_Gtid_Set,Auto_Position,Replicate_Rewrite_DB,Channel_Name,Master_TLS_Version
"Waiting for master to send event",xxx.xxx.xxx.xxx,slave,3306,60,mysql-bin.000441,25191774,relay-bin-db1.000032,25191971,mysql-bin.000441,Yes,Yes,,"mysql,db2_archive,db4_archive",,,,,0,,0,25191774,25192228,None,,0,No,,,,,,0,No,0,,0,,,3484027219,4793282a-6395-4e5b-ad6a-8e45095e3e76,mysql.slave_master_info,0,NULL,"Slave has read all relay log; waiting for more updates",86400,,,,,,,,0,,db1,
"Waiting for master to send event",xxx.xxx.xxx.xxx,slave,3306,60,mysql-bin.000207,50292637,relay-bin-db2.000169,50292834,mysql-bin.000207,Yes,Yes,,"mysql,db2_archive,db4_archive",,,,,0,,0,50292637,50293087,None,,0,No,,,,,,0,No,0,,0,,,2186156188,f7dbab02-beb2-4593-a29f-4633d91a9f02,mysql.slave_master_info,0,NULL,"Slave has read all relay log; waiting for more updates",86400,,,,,,,,0,,db2,
"Waiting for master to send event",xxx.xxx.xxx.xxx,slave,3306,60,mysql-bin.000011,21415826,relay-bin-db3.000040,21416023,mysql-bin.000011,Yes,Yes,,"mysql,db2_archive,db4_archive",,,,,0,,0,21415826,21416280,None,,0,No,,,,,,0,No,0,,0,,,1756702319,b27169e6-8e04-485b-b575-ede018c5e403,mysql.slave_master_info,0,NULL,"Slave has read all relay log; waiting for more updates",86400,,,,,,,,0,,db3,
"Waiting for master to send event",xxx.xxx.xxx.xxx,slave,3306,60,mysql-bin.000212,28880821,relay-bin-db4.000056,10767154,mysql-bin.000212,Yes,Yes,,"mysql,db2_archive,db4_archive",,,,,0,,0,28880821,28881392,None,,0,No,,,,,,0,No,0,,0,,,309156203,a471e72e-24af-4b21-a266-94c3e61a4e91,mysql.slave_master_info,0,NULL,"Slave has read all relay log; waiting for more updates",86400,,,,,,,,0,,db4,
"Waiting for master to send event",xxx.xxx.xxx.xxx,slave,3306,60,mysql-bin.000036,15478374,relay-bin-db5.000004,15478571,mysql-bin.000036,Yes,Yes,,"mysql,db2_archive,db4_archive",,,,,0,,0,15478374,15478822,None,,0,No,,,,,,0,No,0,,0,,,475826812,9054333b-c5b4-446a-9432-d9a28636a2ac,mysql.slave_master_info,0,NULL,"Slave has read all relay log; waiting for more updates",86400,,,,,,,,0,,db5,
```

This PR exposes metrics that are identical to the standard slave_status.go but labelled with Master_UUID, Master_Host and Channel_Name. 

Note: `columnIndex` and `columnName` functions don't do any caching, but this should not have any performance impact, and the code is easier to read. 

 