### PR TITLE
Consistency of error logging.

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -284,7 +284,7 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 	}
 	if *collectTableSchema {
 		if err = collector.ScrapeTableSchema(db, ch); err != nil {
-			log.Errorln("Error scraping collect.info_schema.tables:", err)
+			log.Errorln("Error scraping for collect.info_schema.tables:", err)
 			e.scrapeErrors.WithLabelValues("collect.info_schema.tables").Inc()
 		}
 	}
@@ -356,19 +356,19 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 	}
 	if *collectTableStat {
 		if err = collector.ScrapeTableStat(db, ch); err != nil {
-			log.Errorln("Error scraping table stat:", err)
+			log.Errorln("Error scraping for collect.info_schema.tablestats:", err)
 			e.scrapeErrors.WithLabelValues("collect.info_schema.tablestats").Inc()
 		}
 	}
 	if *collectQueryResponseTime {
 		if err = collector.ScrapeQueryResponseTime(db, ch); err != nil {
-			log.Errorln("Error scraping query response time:", err)
+			log.Errorln("Error scraping for collect.info_schema.query_response_time:", err)
 			e.scrapeErrors.WithLabelValues("collect.info_schema.query_response_time").Inc()
 		}
 	}
 	if *collectEngineTokudbStatus {
 		if err = collector.ScrapeEngineTokudbStatus(db, ch); err != nil {
-			log.Errorln("Error scraping TokuDB engine status:", err)
+			log.Errorln("Error scraping for collect.engine_tokudb_status:", err)
 			e.scrapeErrors.WithLabelValues("collect.engine_tokudb_status").Inc()
 		}
 	}


### PR DESCRIPTION
With this change we will get the consistent error logging messages:
```
$ cat mysqld_exporter.go |grep 'Error scraping'
			log.Errorln("Error scraping for collect.global_status:", err)
			log.Errorln("Error scraping for collect.global_variables:", err)
			log.Errorln("Error scraping for collect.slave_status:", err)
			log.Errorln("Error scraping for collect.info_schema.processlist:", err)
			log.Errorln("Error scraping for collect.info_schema.tables:", err)
			log.Errorln("Error scraping for collect.info_schema.innodb_sys_tablespaces:", err)
			log.Errorln("Error scraping for collect.info_schema.innodb_metrics:", err)
			log.Errorln("Error scraping for collect.auto_increment.columns:", err)
			log.Errorln("Error scraping for collect.binlog_size:", err)
			log.Errorln("Error scraping for collect.perf_schema.tableiowaits:", err)
			log.Errorln("Error scraping for collect.perf_schema.indexiowaits:", err)
			log.Errorln("Error scraping for collect.perf_schema.tablelocks:", err)
			log.Errorln("Error scraping for collect.perf_schema.eventsstatements:", err)
			log.Errorln("Error scraping for collect.perf_schema.eventswaits:", err)
			log.Errorln("Error scraping for collect.perf_schema.file_events:", err)
			log.Errorln("Error scraping for collect.info_schema.userstats:", err)
			log.Errorln("Error scraping for collect.info_schema.tablestats:", err)
			log.Errorln("Error scraping for collect.info_schema.query_response_time:", err)
			log.Errorln("Error scraping for collect.engine_tokudb_status:", err)
```