### PR TITLE
Fix wsrep_cluster_status

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -36,6 +36,13 @@ func parseStatus(data sql.RawBytes) (float64, bool) {
 	if bytes.Compare(data, []byte("Connecting")) == 0 {
 		return 0, true
 	}
+	// SHOW GLOBAL STATUS like 'wsrep_cluster_status' can return "Primary" or "Non-Primary"/"Disconnected"
+	if bytes.Compare(data, []byte("Primary")) == 0 {
+		return 1, true
+	}
+	if bytes.Compare(data, []byte("Non-Primary")) == 0 || bytes.Compare(data, []byte("Disconnected")) == 0 {
+		return 0, true
+	}
 	if logNum := logRE.Find(data); logNum != nil {
 		value, err := strconv.ParseFloat(string(logNum), 64)
 		return value, err == nil


### PR DESCRIPTION
Treat `SHOW GLOBAL STATUS like 'wsrep_cluster_status'`:

- `Primary` node is part of a operational component
- `Non-Primary`/`Disconnected ` the node is part of a nonoperational component