### PR TITLE
Added PXC/Galera info metrics.

### DIFF
--- a/collector/global_status.go
+++ b/collector/global_status.go
@@ -71,6 +71,7 @@ func ScrapeGlobalStatus(db *sql.DB, ch chan<- prometheus.Metric) error {
 	var textItems = map[string]string{
 		"wsrep_local_state_uuid":   "",
 		"wsrep_cluster_state_uuid": "",
+		"wsrep_provider_version":   "",
 	}
 
 	for globalStatusRows.Next() {
@@ -130,8 +131,8 @@ func ScrapeGlobalStatus(db *sql.DB, ch chan<- prometheus.Metric) error {
 	if textItems["wsrep_local_state_uuid"] != "" {
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc(prometheus.BuildFQName(namespace, "galera", "status_info"), "PXC/Galera status information.",
-				[]string{"wsrep_local_state_uuid", "wsrep_cluster_state_uuid"}, nil),
-			prometheus.GaugeValue, 1, textItems["wsrep_local_state_uuid"], textItems["wsrep_cluster_state_uuid"],
+				[]string{"wsrep_local_state_uuid", "wsrep_cluster_state_uuid", "wsrep_provider_version"}, nil),
+			prometheus.GaugeValue, 1, textItems["wsrep_local_state_uuid"], textItems["wsrep_cluster_state_uuid"], textItems["wsrep_provider_version"],
 		)
 	}
 

--- a/collector/global_status.go
+++ b/collector/global_status.go
@@ -68,6 +68,10 @@ func ScrapeGlobalStatus(db *sql.DB, ch chan<- prometheus.Metric) error {
 
 	var key string
 	var val sql.RawBytes
+	var textItems = map[string]string{
+		"wsrep_local_state_uuid":   "",
+		"wsrep_cluster_state_uuid": "",
+	}
 
 	for globalStatusRows.Next() {
 		if err := globalStatusRows.Scan(&key, &val); err != nil {
@@ -117,7 +121,19 @@ func ScrapeGlobalStatus(db *sql.DB, ch chan<- prometheus.Metric) error {
 					globalPerformanceSchemaLostDesc, prometheus.CounterValue, floatVal, match[2],
 				)
 			}
+		} else if _, ok := textItems[key]; ok {
+			textItems[key] = string(val)
 		}
 	}
+
+	// mysql_galera_variables_info metric.
+	if textItems["wsrep_local_state_uuid"] != "" {
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, "galera", "status_info"), "PXC/Galera status information.",
+				[]string{"wsrep_local_state_uuid", "wsrep_cluster_state_uuid"}, nil),
+			prometheus.GaugeValue, 1, textItems["wsrep_local_state_uuid"], textItems["wsrep_cluster_state_uuid"],
+		)
+	}
+
 	return nil
 }

--- a/collector/global_status_test.go
+++ b/collector/global_status_test.go
@@ -29,7 +29,9 @@ func TestScrapeGlobalStatus(t *testing.T) {
 		AddRow("Performance_schema_users_lost", "9").
 		AddRow("Slave_running", "OFF").
 		AddRow("Ssl_version", "").
-		AddRow("Uptime", "10")
+		AddRow("Uptime", "10").
+		AddRow("wsrep_local_state_uuid", "6c06e583-686f-11e6-b9e3-8336ad58138c").
+		AddRow("wsrep_cluster_state_uuid", "6c06e583-686f-11e6-b9e3-8336ad58138c")
 	mock.ExpectQuery(sanitizeQuery(globalStatusQuery)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
@@ -52,6 +54,7 @@ func TestScrapeGlobalStatus(t *testing.T) {
 		{labels: labelMap{"instrumentation": "users_lost"}, value: 9, metricType: dto.MetricType_COUNTER},
 		{labels: labelMap{}, value: 0, metricType: dto.MetricType_UNTYPED},
 		{labels: labelMap{}, value: 10, metricType: dto.MetricType_UNTYPED},
+		{labels: labelMap{"wsrep_local_state_uuid": "6c06e583-686f-11e6-b9e3-8336ad58138c", "wsrep_cluster_state_uuid": "6c06e583-686f-11e6-b9e3-8336ad58138c"}, value: 1, metricType: dto.MetricType_GAUGE},
 	}
 	convey.Convey("Metrics comparison", t, func() {
 		for _, expect := range counterExpected {

--- a/collector/global_status_test.go
+++ b/collector/global_status_test.go
@@ -31,7 +31,8 @@ func TestScrapeGlobalStatus(t *testing.T) {
 		AddRow("Ssl_version", "").
 		AddRow("Uptime", "10").
 		AddRow("wsrep_local_state_uuid", "6c06e583-686f-11e6-b9e3-8336ad58138c").
-		AddRow("wsrep_cluster_state_uuid", "6c06e583-686f-11e6-b9e3-8336ad58138c")
+		AddRow("wsrep_cluster_state_uuid", "6c06e583-686f-11e6-b9e3-8336ad58138c").
+		AddRow("wsrep_provider_version", "3.16(r5c765eb)")
 	mock.ExpectQuery(sanitizeQuery(globalStatusQuery)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
@@ -54,7 +55,7 @@ func TestScrapeGlobalStatus(t *testing.T) {
 		{labels: labelMap{"instrumentation": "users_lost"}, value: 9, metricType: dto.MetricType_COUNTER},
 		{labels: labelMap{}, value: 0, metricType: dto.MetricType_UNTYPED},
 		{labels: labelMap{}, value: 10, metricType: dto.MetricType_UNTYPED},
-		{labels: labelMap{"wsrep_local_state_uuid": "6c06e583-686f-11e6-b9e3-8336ad58138c", "wsrep_cluster_state_uuid": "6c06e583-686f-11e6-b9e3-8336ad58138c"}, value: 1, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"wsrep_local_state_uuid": "6c06e583-686f-11e6-b9e3-8336ad58138c", "wsrep_cluster_state_uuid": "6c06e583-686f-11e6-b9e3-8336ad58138c", "wsrep_provider_version": "3.16(r5c765eb)"}, value: 1, metricType: dto.MetricType_GAUGE},
 	}
 	convey.Convey("Metrics comparison", t, func() {
 		for _, expect := range counterExpected {

--- a/collector/global_variables.go
+++ b/collector/global_variables.go
@@ -26,10 +26,11 @@ func ScrapeGlobalVariables(db *sql.DB, ch chan<- prometheus.Metric) error {
 
 	var key string
 	var val sql.RawBytes
-	var mysqlVersion = map[string]string{
-		"innodb_version":  "",
-		"version":         "",
-		"version_comment": "",
+	var textItems = map[string]string{
+		"innodb_version":     "",
+		"version":            "",
+		"version_comment":    "",
+		"wsrep_cluster_name": "",
 	}
 
 	for globalVariablesRows.Next() {
@@ -44,15 +45,26 @@ func ScrapeGlobalVariables(db *sql.DB, ch chan<- prometheus.Metric) error {
 				floatVal,
 			)
 			continue
-		} else if _, ok := mysqlVersion[key]; ok {
-			mysqlVersion[key] = string(val)
+		} else if _, ok := textItems[key]; ok {
+			textItems[key] = string(val)
 		}
 	}
-	// Create mysql_version_info metric
+
+	// mysql_version_info metric.
 	ch <- prometheus.MustNewConstMetric(
 		prometheus.NewDesc(prometheus.BuildFQName(namespace, "version", "info"), "MySQL version and distribution.",
 			[]string{"innodb_version", "version", "version_comment"}, nil),
-		prometheus.GaugeValue, 1, mysqlVersion["innodb_version"], mysqlVersion["version"], mysqlVersion["version_comment"],
+		prometheus.GaugeValue, 1, textItems["innodb_version"], textItems["version"], textItems["version_comment"],
 	)
+
+	// mysql_galera_variables_info metric.
+	if textItems["wsrep_cluster_name"] != "" {
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, "galera", "variables_info"), "PXC/Galera variables information.",
+				[]string{"wsrep_cluster_name"}, nil),
+			prometheus.GaugeValue, 1, textItems["wsrep_cluster_name"],
+		)
+	}
+
 	return nil
 }

--- a/collector/global_variables_test.go
+++ b/collector/global_variables_test.go
@@ -1,0 +1,67 @@
+package collector
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/smartystreets/goconvey/convey"
+	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+)
+
+func TestScrapeGlobalVariables(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("error opening a stub database connection: %s", err)
+	}
+	defer db.Close()
+
+	columns := []string{"Variable_name", "Value"}
+	rows := sqlmock.NewRows(columns).
+		AddRow("wait_timeout", "28800").
+		AddRow("version_compile_os", "Linux").
+		AddRow("userstat", "OFF").
+		AddRow("transaction_prealloc_size", "4096").
+		AddRow("tx_isolation", "REPEATABLE-READ").
+		AddRow("tmp_table_size", "16777216").
+		AddRow("tmpdir", "/tmp").
+		AddRow("sync_binlog", "0").
+		AddRow("sync_frm", "ON").
+		AddRow("slow_launch_time", "2").
+		AddRow("innodb_version", "5.6.30-76.3").
+		AddRow("version", "5.6.30-76.3-56").
+		AddRow("version_comment", "Percona XtraDB Cluster...").
+		AddRow("wsrep_cluster_name", "supercluster")
+	mock.ExpectQuery(globalVariablesQuery).WillReturnRows(rows)
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		if err = ScrapeGlobalVariables(db, ch); err != nil {
+			t.Errorf("error calling function on test: %s", err)
+		}
+		close(ch)
+	}()
+
+	counterExpected := []MetricResult{
+		{labels: labelMap{}, value: 28800, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{}, value: 0, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{}, value: 4096, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{}, value: 16777216, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{}, value: 0, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{}, value: 1, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{}, value: 2, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"innodb_version": "5.6.30-76.3", "version": "5.6.30-76.3-56", "version_comment": "Percona XtraDB Cluster..."}, value: 1, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"wsrep_cluster_name": "supercluster"}, value: 1, metricType: dto.MetricType_GAUGE},
+	}
+	convey.Convey("Metrics comparison", t, func() {
+		for _, expect := range counterExpected {
+			got := readMetric(<-ch)
+			convey.So(got, convey.ShouldResemble, expect)
+		}
+	})
+
+	// Ensure all SQL queries were executed
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expections: %s", err)
+	}
+}


### PR DESCRIPTION
* Added `mysql_galera_status_info`, `mysql_galera_variables_info` metrics.
* Added global variables test.

```
# HELP mysql_galera_status_info PXC/Galera status information.
# TYPE mysql_galera_status_info gauge
mysql_galera_status_info{wsrep_cluster_state_uuid="6c06e583-686f-11e6-b9e3-8336ad58138c",wsrep_local_state_uuid="6c06e583-686f-11e6-b9e3-8336ad58138c",wsrep_provider_version="3.16(r5c765eb)"} 1
# HELP mysql_galera_variables_info PXC/Galera variables information.
# TYPE mysql_galera_variables_info gauge
mysql_galera_variables_info{wsrep_cluster_name="supercluster"} 1
```

I didn't create another collector for those metrics as they are derived from the existing ones, whether `SHOW GLOBAL VARIABLES` or `SHOW GLOBAL STATUS` which are scraped usually anyway.

Also I think we don't need any other `wsrep_` vars, don't we?
```
mysql> show global variables where Variable_Name like 'wsrep%';
+---------------------------------+-----------------------------------------+
| Variable_name                   | Value                                   |
+---------------------------------+-----------------------------------------+
| wsrep_OSU_method                | TOI                                     |
| wsrep_auto_increment_control    | ON                                      |
| wsrep_causal_reads              | OFF                                     |
| wsrep_certify_nonPK             | ON                                      |
| wsrep_cluster_address           | gcomm://                                |
| wsrep_cluster_name              | supercluster                            |
| wsrep_convert_LOCK_to_trx       | OFF                                     |
| wsrep_data_home_dir             | /var/lib/mysql/                         |
| wsrep_dbug_option               |                                         |
| wsrep_debug                     | OFF                                     |
| wsrep_desync                    | OFF                                     |
| wsrep_dirty_reads               | OFF                                     |
| wsrep_drupal_282555_workaround  | OFF                                     |
| wsrep_forced_binlog_format      | NONE                                    |
| wsrep_load_data_splitting       | ON                                      |
| wsrep_log_conflicts             | OFF                                     |
| wsrep_max_ws_rows               | 131072                                  |
| wsrep_max_ws_size               | 1073741824                              |
| wsrep_mysql_replication_bundle  | 0                                       |
| wsrep_node_address              |                                         |
| wsrep_node_incoming_address     | AUTO                                    |
| wsrep_node_name                 | 94bfe416e0a3                            |
| wsrep_notify_cmd                |                                         |
| wsrep_preordered                | OFF                                     |
| wsrep_provider                  | /usr/lib64/galera3/libgalera_smm.so     |
| wsrep_recover                   | OFF                                     |
| wsrep_reject_queries            | NONE                                    |
| wsrep_replicate_myisam          | OFF                                     |
| wsrep_restart_slave             | OFF                                     |
| wsrep_retry_autocommit          | 1                                       |
| wsrep_provider_options          | ...                                     |
| wsrep_slave_FK_checks           | ON                                      |
| wsrep_slave_UK_checks           | OFF                                     |
| wsrep_slave_threads             | 2                                       |
| wsrep_sst_auth                  | ********                                |
| wsrep_sst_donor                 |                                         |
| wsrep_sst_donor_rejects_queries | OFF                                     |
| wsrep_sst_method                | xtrabackup-v2                           |
| wsrep_sst_receive_address       | AUTO                                    |
| wsrep_start_position            | 00000000-0000-0000-0000-000000000000:-1 |
| wsrep_sync_wait                 | 0                                       |
+---------------------------------+-----------------------------------------+
40 rows in set (0.02 sec)

mysql> show global status where Variable_Name like 'wsrep%';
+------------------------------+--------------------------------------+
| Variable_name                | Value                                |
+------------------------------+--------------------------------------+
| wsrep_local_state_uuid       | 6c06e583-686f-11e6-b9e3-8336ad58138c |
| wsrep_protocol_version       | 7                                    |
| wsrep_last_committed         | 0                                    |
| wsrep_replicated             | 0                                    |
| wsrep_replicated_bytes       | 0                                    |
| wsrep_repl_keys              | 0                                    |
| wsrep_repl_keys_bytes        | 0                                    |
| wsrep_repl_data_bytes        | 0                                    |
| wsrep_repl_other_bytes       | 0                                    |
| wsrep_received               | 2                                    |
| wsrep_received_bytes         | 146                                  |
| wsrep_local_commits          | 0                                    |
| wsrep_local_cert_failures    | 0                                    |
| wsrep_local_replays          | 0                                    |
| wsrep_local_send_queue       | 0                                    |
| wsrep_local_send_queue_max   | 1                                    |
| wsrep_local_send_queue_min   | 0                                    |
| wsrep_local_send_queue_avg   | 0.000000                             |
| wsrep_local_recv_queue       | 0                                    |
| wsrep_local_recv_queue_max   | 2                                    |
| wsrep_local_recv_queue_min   | 0                                    |
| wsrep_local_recv_queue_avg   | 0.500000                             |
| wsrep_local_cached_downto    | 0                                    |
| wsrep_flow_control_paused_ns | 0                                    |
| wsrep_flow_control_paused    | 0.000000                             |
| wsrep_flow_control_sent      | 0                                    |
| wsrep_flow_control_recv      | 0                                    |
| wsrep_cert_deps_distance     | 0.000000                             |
| wsrep_apply_oooe             | 0.000000                             |
| wsrep_apply_oool             | 0.000000                             |
| wsrep_apply_window           | 0.000000                             |
| wsrep_commit_oooe            | 0.000000                             |
| wsrep_commit_oool            | 0.000000                             |
| wsrep_commit_window          | 0.000000                             |
| wsrep_local_state            | 4                                    |
| wsrep_local_state_comment    | Synced                               |
| wsrep_cert_index_size        | 0                                    |
| wsrep_cert_bucket_count      | 22                                   |
| wsrep_gcache_pool_size       | 1320                                 |
| wsrep_causal_reads           | 0                                    |
| wsrep_cert_interval          | 0.000000                             |
| wsrep_incoming_addresses     | 172.21.0.2:3306                      |
| wsrep_desync_count           | 0                                    |
| wsrep_evs_delayed            |                                      |
| wsrep_evs_evict_list         |                                      |
| wsrep_evs_repl_latency       | 0/0/0/0/0                            |
| wsrep_evs_state              | OPERATIONAL                          |
| wsrep_gcomm_uuid             | 6c0452ad-686f-11e6-904e-7a019bfe35ac |
| wsrep_cluster_conf_id        | 1                                    |
| wsrep_cluster_size           | 1                                    |
| wsrep_cluster_state_uuid     | 6c06e583-686f-11e6-b9e3-8336ad58138c |
| wsrep_cluster_status         | Primary                              |
| wsrep_connected              | ON                                   |
| wsrep_local_bf_aborts        | 0                                    |
| wsrep_local_index            | 0                                    |
| wsrep_provider_name          | Galera                               |
| wsrep_provider_vendor        | Codership Oy <info@codership.com>    |
| wsrep_provider_version       | 3.16(r5c765eb)                       |
| wsrep_ready                  | ON                                   |
+------------------------------+--------------------------------------+
59 rows in set (0.01 sec)
```