### PR TITLE
Updated MySQL version supported for -collect.perf_schema.file_events

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ collect.perf_schema.eventsstatements.digest_text_limit | 5.6           | Maximum
 collect.perf_schema.eventsstatements.limit             | 5.6           | Limit the number of events statements digests by response time. (default: 250)
 collect.perf_schema.eventsstatements.timelimit         | 5.6           | Limit how old the 'last_seen' events statements can be, in seconds. (default: 86400)
 collect.perf_schema.eventswaits                        | 5.5           | Collect metrics from performance_schema.events_waits_summary_global_by_event_name.
-collect.perf_schema.file_events                        | 5.5           | Collect metrics from performance_schema.file_summary_by_event_name.
+collect.perf_schema.file_events                        | 5.6           | Collect metrics from performance_schema.file_summary_by_event_name.
 collect.perf_schema.indexiowaits                       | 5.6           | Collect metrics from performance_schema.table_io_waits_summary_by_index_usage.
 collect.perf_schema.tableiowaits                       | 5.6           | Collect metrics from performance_schema.table_io_waits_summary_by_table.
 collect.perf_schema.tablelocks                         | 5.6           | Collect metrics from performance_schema.table_lock_waits_summary_by_table.


### PR DESCRIPTION
MySQL 5.5 gives this error when `-collect.perf_schema.file_events` enabled:
```
collect.perf_schema.file_events: Error 1054: Unknown column 'SUM_TIMER_READ' in 'field list'"...
```

It is actually 5.6 focused, not sure there is a reason to support it in 5.5.
Let's fix this in README.