### PR TITLE
Add mysql_galera_gcache_size_bytes metric.

### DIFF
--- a/collector/global_variables.go
+++ b/collector/global_variables.go
@@ -4,6 +4,8 @@ package collector
 
 import (
 	"database/sql"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,10 +29,11 @@ func ScrapeGlobalVariables(db *sql.DB, ch chan<- prometheus.Metric) error {
 	var key string
 	var val sql.RawBytes
 	var textItems = map[string]string{
-		"innodb_version":     "",
-		"version":            "",
-		"version_comment":    "",
-		"wsrep_cluster_name": "",
+		"innodb_version":         "",
+		"version":                "",
+		"version_comment":        "",
+		"wsrep_cluster_name":     "",
+		"wsrep_provider_options": "",
 	}
 
 	for globalVariablesRows.Next() {
@@ -66,5 +69,34 @@ func ScrapeGlobalVariables(db *sql.DB, ch chan<- prometheus.Metric) error {
 		)
 	}
 
+	// mysql_galera_gcache_size_bytes metric.
+	if textItems["wsrep_provider_options"] != "" {
+		ch <- prometheus.MustNewConstMetric(
+			newDesc("galera", "gcache_size_bytes", "PXC/Galera gcache size."),
+			prometheus.GaugeValue,
+			parseWsrepProviderOptions(textItems["wsrep_provider_options"]),
+		)
+	}
+
 	return nil
+}
+
+// parseWsrepProviderOptions parse wsrep_provider_options to get gcache.size in bytes.
+func parseWsrepProviderOptions(opts string) float64 {
+	var val float64
+	r, _ := regexp.Compile(`gcache.size = (\d+)([MG]?);`)
+	data := r.FindStringSubmatch(opts)
+	if data == nil {
+		return 0
+	}
+
+	val, _ = strconv.ParseFloat(data[1], 64)
+	switch data[2] {
+	case "M":
+		val = val * 1024 * 1024
+	case "G":
+		val = val * 1024 * 1024 * 1024
+	}
+
+	return val
 }

--- a/collector/global_variables_test.go
+++ b/collector/global_variables_test.go
@@ -31,7 +31,8 @@ func TestScrapeGlobalVariables(t *testing.T) {
 		AddRow("innodb_version", "5.6.30-76.3").
 		AddRow("version", "5.6.30-76.3-56").
 		AddRow("version_comment", "Percona XtraDB Cluster...").
-		AddRow("wsrep_cluster_name", "supercluster")
+		AddRow("wsrep_cluster_name", "supercluster").
+		AddRow("wsrep_provider_options", "base_dir = /var/lib/mysql/; base_host = 10.91.142.82; base_port = 4567; cert.log_conflicts = no; debug = no; evs.auto_evict = 0; evs.causal_keepalive_period = PT1S; evs.debug_log_mask = 0x1; evs.delay_margin = PT1S; evs.delayed_keep_period = PT30S; evs.inactive_check_period = PT0.5S; evs.inactive_timeout = PT15S; evs.info_log_mask = 0; evs.install_timeout = PT7.5S; evs.join_retrans_period = PT1S; evs.keepalive_period = PT1S; evs.max_install_timeouts = 3; evs.send_window = 4; evs.stats_report_period = PT1M; evs.suspect_timeout = PT5S; evs.use_aggregate = true; evs.user_send_window = 2; evs.version = 0; evs.view_forget_timeout = P1D; gcache.dir = /var/lib/mysql/; gcache.keep_pages_count = 0; gcache.keep_pages_size = 0; gcache.mem_size = 0; gcache.name = /var/lib/mysql//galera.cache; gcache.page_size = 128M; gcache.size = 128M; gcomm.thread_prio = ; gcs.fc_debug = 0; gcs.fc_factor = 1.0; gcs.fc_limit = 16; gcs.fc_master_slave = no; gcs.max_packet_size = 64500; gcs.max_throttle = 0.25; gcs.recv_q_hard_limit = 9223372036854775807; gcs.recv_q_soft_limit = 0.25; gcs.sync_donor = no; gmcast.listen_addr = tcp://0.0.0.0:4567; gmcast.mcast_addr = ; gmcast.mcast_ttl = 1; gmcast.peer_timeout = PT3S; gmcast.segment = 0; gmcast.time_wait = PT5S; gmcast.version = 0; ist.recv_addr = 10.91.142.82; pc.announce_timeout = PT3S; pc.checksum = false; pc.ignore_quorum = false; pc.ignore_sb = false; pc.linger = PT20S; pc.npvo = false; pc.recovery = true; pc.version = 0; pc.wait_prim = true; pc.wait_prim_timeout = P30S; pc.weight = 1; protonet.backend = asio; protonet.version = 0; repl.causal_read_timeout = PT30S; repl.commit_order = 3; repl.key_format = FLAT8; repl.max_ws_size = 2147483647; repl.proto_max = 7; socket.checksum = 2; socket.recv_buf_size = 212992;")
 	mock.ExpectQuery(globalVariablesQuery).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
@@ -52,6 +53,7 @@ func TestScrapeGlobalVariables(t *testing.T) {
 		{labels: labelMap{}, value: 2, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{"innodb_version": "5.6.30-76.3", "version": "5.6.30-76.3-56", "version_comment": "Percona XtraDB Cluster..."}, value: 1, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{"wsrep_cluster_name": "supercluster"}, value: 1, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{}, value: 134217728, metricType: dto.MetricType_GAUGE},
 	}
 	convey.Convey("Metrics comparison", t, func() {
 		for _, expect := range counterExpected {
@@ -64,4 +66,17 @@ func TestScrapeGlobalVariables(t *testing.T) {
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled expections: %s", err)
 	}
+}
+
+func TestParseWsrepProviderOptions(t *testing.T) {
+	testE := ""
+	testM := "base_dir = /var/lib/mysql/; base_host = 10.91.142.82; base_port = 4567; cert.log_conflicts = no; debug = no; evs.auto_evict = 0; evs.causal_keepalive_period = PT1S; evs.debug_log_mask = 0x1; evs.delay_margin = PT1S; evs.delayed_keep_period = PT30S; evs.inactive_check_period = PT0.5S; evs.inactive_timeout = PT15S; evs.info_log_mask = 0; evs.install_timeout = PT7.5S; evs.join_retrans_period = PT1S; evs.keepalive_period = PT1S; evs.max_install_timeouts = 3; evs.send_window = 4; evs.stats_report_period = PT1M; evs.suspect_timeout = PT5S; evs.use_aggregate = true; evs.user_send_window = 2; evs.version = 0; evs.view_forget_timeout = P1D; gcache.dir = /var/lib/mysql/; gcache.keep_pages_count = 0; gcache.keep_pages_size = 0; gcache.mem_size = 0; gcache.name = /var/lib/mysql//galera.cache; gcache.page_size = 128M; gcache.size = 128M; gcomm.thread_prio = ; gcs.fc_debug = 0; gcs.fc_factor = 1.0; gcs.fc_limit = 16; gcs.fc_master_slave = no; gcs.max_packet_size = 64500; gcs.max_throttle = 0.25; gcs.recv_q_hard_limit = 9223372036854775807; gcs.recv_q_soft_limit = 0.25; gcs.sync_donor = no; gmcast.listen_addr = tcp://0.0.0.0:4567; gmcast.mcast_addr = ; gmcast.mcast_ttl = 1; gmcast.peer_timeout = PT3S; gmcast.segment = 0; gmcast.time_wait = PT5S; gmcast.version = 0; ist.recv_addr = 10.91.142.82; pc.announce_timeout = PT3S; pc.checksum = false; pc.ignore_quorum = false; pc.ignore_sb = false; pc.linger = PT20S; pc.npvo = false; pc.recovery = true; pc.version = 0; pc.wait_prim = true; pc.wait_prim_timeout = P30S; pc.weight = 1; protonet.backend = asio; protonet.version = 0; repl.causal_read_timeout = PT30S; repl.commit_order = 3; repl.key_format = FLAT8; repl.max_ws_size = 2147483647; repl.proto_max = 7; socket.checksum = 2; socket.recv_buf_size = 212992;"
+	testG := "base_dir = /var/lib/mysql/; base_host = 10.91.194.244; base_port = 4567; cert.log_conflicts = no; debug = no; evs.auto_evict = 0; evs.causal_keepalive_period = PT1S; evs.debug_log_mask = 0x1; evs.delay_margin = PT1S; evs.delayed_keep_period = PT30S; evs.inactive_check_period = PT0.5S; evs.inactive_timeout = PT15S; evs.info_log_mask = 0; evs.install_timeout = PT7.5S; evs.join_retrans_period = PT1S; evs.keepalive_period = PT1S; evs.max_install_timeouts = 3; evs.send_window = 4; evs.stats_report_period = PT1M; evs.suspect_timeout = PT5S; evs.use_aggregate = true; evs.user_send_window = 2; evs.version = 0; evs.view_forget_timeout = P1D; gcache.dir = /var/lib/mysql/; gcache.keep_pages_count = 0; gcache.keep_pages_size = 0; gcache.mem_size = 0; gcache.name = /var/lib/mysql//galera.cache; gcache.page_size = 128M; gcache.size = 2G; gcomm.thread_prio = ; gcs.fc_debug = 0; gcs.fc_factor = 1.0; gcs.fc_limit = 16; gcs.fc_master_slave = no; gcs.max_packet_size = 64500; gcs.max_throttle = 0.25; gcs.recv_q_hard_limit = 9223372036854775807; gcs.recv_q_soft_limit = 0.25; gcs.sync_donor = no; gmcast.listen_addr = tcp://0.0.0.0:4567; gmcast.mcast_addr = ; gmcast.mcast_ttl = 1; gmcast.peer_timeout = PT3S; gmcast.segment = 0; gmcast.time_wait = PT5S; gmcast.version = 0; ist.recv_addr = 10.91.194.244; pc.announce_timeout = PT3S; pc.checksum = false; pc.ignore_quorum = false; pc.ignore_sb = false; pc.linger = PT20S; pc.npvo = false; pc.recovery = true; pc.version = 0; pc.wait_prim = true; pc.wait_prim_timeout = P30S; pc.weight = 1; protonet.backend = asio; protonet.version = 0; repl.causal_read_timeout = PT30S; repl.commit_order = 3; repl.key_format = FLAT8; repl.max_ws_size = 2147483647; repl.proto_max = 7; socket.checksum = 2; socket.recv_buf_size = 212992;"
+	testB := "gcache.page_size = 128M; gcache.size = 131072; gcomm.thread_prio = ;"
+	convey.Convey("Parse wsrep_provider_options", t, func() {
+		convey.So(parseWsrepProviderOptions(testE), convey.ShouldEqual, 0)
+		convey.So(parseWsrepProviderOptions(testM), convey.ShouldEqual, 128*1024*1024)
+		convey.So(parseWsrepProviderOptions(testG), convey.ShouldEqual, 2*1024*1024*1024)
+		convey.So(parseWsrepProviderOptions(testB), convey.ShouldEqual, 131072)
+	})
 }


### PR DESCRIPTION
Added `gcache.size` as a metric from `wsrep_provider_options` global variable for PXC/Galera.

This is useful to compare with the rate of `sum(wsrep%bytes)` status variables to figure out how much time a node can be out of the cluster before it will require SST vs IST. [Details](http://severalnines.com/blog/how-avoid-sst-when-adding-new-node-galera-cluster)