### PR TITLE
Add MariaDB multi source replication support

### DIFF
--- a/collector/slave_status.go
+++ b/collector/slave_status.go
@@ -13,10 +13,9 @@ import (
 const (
 	// Subsystem.
 	slaveStatus = "slave_status"
-	// Query.
-	slaveStatusQuery = `SHOW SLAVE STATUS`
 )
 
+var slaveStatusQueries = [2]string{"SHOW ALL SLAVES STATUS", "SHOW SLAVE STATUS"}
 var slaveStatusQuerySuffixes = [3]string{" NONBLOCKING", " NOLOCK", ""}
 
 func columnIndex(slaveCols []string, colName string) int {
@@ -42,10 +41,18 @@ func ScrapeSlaveStatus(db *sql.DB, ch chan<- prometheus.Metric) error {
 		slaveStatusRows *sql.Rows
 		err             error
 	)
-	// Leverage lock-free SHOW SLAVE STATUS by guessing the right suffix
-	for _, suffix := range slaveStatusQuerySuffixes {
-		slaveStatusRows, err = db.Query(fmt.Sprint(slaveStatusQuery, suffix))
-		if err == nil {
+	// Try the both syntax for MySQL/Percona and MariaDB
+	for _, query := range slaveStatusQueries {
+		slaveStatusRows, err = db.Query(query)
+		if err != nil { // MySQL/Percona
+			// Leverage lock-free SHOW SLAVE STATUS by guessing the right suffix
+			for _, suffix := range slaveStatusQuerySuffixes {
+				slaveStatusRows, err = db.Query(fmt.Sprint(query, suffix))
+				if err == nil {
+					break
+				}
+			}
+		} else { // MariaDB
 			break
 		}
 	}
@@ -74,7 +81,8 @@ func ScrapeSlaveStatus(db *sql.DB, ch chan<- prometheus.Metric) error {
 
 		masterUUID := columnValue(scanArgs, slaveCols, "Master_UUID")
 		masterHost := columnValue(scanArgs, slaveCols, "Master_Host")
-		channelName := columnValue(scanArgs, slaveCols, "Channel_Name")
+		channelName := columnValue(scanArgs, slaveCols, "Channel_Name") // MySQL & Percona
+		connectionName := columnValue(scanArgs, slaveCols, "Connection_name") // MariaDB
 
 		for i, col := range slaveCols {
 			if value, ok := parseStatus(*scanArgs[i].(*sql.RawBytes)); ok { // Silently skip unparsable values.
@@ -82,12 +90,12 @@ func ScrapeSlaveStatus(db *sql.DB, ch chan<- prometheus.Metric) error {
 					prometheus.NewDesc(
 						prometheus.BuildFQName(namespace, slaveStatus, strings.ToLower(col)),
 						"Generic metric from SHOW SLAVE STATUS.",
-						[]string{"master_uuid", "master_host", "channel_name"},
+						[]string{"master_host", "master_uuid", "channel_name", "connection_name"},
 						nil,
 					),
 					prometheus.UntypedValue,
 					value,
-					masterUUID, masterHost, channelName,
+					masterHost, masterUUID, channelName, connectionName,
 				)
 			}
 		}

--- a/collector/slave_status_test.go
+++ b/collector/slave_status_test.go
@@ -19,7 +19,7 @@ func TestScrapeSlaveStatus(t *testing.T) {
 	columns := []string{"Master_Host", "Read_Master_Log_Pos", "Slave_IO_Running", "Slave_SQL_Running", "Seconds_Behind_Master"}
 	rows := sqlmock.NewRows(columns).
 		AddRow("127.0.0.1", "1", "Connecting", "Yes", "2")
-	mock.ExpectQuery(sanitizeQuery(slaveStatusQuery)).WillReturnRows(rows)
+	mock.ExpectQuery(sanitizeQuery("SHOW SLAVE STATUS")).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
 	go func() {
@@ -30,10 +30,10 @@ func TestScrapeSlaveStatus(t *testing.T) {
 	}()
 
 	counterExpected := []MetricResult{
-		{labels: labelMap{"channel_name": "", "master_host": "127.0.0.1", "master_uuid": ""}, value: 1, metricType: dto.MetricType_UNTYPED},
-		{labels: labelMap{"channel_name": "", "master_host": "127.0.0.1", "master_uuid": ""}, value: 0, metricType: dto.MetricType_UNTYPED},
-		{labels: labelMap{"channel_name": "", "master_host": "127.0.0.1", "master_uuid": ""}, value: 1, metricType: dto.MetricType_UNTYPED},
-		{labels: labelMap{"channel_name": "", "master_host": "127.0.0.1", "master_uuid": ""}, value: 2, metricType: dto.MetricType_UNTYPED},
+		{labels: labelMap{"channel_name": "", "connection_name": "", "master_host": "127.0.0.1", "master_uuid": ""}, value: 1, metricType: dto.MetricType_UNTYPED},
+		{labels: labelMap{"channel_name": "", "connection_name": "", "master_host": "127.0.0.1", "master_uuid": ""}, value: 0, metricType: dto.MetricType_UNTYPED},
+		{labels: labelMap{"channel_name": "", "connection_name": "", "master_host": "127.0.0.1", "master_uuid": ""}, value: 1, metricType: dto.MetricType_UNTYPED},
+		{labels: labelMap{"channel_name": "", "connection_name": "", "master_host": "127.0.0.1", "master_uuid": ""}, value: 2, metricType: dto.MetricType_UNTYPED},
 	}
 	convey.Convey("Metrics comparison", t, func() {
 		for _, expect := range counterExpected {


### PR DESCRIPTION
The syntax differs between MySQL/Percona and MariaDB for the multi source replication.

The `SHOW SLAVE STATUS` is `SHOW ALL SLAVES STATUS` and the `Channel_name` is `Connection_name`.

Cheers,

Max.