### PR TITLE
Add an example of heartbeat metrics for slave lag

### DIFF
--- a/example.rules
+++ b/example.rules
@@ -12,6 +12,8 @@
 # `mysql_slave_status_sql_delay` into account
 mysql_slave_lag_seconds = mysql_slave_status_seconds_behind_master - mysql_slave_status_sql_delay
 
+# Record slave lag via heartbeat method
+mysql_heartbeat_lag_seconds = mysql_heartbeat_now_timestamp_seconds - mysql_heartbeat_stored_timestamp_seconds
 
 ###
 # Galera Alerts
@@ -68,13 +70,31 @@ ALERT MySQLReplicationNotRunning
     description = "Slave replication (IO or SQL) has been down for more than 2 minutes.",
   }
 
-# Alert: The replicaiton lag is non-zero and it predicted to not recover within
+# Alert: The replication lag is non-zero and it predicted to not recover within
 #        2 minutes.  This allows for a small amount of replication lag.
+# NOTE: This alert depends on the recording rule at the top of the file.
 ALERT MySQLReplicationLag
   IF
       (mysql_slave_lag_seconds > 30)
     AND on (instance)
       (predict_linear(mysql_slave_lag_seconds[5m], 60*2) > 0)
+  FOR 1m
+  LABELS {
+    severity = "critical"
+  }
+  ANNOTATIONS {
+    summary = "MySQL slave replication is lagging",
+    description = "The mysql slave replication has fallen behind and is not recovering",
+  }
+
+# Alert: The replication lag is non-zero and it predicted to not recover within
+#        2 minutes.  This allows for a small amount of replication lag.
+# NOTE: This alert depends on the recording rule at the top of the file.
+ALERT MySQLReplicationLag
+  IF
+      (mysql_heartbeat_lag_seconds > 30)
+    AND on (instance)
+      (predict_linear(mysql_heartbeat_lag_seconds[5m], 60*2) > 0)
   FOR 1m
   LABELS {
     severity = "critical"


### PR DESCRIPTION
Heartbeat[0] metrics allow for similar alerting symantics to "seconds
behind master" metrics.
* Add a recording rule to provide a similar gauge of seconds behind.
* Add an alert with the same style.

[0]: https://github.com/prometheus/mysqld_exporter/pull/183