### PR TITLE
Add basic file_summary_by_instance metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ collect.perf_schema.eventsstatements.limit             | 5.6           | Limit t
 collect.perf_schema.eventsstatements.timelimit         | 5.6           | Limit how old the 'last_seen' events statements can be, in seconds. (default: 86400)
 collect.perf_schema.eventswaits                        | 5.5           | Collect metrics from performance_schema.events_waits_summary_global_by_event_name.
 collect.perf_schema.file_events                        | 5.6           | Collect metrics from performance_schema.file_summary_by_event_name.
+collect.perf_schema.file_instances                     | 5.5           | Collect metrics from performance_schema.file_summary_by_instance
 collect.perf_schema.indexiowaits                       | 5.6           | Collect metrics from performance_schema.table_io_waits_summary_by_index_usage.
 collect.perf_schema.tableiowaits                       | 5.6           | Collect metrics from performance_schema.table_io_waits_summary_by_table.
 collect.perf_schema.tablelocks                         | 5.6           | Collect metrics from performance_schema.table_lock_waits_summary_by_table.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ collect.perf_schema.eventsstatements.limit             | 5.6           | Limit t
 collect.perf_schema.eventsstatements.timelimit         | 5.6           | Limit how old the 'last_seen' events statements can be, in seconds. (default: 86400)
 collect.perf_schema.eventswaits                        | 5.5           | Collect metrics from performance_schema.events_waits_summary_global_by_event_name.
 collect.perf_schema.file_events                        | 5.6           | Collect metrics from performance_schema.file_summary_by_event_name.
-collect.perf_schema.file_instances                     | 5.5           | Collect metrics from performance_schema.file_summary_by_instance
+collect.perf_schema.file_instances                     | 5.5           | Collect metrics from performance_schema.file_summary_by_instance.
 collect.perf_schema.indexiowaits                       | 5.6           | Collect metrics from performance_schema.table_io_waits_summary_by_index_usage.
 collect.perf_schema.tableiowaits                       | 5.6           | Collect metrics from performance_schema.table_io_waits_summary_by_table.
 collect.perf_schema.tablelocks                         | 5.6           | Collect metrics from performance_schema.table_lock_waits_summary_by_table.

--- a/collector/perf_schema_file_instances.go
+++ b/collector/perf_schema_file_instances.go
@@ -8,7 +8,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"flag"
-	"strings"
+	"path"
+	"path/filepath"
 )
 
 const perfFileInstancesQuery = `
@@ -68,11 +69,8 @@ func ScrapePerfFileInstances(db *sql.DB, ch chan<- prometheus.Metric) error {
 			return err
 		}
 
-		if *performanceSchemaFileInstancesRemovePrefix && *performanceSchemaFileInstancesFilter != ".*" {
-			pos := strings.LastIndexAny(fileName, "/\\")
-			if pos != -1 && pos < len(fileName) {
-				fileName = fileName[pos+1:]
-			}
+		if *performanceSchemaFileInstancesRemovePrefix {
+			fileName = path.Base(filepath.ToSlash(fileName))
 		}
 		ch <- prometheus.MustNewConstMetric(
 			performanceSchemaFileInstancesCountDesc, prometheus.CounterValue, float64(countRead),

--- a/collector/perf_schema_file_instances.go
+++ b/collector/perf_schema_file_instances.go
@@ -1,0 +1,83 @@
+// Scrape `performance_schema.file_summary_by_event_name`.
+
+package collector
+
+import (
+	"database/sql"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"strings"
+)
+
+const perfFileInstancesQuery = `
+	SELECT
+	    FILE_NAME,
+	    COUNT_READ, COUNT_WRITE,
+	    SUM_NUMBER_OF_BYTES_READ, SUM_NUMBER_OF_BYTES_WRITE
+	  FROM performance_schema.file_summary_by_instance
+	     where LOCATE(?,FILE_NAME)>0
+	`
+
+// Metric descriptors.
+var (
+	performanceSchemaFileInstancesBytesDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "file_instances_bytes"),
+		"The number of bytes read or write by the file.",
+		[]string{"file", "mode"}, nil,
+	)
+	performanceSchemaFileInstancesCountDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "file_instances_count"),
+		"The number of operations by the file.",
+		[]string{"file", "mode"}, nil,
+	)
+)
+
+// ScrapePerfFileEvents collects from `performance_schema.file_summary_by_event_name`.
+func ScrapePerfFileInstances(db *sql.DB, ch chan<- prometheus.Metric, filter *string) error {
+	// Timers here are returned in picoseconds.
+	perfSchemaFileInstancesRows, err := db.Query(perfFileInstancesQuery, *filter)
+	if err != nil {
+		return err
+	}
+	defer perfSchemaFileInstancesRows.Close()
+
+	var (
+		fileName                      string
+		countRead, countWrite         uint64
+		sumBytesRead, sumBytesWritten uint64
+	)
+	for perfSchemaFileInstancesRows.Next() {
+		if err := perfSchemaFileInstancesRows.Scan(
+			&fileName,
+			&countRead, &countWrite,
+			&sumBytesRead, &sumBytesWritten,
+		); err != nil {
+			return err
+		}
+		if len(*filter) > 0 {
+			pos:=strings.LastIndex(fileName,*filter)
+			if pos>-1 {
+				fileName=fileName[pos+len(*filter):]
+			}
+		}
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaFileInstancesCountDesc, prometheus.CounterValue, float64(countRead),
+			fileName, "read",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaFileInstancesCountDesc , prometheus.CounterValue, float64(countWrite),
+			fileName, "write",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaFileInstancesBytesDesc, prometheus.CounterValue, float64(sumBytesRead),
+			fileName, "read",
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaFileInstancesBytesDesc, prometheus.CounterValue, float64(sumBytesWritten),
+			fileName, "write",
+		)
+
+	}
+	return nil
+}

--- a/collector/perf_schema_file_instances.go
+++ b/collector/perf_schema_file_instances.go
@@ -23,7 +23,7 @@ const perfFileInstancesQuery = `
 // Metric descriptors.
 var (
 	performanceSchemaFileInstancesFilter = flag.String(
-		"collect.perf_schema.file_instances.filter", "",
+		"collect.perf_schema.file_instances.filter", ".*",
 		"RegEx file_name filter for performance_schema.file_summary_by_instance",
 	)
 
@@ -68,9 +68,9 @@ func ScrapePerfFileInstances(db *sql.DB, ch chan<- prometheus.Metric) error {
 			return err
 		}
 
-		if *performanceSchemaFileInstancesRemovePrefix {
-			pos:=strings.LastIndexAny(fileName,"/\\")
-			if pos!=-1 {
+		if *performanceSchemaFileInstancesRemovePrefix && *performanceSchemaFileInstancesFilter != ".*" {
+			pos := strings.LastIndexAny(fileName, "/\\")
+			if pos != -1 && pos < len(fileName) {
 				fileName = fileName[pos+1:]
 			}
 		}

--- a/collector/perf_schema_file_instances_test.go
+++ b/collector/perf_schema_file_instances_test.go
@@ -1,0 +1,62 @@
+package collector
+
+import (
+	"testing"
+
+	"flag"
+	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/smartystreets/goconvey/convey"
+	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+)
+
+func TestScrapePerfFileInstances(t *testing.T) {
+	err := flag.Set("collect.perf_schema.file_instances.filter", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("error opening a stub database connection: %s", err)
+	}
+	defer db.Close()
+
+	columns := []string{"FILE_NAME", "COUNT_READ", "COUNT_WRITE", "SUM_NUMBER_OF_BYTES_READ", "SUM_NUMBER_OF_BYTES_WRITE"}
+
+	rows := sqlmock.NewRows(columns).
+		AddRow("file_1", "3", "4", "725", "128").
+		AddRow("file_2", "23", "12", "3123", "967")
+	mock.ExpectQuery(sanitizeQuery(perfFileInstancesQuery)).WillReturnRows(rows)
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		if err = ScrapePerfFileInstances(db, ch); err != nil {
+			panic(fmt.Sprintf("error calling function on test: %s", err))
+		}
+		close(ch)
+	}()
+
+	metricExpected := []MetricResult{
+		{labels: labelMap{"file_name": "file_1", "mode": "read"}, value: 3, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "file_1", "mode": "write"}, value: 4, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "file_1", "mode": "read"}, value: 725, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "file_1", "mode": "write"}, value: 128, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "file_2", "mode": "read"}, value: 23, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "file_2", "mode": "write"}, value: 12, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "file_2", "mode": "read"}, value: 3123, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "file_2", "mode": "write"}, value: 967, metricType: dto.MetricType_COUNTER},
+	}
+	convey.Convey("Metrics comparison", t, func() {
+		for _, expect := range metricExpected {
+			got := readMetric(<-ch)
+			convey.So(got, convey.ShouldResemble, expect)
+		}
+	})
+
+	// Ensure all SQL queries were executed
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expections: %s", err)
+	}
+}

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -103,10 +103,6 @@ var (
 		"collect.perf_schema.file_instances", false,
 		"Collect metrics from performance_schema.file_summary_by_instance",
 	)
-	collectPerfFileInstancesFilter = flag.String(
-		"collect.perf_schema.file_instances.filter", "",
-		"Filter for performance_schema.file_summary_by_instance",
-	)
 	collectUserStat = flag.Bool("collect.info_schema.userstats", false,
 		"If running with userstat=1, set to true to collect user statistics",
 	)
@@ -377,7 +373,7 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 		}
 	}
 	if *collectPerfFileInstances {
-		if err = collector.ScrapePerfFileInstances(db, ch,collectPerfFileInstancesFilter); err != nil {
+		if err = collector.ScrapePerfFileInstances(db, ch); err != nil {
 			log.Errorln("Error scraping for collect.perf_schema.file_instances:", err)
 			e.scrapeErrors.WithLabelValues("collect.perf_schema.file_instances").Inc()
 		}

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -99,6 +99,14 @@ var (
 		"collect.perf_schema.file_events", false,
 		"Collect metrics from performance_schema.file_summary_by_event_name",
 	)
+	collectPerfFileInstances = flag.Bool(
+		"collect.perf_schema.file_instances", false,
+		"Collect metrics from performance_schema.file_summary_by_instance",
+	)
+	collectPerfFileInstancesFilter = flag.String(
+		"collect.perf_schema.file_instances.filter", "",
+		"Filter for performance_schema.file_summary_by_instance",
+	)
 	collectUserStat = flag.Bool("collect.info_schema.userstats", false,
 		"If running with userstat=1, set to true to collect user statistics",
 	)
@@ -366,6 +374,12 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 		if err = collector.ScrapePerfFileEvents(db, ch); err != nil {
 			log.Errorln("Error scraping for collect.perf_schema.file_events:", err)
 			e.scrapeErrors.WithLabelValues("collect.perf_schema.file_events").Inc()
+		}
+	}
+	if *collectPerfFileInstances {
+		if err = collector.ScrapePerfFileInstances(db, ch,collectPerfFileInstancesFilter); err != nil {
+			log.Errorln("Error scraping for collect.perf_schema.file_instances:", err)
+			e.scrapeErrors.WithLabelValues("collect.perf_schema.file_instances").Inc()
 		}
 	}
 	if *collectUserStat {


### PR DESCRIPTION
This adds MySQL 5.5 compatible file access metrics. It might be related to #126.

I needed this to monitor table access in MySQL 5.5 where newer performance_schema tables are not present.

It could be enabled with:

    -collect.perf_schema.file_instances

The emitted metrics per file are (example):

    mysql_perf_schema_file_instances_bytes{file_name="table.MYD",mode="read"} 244
    mysql_perf_schema_file_instances_bytes{file_name="table.MYD",mode="write"} 0
    mysql_perf_schema_file_instances_total{file_name="table.MYD",mode="read"} 4
    mysql_perf_schema_file_instances_total{file_name="table.MYD",mode="write"} 0

Filtering 'file_name' is possible via a regexp to restrict the number of emitted metrics:

     -collect.perf_schema.file_instances.filter=basedir/.*(MYD|MYI)

The path-prefix of the 'file_name' label is automatically stripped, but could be re-enabled with

    -collect.perf_schema.file_instances.remove_prefix=false

It is mostly adapted from _perf_schema_file_events.go_. 





    