### PR TITLE
Add a recording rule example for TPS

### DIFF
--- a/example.rules
+++ b/example.rules
@@ -15,6 +15,10 @@ mysql_slave_lag_seconds = mysql_slave_status_seconds_behind_master - mysql_slave
 # Record slave lag via heartbeat method
 mysql_heartbeat_lag_seconds = mysql_heartbeat_now_timestamp_seconds - mysql_heartbeat_stored_timestamp_seconds
 
+# Record "Transactions per second"
+# See: https://dev.mysql.com/doc/refman/5.7/en/glossary.html#glos_transaction
+job:mysql_transactions:rate5m = sum(rate(mysql_global_status_commands_total{command=~"(commit|rollback)"}[5m])) without (command)
+
 ###
 # Galera Alerts
 


### PR DESCRIPTION
Add a recording rule example for "Transactions Per Second".

[0]: https://dev.mysql.com/doc/refman/5.7/en/glossary.html#glos_transaction

Closes: https://github.com/prometheus/mysqld_exporter/issues/198