### PR TITLE
Fix file_instances metric collector

### DIFF
--- a/collector/perf_schema_file_instances.go
+++ b/collector/perf_schema_file_instances.go
@@ -29,7 +29,7 @@ var (
 	)
 
 	performanceSchemaFileInstancesRemovePrefix = flag.Bool(
-		"collect.perf_schema.file_instances.remove_prefix", true,
+		"collect.perf_schema.file_instances.remove_prefix", false,
 		"Remove path prefix in performance_schema.file_summary_by_instance",
 	)
 

--- a/collector/perf_schema_file_instances_test.go
+++ b/collector/perf_schema_file_instances_test.go
@@ -23,11 +23,11 @@ func TestScrapePerfFileInstances(t *testing.T) {
 	}
 	defer db.Close()
 
-	columns := []string{"FILE_NAME", "COUNT_READ", "COUNT_WRITE", "SUM_NUMBER_OF_BYTES_READ", "SUM_NUMBER_OF_BYTES_WRITE"}
+	columns := []string{"FILE_NAME", "EVENT_NAME", "COUNT_READ", "COUNT_WRITE", "SUM_NUMBER_OF_BYTES_READ", "SUM_NUMBER_OF_BYTES_WRITE"}
 
 	rows := sqlmock.NewRows(columns).
-		AddRow("file_1", "3", "4", "725", "128").
-		AddRow("file_2", "23", "12", "3123", "967")
+		AddRow("file_1", "event1", "3", "4", "725", "128").
+		AddRow("file_2", "event2", "23", "12", "3123", "967")
 	mock.ExpectQuery(sanitizeQuery(perfFileInstancesQuery)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
@@ -39,14 +39,14 @@ func TestScrapePerfFileInstances(t *testing.T) {
 	}()
 
 	metricExpected := []MetricResult{
-		{labels: labelMap{"file_name": "file_1", "mode": "read"}, value: 3, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"file_name": "file_1", "mode": "write"}, value: 4, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"file_name": "file_1", "mode": "read"}, value: 725, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"file_name": "file_1", "mode": "write"}, value: 128, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"file_name": "file_2", "mode": "read"}, value: 23, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"file_name": "file_2", "mode": "write"}, value: 12, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"file_name": "file_2", "mode": "read"}, value: 3123, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"file_name": "file_2", "mode": "write"}, value: 967, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "file_1", "event_name": "event1", "mode": "read"}, value: 3, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "file_1", "event_name": "event1", "mode": "write"}, value: 4, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "file_1", "event_name": "event1", "mode": "read"}, value: 725, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "file_1", "event_name": "event1", "mode": "write"}, value: 128, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "file_2", "event_name": "event2", "mode": "read"}, value: 23, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "file_2", "event_name": "event2", "mode": "write"}, value: 12, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "file_2", "event_name": "event2", "mode": "read"}, value: 3123, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "file_2", "event_name": "event2", "mode": "write"}, value: 967, metricType: dto.MetricType_COUNTER},
 	}
 	convey.Convey("Metrics comparison", t, func() {
 		for _, expect := range metricExpected {


### PR DESCRIPTION
Include the event name column as a label for metrics gathered from `performance_schema.file_summary_by_instance`.

Default to not cleaning the path on `performance_schema.file_summary_by_instance`
names to avoid name colisions.

Closes: https://github.com/prometheus/mysqld_exporter/issues/203