### PR TITLE
Limit number and lifetime of connections

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -258,10 +258,10 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 	}
 	defer db.Close()
 
-	// by design exporter should use maximum one connection at any given time
+	// By design exporter should use maximum one connection per request.
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
-	// set max lifetime for a connection
+	// Set max lifetime for a connection.
 	db.SetConnMaxLifetime(1 * time.Minute)
 
 	isUpRows, err := db.Query(upQuery)

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -258,11 +258,11 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 	}
 	defer db.Close()
 
-	// limit connections to recommended value
-	db.SetMaxOpenConns(3)
-	db.SetMaxIdleConns(3)
-	// close idle connections after max lifetime
-	db.SetConnMaxLifetime(5 * time.Minute)
+	// by design exporter should use maximum one connection at any given time
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	// set max lifetime for a connection
+	db.SetConnMaxLifetime(1 * time.Minute)
 
 	isUpRows, err := db.Query(upQuery)
 	if err != nil {

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -258,6 +258,12 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 	}
 	defer db.Close()
 
+	// limit connections to recommended value
+	db.SetMaxOpenConns(3)
+	db.SetMaxIdleConns(3)
+	// close idle connections after max lifetime
+	db.SetConnMaxLifetime(5 * time.Minute)
+
 	isUpRows, err := db.Query(upQuery)
 	if err != nil {
 		log.Errorln("Error pinging mysqld:", err)


### PR DESCRIPTION
I'm trying to hunt down some leaking connection issues. While this doesn't nail the issue it's something I was surprised not to see in exporter.

If user forgets to limit number of connections from db perspective, we still won't create hundreds of them. Even if user sets `MAX_USER_CONNECTIONS 3` then golang driver won't even try to create new connection.

Also `SetConnMaxLifetime` gets rid of idle and stale/broken connections.

Let me know what you think.

https://golang.org/pkg/database/sql/#DB.SetMaxIdleConns
https://golang.org/pkg/database/sql/#DB.SetMaxOpenConns
https://github.com/golang/go/commit/0c516c16328575ab78a4cce49874955dd590efa2