### PR TITLE
Update Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: false
 language: go
 go:
 - 1.8.x
+- tip
+
+go_import_path: github.com/prometheus/mysqld_exporter
 
 script:
 - make


### PR DESCRIPTION
1. Test with tip Go version. Go 1.9 will add a lot of stuff to `database/sql` so it makes sense to test it now.
2. Set Go import path on Travis CI. That's changes nothing for this repository but allows forks to use Travis CI without hacking configuration and makes merging with upstream easier.