### PR TITLE
Add 'collect' URL parameter to filter enabled collectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ reference heartbeat implementation supported.
 
 ## Prometheus Configuration
 
-The mysqld exporter can be passed a list desired (enabled) collectors. The `collect[]` parameter accepts values matching [Collector Flags](#collector-flags) names.
+The mysqld exporter will expose all metrics from enabled collectors by default, but it can be passed an optional list of collectors to filter metrics. The `collect[]` parameter accepts values matching [Collector Flags](#collector-flags) names (without `collect.` prefix).
+
 This can be useful for specifying different scrape intervals for different collectors.
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -108,6 +108,35 @@ reference heartbeat implementation supported.
 
 [pth]:https://www.percona.com/doc/percona-toolkit/2.2/pt-heartbeat.html
 
+
+## Prometheus Configuration
+
+The mysqld exporter can be passed a list desired (enabled) collectors. The `collect[]` parameter accepts values matching [Collector Flags](#collector-flags) names.
+This can be useful for specifying different scrape intervals for different collectors.
+
+```yaml
+scrape_configs:
+  - job_name: 'mysql global status'
+    scrape_interval: 15s
+    static_configs:
+      - targets:
+        - '192.168.1.2:9104'
+    params:
+      collect[]:
+        - global_status
+
+  - job_name: 'mysql performance'
+    scrape_interval: 1m
+    static_configs:
+      - targets:
+        - '192.168.1.2:9104'
+    params:
+      collect[]:
+        - perf_schema.tableiowaits
+        - perf_schema.indexiowaits
+        - perf_schema.tablelocks
+```
+
 ## Example Rules
 
 There are some sample rules available in [example.rules](example.rules)

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -191,12 +190,11 @@ func filter(filters map[string]bool, name string) bool {
 
 func handler(w http.ResponseWriter, r *http.Request) {
 	var filters map[string]bool
-	query := r.URL.Query().Get("collect")
-	log.Debugln("collect query:", query)
+	params := r.URL.Query()["collect[]"]
+	log.Debugln("collect query:", params)
 
-	if len(query) > 0 {
+	if len(params) > 0 {
 		filters = make(map[string]bool)
-		params := strings.Split(query, ",")
 		for _, param := range params {
 			f := flag.Lookup("collect." + param)
 			if f == nil {

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -230,7 +230,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		prometheus.DefaultGatherer,
 		registry,
 	}
-	// Delegate http serving to Promethues client library, which will call collector.Collect.
+	// Delegate http serving to Prometheus client library, which will call collector.Collect.
 	h := promhttp.HandlerFor(gatherers, promhttp.HandlerOpts{})
 	h.ServeHTTP(w, r)
 }
@@ -251,9 +251,6 @@ func main() {
 			log.Fatal(err)
 		}
 	}
-
-	//prometheus.MustRegister(prometheus.NewGoCollector())
-	//prometheus.MustRegister(prometheus.NewProcessCollector(os.Getpid(), ""))
 
 	http.HandleFunc(*metricPath, prometheus.InstrumentHandlerFunc("metrics", handler))
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -234,8 +234,9 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	registry := prometheus.NewRegistry()
-	c := collector.New(dsn, collect)
-	registry.MustRegister(c)
+	registry.MustRegister(prometheus.NewProcessCollector(os.Getpid(), ""))
+	registry.MustRegister(collector.New(dsn, collect))
+
 	// Delegate http serving to Promethues client library, which will call collector.Collect.
 	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 	h.ServeHTTP(w, r)

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -226,9 +226,10 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	registry.MustRegister(prometheus.NewGoCollector())
 	registry.MustRegister(prometheus.NewProcessCollector(os.Getpid(), ""))
 	registry.MustRegister(collector.New(dsn, collect))
+	prometheus.DefaultRegisterer = registry
 
 	// Delegate http serving to Promethues client library, which will call collector.Collect.
-	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
+	h := prometheus.InstrumentHandler("metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
 	h.ServeHTTP(w, r)
 }
 

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -223,6 +223,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	registry := prometheus.NewRegistry()
+	registry.MustRegister(prometheus.NewGoCollector())
 	registry.MustRegister(prometheus.NewProcessCollector(os.Getpid(), ""))
 	registry.MustRegister(collector.New(dsn, collect))
 

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -224,7 +224,6 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 	registry := prometheus.NewRegistry()
 	registry.MustRegister(collector.New(dsn, collect))
-	prometheus.DefaultRegisterer = registry
 
 	gatherers := prometheus.Gatherers{
 		prometheus.DefaultGatherer,

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -176,13 +176,13 @@ func init() {
 }
 
 func filter(filters map[string]bool, name string) bool {
-	flg := flag.Lookup("collect." + name)
+	f := flag.Lookup("collect." + name)
 
-	if flg != nil {
+	if f != nil {
 		if len(filters) > 0 {
-			return flg.Value.(flag.Getter).Get().(bool) && filters[name]
+			return f.Value.(flag.Getter).Get().(bool) && filters[name]
 		}
-		return flg.Value.(flag.Getter).Get().(bool)
+		return f.Value.(flag.Getter).Get().(bool)
 	}
 
 	log.Warnln("Missing collector with name:", name)
@@ -198,8 +198,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		filters = make(map[string]bool)
 		params := strings.Split(query, ",")
 		for _, param := range params {
-			flg := flag.Lookup("collect." + param)
-			if flg == nil {
+			f := flag.Lookup("collect." + param)
+			if f == nil {
 				log.Warnln("Could not match collection filter parameter:", param)
 			}
 			filters[param] = true
@@ -235,14 +235,12 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		HeartbeatTable:       *collectHeartbeatTable,
 	}
 
-	//start := time.Now()
 	registry := prometheus.NewRegistry()
 	c := collector.New(dsn, collect)
 	registry.MustRegister(c)
 	// Delegate http serving to Promethues client library, which will call collector.Collect.
 	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 	h.ServeHTTP(w, r)
-	//duration := float64(time.Since(start).Seconds())
 }
 
 func main() {

--- a/vendor/github.com/prometheus/client_golang/prometheus/promhttp/http.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/promhttp/http.go
@@ -1,0 +1,201 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright (c) 2013, The Prometheus Authors
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+// Package promhttp contains functions to create http.Handler instances to
+// expose Prometheus metrics via HTTP. In later versions of this package, it
+// will also contain tooling to instrument instances of http.Handler and
+// http.RoundTripper.
+//
+// promhttp.Handler acts on the prometheus.DefaultGatherer. With HandlerFor,
+// you can create a handler for a custom registry or anything that implements
+// the Gatherer interface. It also allows to create handlers that act
+// differently on errors or allow to log errors.
+package promhttp
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/prometheus/common/expfmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	contentTypeHeader     = "Content-Type"
+	contentLengthHeader   = "Content-Length"
+	contentEncodingHeader = "Content-Encoding"
+	acceptEncodingHeader  = "Accept-Encoding"
+)
+
+var bufPool sync.Pool
+
+func getBuf() *bytes.Buffer {
+	buf := bufPool.Get()
+	if buf == nil {
+		return &bytes.Buffer{}
+	}
+	return buf.(*bytes.Buffer)
+}
+
+func giveBuf(buf *bytes.Buffer) {
+	buf.Reset()
+	bufPool.Put(buf)
+}
+
+// Handler returns an HTTP handler for the prometheus.DefaultGatherer. The
+// Handler uses the default HandlerOpts, i.e. report the first error as an HTTP
+// error, no error logging, and compression if requested by the client.
+//
+// If you want to create a Handler for the DefaultGatherer with different
+// HandlerOpts, create it with HandlerFor with prometheus.DefaultGatherer and
+// your desired HandlerOpts.
+func Handler() http.Handler {
+	return HandlerFor(prometheus.DefaultGatherer, HandlerOpts{})
+}
+
+// HandlerFor returns an http.Handler for the provided Gatherer. The behavior
+// of the Handler is defined by the provided HandlerOpts.
+func HandlerFor(reg prometheus.Gatherer, opts HandlerOpts) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		mfs, err := reg.Gather()
+		if err != nil {
+			if opts.ErrorLog != nil {
+				opts.ErrorLog.Println("error gathering metrics:", err)
+			}
+			switch opts.ErrorHandling {
+			case PanicOnError:
+				panic(err)
+			case ContinueOnError:
+				if len(mfs) == 0 {
+					http.Error(w, "No metrics gathered, last error:\n\n"+err.Error(), http.StatusInternalServerError)
+					return
+				}
+			case HTTPErrorOnError:
+				http.Error(w, "An error has occurred during metrics gathering:\n\n"+err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		contentType := expfmt.Negotiate(req.Header)
+		buf := getBuf()
+		defer giveBuf(buf)
+		writer, encoding := decorateWriter(req, buf, opts.DisableCompression)
+		enc := expfmt.NewEncoder(writer, contentType)
+		var lastErr error
+		for _, mf := range mfs {
+			if err := enc.Encode(mf); err != nil {
+				lastErr = err
+				if opts.ErrorLog != nil {
+					opts.ErrorLog.Println("error encoding metric family:", err)
+				}
+				switch opts.ErrorHandling {
+				case PanicOnError:
+					panic(err)
+				case ContinueOnError:
+					// Handled later.
+				case HTTPErrorOnError:
+					http.Error(w, "An error has occurred during metrics encoding:\n\n"+err.Error(), http.StatusInternalServerError)
+					return
+				}
+			}
+		}
+		if closer, ok := writer.(io.Closer); ok {
+			closer.Close()
+		}
+		if lastErr != nil && buf.Len() == 0 {
+			http.Error(w, "No metrics encoded, last error:\n\n"+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		header := w.Header()
+		header.Set(contentTypeHeader, string(contentType))
+		header.Set(contentLengthHeader, fmt.Sprint(buf.Len()))
+		if encoding != "" {
+			header.Set(contentEncodingHeader, encoding)
+		}
+		w.Write(buf.Bytes())
+		// TODO(beorn7): Consider streaming serving of metrics.
+	})
+}
+
+// HandlerErrorHandling defines how a Handler serving metrics will handle
+// errors.
+type HandlerErrorHandling int
+
+// These constants cause handlers serving metrics to behave as described if
+// errors are encountered.
+const (
+	// Serve an HTTP status code 500 upon the first error
+	// encountered. Report the error message in the body.
+	HTTPErrorOnError HandlerErrorHandling = iota
+	// Ignore errors and try to serve as many metrics as possible.  However,
+	// if no metrics can be served, serve an HTTP status code 500 and the
+	// last error message in the body. Only use this in deliberate "best
+	// effort" metrics collection scenarios. It is recommended to at least
+	// log errors (by providing an ErrorLog in HandlerOpts) to not mask
+	// errors completely.
+	ContinueOnError
+	// Panic upon the first error encountered (useful for "crash only" apps).
+	PanicOnError
+)
+
+// Logger is the minimal interface HandlerOpts needs for logging. Note that
+// log.Logger from the standard library implements this interface, and it is
+// easy to implement by custom loggers, if they don't do so already anyway.
+type Logger interface {
+	Println(v ...interface{})
+}
+
+// HandlerOpts specifies options how to serve metrics via an http.Handler. The
+// zero value of HandlerOpts is a reasonable default.
+type HandlerOpts struct {
+	// ErrorLog specifies an optional logger for errors collecting and
+	// serving metrics. If nil, errors are not logged at all.
+	ErrorLog Logger
+	// ErrorHandling defines how errors are handled. Note that errors are
+	// logged regardless of the configured ErrorHandling provided ErrorLog
+	// is not nil.
+	ErrorHandling HandlerErrorHandling
+	// If DisableCompression is true, the handler will never compress the
+	// response, even if requested by the client.
+	DisableCompression bool
+}
+
+// decorateWriter wraps a writer to handle gzip compression if requested.  It
+// returns the decorated writer and the appropriate "Content-Encoding" header
+// (which is empty if no compression is enabled).
+func decorateWriter(request *http.Request, writer io.Writer, compressionDisabled bool) (io.Writer, string) {
+	if compressionDisabled {
+		return writer, ""
+	}
+	header := request.Header.Get(acceptEncodingHeader)
+	parts := strings.Split(header, ",")
+	for _, part := range parts {
+		part := strings.TrimSpace(part)
+		if part == "gzip" || strings.HasPrefix(part, "gzip;") {
+			return gzip.NewWriter(writer), "gzip"
+		}
+	}
+	return writer, ""
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -73,6 +73,14 @@
 			"versionExact": "v0.8.0"
 		},
 		{
+			"checksumSHA1": "lG3//eDlwqA4IOuAPrNtLh9G0TA=",
+			"path": "github.com/prometheus/client_golang/prometheus/promhttp",
+			"revision": "c5b7fccd204277076155f10851dad72b76a49317",
+			"revisionTime": "2016-08-17T15:48:24Z",
+			"version": "v0.8.0",
+			"versionExact": "v0.8.0"
+		},
+		{
 			"checksumSHA1": "DvwvOlPNAgRntBzt3b3OSRMS2N4=",
 			"path": "github.com/prometheus/client_model/go",
 			"revision": "fa8ad6fec33561be4280a8f0514318c79d7f6cb6",


### PR DESCRIPTION
As discussed on #234 and IRC, this PR adds a `collect` URL parameter to filter currently enabled collectors.

Closes: https://github.com/prometheus/mysqld_exporter/issues/234