### PR TITLE
Modified required grants in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ reference heartbeat implementation supported.
 
 [pth]:https://www.percona.com/doc/percona-toolkit/2.2/pt-heartbeat.html
 
-Please remind to add the following grant:
+You will need to grant the exporter access to the heartbeat table:
 
 ```sql
 GRANT SELECT ON `<db_name>.<table_name>` TO 'exporter'@'localhost';

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ NOTE: Not all collection methods are supported on MySQL < 5.6
 
 ```sql
 CREATE USER 'exporter'@'localhost' IDENTIFIED BY 'XXXXXXXX' WITH MAX_USER_CONNECTIONS 3;
-GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'exporter'@'localhost';
+GRANT PROCESS, REPLICATION CLIENT ON *.* TO 'exporter'@'localhost';
+GRANT SELECT ON `information_schema`.* TO 'exporter'@'localhost';
+GRANT SELECT ON `performance_schema`.* TO 'exporter'@'localhost';
 ```
 
 NOTE: It is recommended to set a max connection limit for the user to avoid overloading the server with monitoring scrapes under heavy load.
@@ -108,6 +110,11 @@ reference heartbeat implementation supported.
 
 [pth]:https://www.percona.com/doc/percona-toolkit/2.2/pt-heartbeat.html
 
+Please remind to add the following grant:
+
+```sql
+GRANT SELECT ON `<db_name>.<table_name>` TO 'exporter'@'localhost';
+```
 
 ## Prometheus Configuration
 


### PR DESCRIPTION
After reviewing the collectors code I think we can reduce the scope of the MySQL grants to strictly mentions what it needs to run.

I'm not sure we really need 

```GRANT SELECT ON `information_schema`.* TO 'exporter'@'localhost';```

as for InnoDB tables it should be indirectly granted by the `PROCESS` privilege (at least on MySQL 5.7+).