### PR TITLE
Changes for getting MySQL metrics in parallel using multiple connections

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -133,6 +133,10 @@ var (
 		"collect.heartbeat.table",
 		"Table from where to collect heartbeat data",
 	).Default("heartbeat").String()
+	mysqlMaxconns = kingpin.Flag(
+		"mysql.max.connection",
+		"Maximum connection pool size to MySQL server (max value 64)",
+	).Default("8").Int()
 	dsn string
 )
 
@@ -220,6 +224,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		Heartbeat:            filter(filters, "heartbeat", *collectHeartbeat),
 		HeartbeatDatabase:    *collectHeartbeatDatabase,
 		HeartbeatTable:       *collectHeartbeatTable,
+		MaxMySQLConns:        *mysqlMaxconns,
 	}
 
 	registry := prometheus.NewRegistry()


### PR DESCRIPTION
I have made changes to pull the MySQL metrics in parallel by using multiple connections. The connection pool size cannot be greater than 64 though. Added a new command line flag mysql.max.connection to set the connection pool size.
Sometimes the exporter takes long time when we collect metrics from a MySQL server with multiple databases and huge number of tables. For example, today I was running the tool on one of our database server and the exporter was taking on average 10 minutes to collect the metrics. With a connection pool of size 10  (so 10 queries in parallel), the scrape time reduced to almost 1 minute 10 seconds on average.