### PR TITLE
Cleanup and simplify scrape logic

### DIFF
--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -177,6 +177,8 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 		label   string
 		fn      scrapeFunc
 	}{
+		// "log_slow_filter" needs to be the first, since it changes the session.
+		// TODO: Set via DSN parameter instead? See https://github.com/go-sql-driver/mysql/#system-variables
 		{e.collect.SlowLogFilter, "log_slow_filter", func(db *sql.DB, ch chan<- prometheus.Metric) error {
 			sessionSettingsRows, err := db.Query(sessionSettingsQuery)
 			if err != nil {


### PR DESCRIPTION
The existing logic consists mostly of code tracking errors and timings, which is the same for each scrape "target".

SImplify the code by tracking all targets in a slice and ranging over it and moving the error and timing logic out into its own method.

Also add a comment to "log_slow_filter" that explains that it must be first. This was not obvious before and thus changes (e.g. #253) could accidentally change the behaviour. This can be avoided completely be settings the log_slow_filter variable via the DSN (see https://github.com/go-sql-driver/mysql/#system-variables), but this can be done in a later PR.