### PR TITLE
Support custom CA truststore and client SSL keypair.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,24 @@ The MySQL server's [data source name](http://en.wikipedia.org/wiki/Data_source_n
 must be set via the `DATA_SOURCE_NAME` environment variable.
 The format of this variable is described at https://github.com/go-sql-driver/mysql#dsn-data-source-name.
 
+
+## Customizing Configuration for a SSL Connection
+if The MySQL server supports SSL, you may need to specify a CA truststore to verify the server's chain-of-trust. You may also need to specify a SSL keypair for the client side of the SSL connection. To configure the mysqld exporter to use a custom CA certificate, add the following to the mysql cnf file:
+
+```
+ssl-ca=/path/to/ca/file
+```
+
+To specify the client SSL keypair, add the following to the cnf. 
+
+```
+ssl-key=/path/to/ssl/client/key
+ssl-cert=/path/to/ssl/client/cert
+```
+
+Customizing the SSL configuration is only supported in the mysql cnf file and is not supported if you set the mysql server's data source name in the environment variable DATA_SOURCE_NAME.
+
+
 ## Using Docker
 
 You can deploy this exporter using the [prom/mysqld-exporter](https://registry.hub.docker.com/u/prom/mysqld-exporter/) Docker image.


### PR DESCRIPTION
Per discussion in #226, there is no way to specify a custom CA that the
mysqld exporter will trust when establishing a SSL connection to a mysql
server. So if a mysql server has a custom truststore, an operator would
need to set DSN, where tls=skip-verify.

With this change, a user can define the ssl options in the mysql cnf and
then the mysqld exporter will construct a DSN and a custom TLS config
based on those options.