### PR TITLE
Fix prefix removal in perf_schema_file_instances

### DIFF
--- a/collector/perf_schema_file_instances_test.go
+++ b/collector/perf_schema_file_instances_test.go
@@ -26,8 +26,9 @@ func TestScrapePerfFileInstances(t *testing.T) {
 	columns := []string{"FILE_NAME", "EVENT_NAME", "COUNT_READ", "COUNT_WRITE", "SUM_NUMBER_OF_BYTES_READ", "SUM_NUMBER_OF_BYTES_WRITE"}
 
 	rows := sqlmock.NewRows(columns).
-		AddRow("file_1", "event1", "3", "4", "725", "128").
-		AddRow("file_2", "event2", "23", "12", "3123", "967")
+		AddRow("/var/lib/mysql/db1/file", "event1", "3", "4", "725", "128").
+		AddRow("/var/lib/mysql/db2/file", "event2", "23", "12", "3123", "967").
+		AddRow("db3/file", "event3", "45", "32", "1337", "326")
 	mock.ExpectQuery(sanitizeQuery(perfFileInstancesQuery)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
@@ -39,14 +40,18 @@ func TestScrapePerfFileInstances(t *testing.T) {
 	}()
 
 	metricExpected := []MetricResult{
-		{labels: labelMap{"file_name": "file_1", "event_name": "event1", "mode": "read"}, value: 3, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"file_name": "file_1", "event_name": "event1", "mode": "write"}, value: 4, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"file_name": "file_1", "event_name": "event1", "mode": "read"}, value: 725, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"file_name": "file_1", "event_name": "event1", "mode": "write"}, value: 128, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"file_name": "file_2", "event_name": "event2", "mode": "read"}, value: 23, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"file_name": "file_2", "event_name": "event2", "mode": "write"}, value: 12, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"file_name": "file_2", "event_name": "event2", "mode": "read"}, value: 3123, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"file_name": "file_2", "event_name": "event2", "mode": "write"}, value: 967, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "db1/file", "event_name": "event1", "mode": "read"}, value: 3, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "db1/file", "event_name": "event1", "mode": "write"}, value: 4, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "db1/file", "event_name": "event1", "mode": "read"}, value: 725, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "db1/file", "event_name": "event1", "mode": "write"}, value: 128, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "db2/file", "event_name": "event2", "mode": "read"}, value: 23, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "db2/file", "event_name": "event2", "mode": "write"}, value: 12, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "db2/file", "event_name": "event2", "mode": "read"}, value: 3123, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "db2/file", "event_name": "event2", "mode": "write"}, value: 967, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "db3/file", "event_name": "event3", "mode": "read"}, value: 45, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "db3/file", "event_name": "event3", "mode": "write"}, value: 32, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "db3/file", "event_name": "event3", "mode": "read"}, value: 1337, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"file_name": "db3/file", "event_name": "event3", "mode": "write"}, value: 326, metricType: dto.MetricType_COUNTER},
 	}
 	convey.Convey("Metrics comparison", t, func() {
 		for _, expect := range metricExpected {


### PR DESCRIPTION
Splitting on path is unsafe if two tables have the same name, but are in
different databases.  Use a single string prefix to remove the noisy
path data from the labels.

Closes: https://github.com/prometheus/mysqld_exporter/issues/256