### PR TITLE
Move session params to DSN

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Name                                       | Description
 config.my-cnf                              | Path to .my.cnf file to read MySQL credentials from. (default: `~/.my.cnf`)
 log.level                                  | Logging verbosity (default: info)
 exporter.lock_wait_timeout                 | Set a lock_wait_timeout on the connection to avoid long metadata locking. (default: 2 seconds)
-exporter.log_slow_filter                   | Add a log_slow_filter to avoid exessive MySQL slow logging.  NOTE: Not supported by Oracle MySQL.
+exporter.log_slow_filter                   | Add a log_slow_filter to avoid slow query logging of scrapes.  NOTE: Not supported by Oracle MySQL.
 web.listen-address                         | Address to listen on for web interface and telemetry.
 web.telemetry-path                         | Path under which to expose metrics.
 version                                    | Print the version information.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ Name                                       | Description
 -------------------------------------------|--------------------------------------------------------------------------------------------------
 config.my-cnf                              | Path to .my.cnf file to read MySQL credentials from. (default: `~/.my.cnf`)
 log.level                                  | Logging verbosity (default: info)
-log_slow_filter                            | Add a log_slow_filter to avoid exessive MySQL slow logging.  NOTE: Not supported by Oracle MySQL.
+exporter.lock_wait_timeout                 | Set a lock_wait_timeout on the connection to avoid long metadata locking. (default: 2 seconds)
+exporter.log_slow_filter                   | Add a log_slow_filter to avoid exessive MySQL slow logging.  NOTE: Not supported by Oracle MySQL.
 web.listen-address                         | Address to listen on for web interface and telemetry.
 web.telemetry-path                         | Path under which to expose metrics.
 version                                    | Print the version information.

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -29,10 +29,6 @@ var (
 		"config.my-cnf",
 		"Path to .my.cnf file to read MySQL credentials from.",
 	).Default(path.Join(os.Getenv("HOME"), ".my.cnf")).String()
-	slowLogFilter = kingpin.Flag(
-		"log_slow_filter",
-		"Add a log_slow_filter to avoid exessive MySQL slow logging.  NOTE: Not supported by Oracle MySQL.",
-	).Default("false").Bool()
 	collectProcesslist = kingpin.Flag(
 		"collect.info_schema.processlist",
 		"Collect current thread state counts from the information_schema.processlist",
@@ -194,7 +190,6 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	collect := collector.Collect{
-		SlowLogFilter:        *slowLogFilter,
 		Processlist:          filter(filters, "info_schema.processlist", *collectProcesslist),
 		TableSchema:          filter(filters, "info_schema.tables", *collectTableSchema),
 		InnodbTablespaces:    filter(filters, "info_schema.innodb_tablespaces", *collectInnodbTablespaces),


### PR DESCRIPTION
In order to avoid lost session params if the `db` object reconnects in
the background, move session params to the DSN string configuration.