### PR TITLE
Introduce Scraper interface

### DIFF
--- a/collector/binlog.go
+++ b/collector/binlog.go
@@ -38,7 +38,20 @@ var (
 )
 
 // ScrapeBinlogSize colects from `SHOW BINARY LOGS`.
-func ScrapeBinlogSize(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapeBinlogSize struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapeBinlogSize) Name() string {
+	return "binlog_size"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapeBinlogSize) Help() string {
+	return "Collect the current size of all registered binlog files"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapeBinlogSize) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	var logBin uint8
 	err := db.QueryRow(logbinQuery).Scan(&logBin)
 	if err != nil {

--- a/collector/binlog_test.go
+++ b/collector/binlog_test.go
@@ -27,7 +27,7 @@ func TestScrapeBinlogSize(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = ScrapeBinlogSize(db, ch); err != nil {
+		if err = (ScrapeBinlogSize{}).Scrape(db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/engine_innodb.go
+++ b/collector/engine_innodb.go
@@ -19,7 +19,20 @@ const (
 )
 
 // ScrapeEngineInnodbStatus scrapes from `SHOW ENGINE INNODB STATUS`.
-func ScrapeEngineInnodbStatus(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapeEngineInnodbStatus struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapeEngineInnodbStatus) Name() string {
+	return "engine_innodb_status"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapeEngineInnodbStatus) Help() string {
+	return "Collect from SHOW ENGINE INNODB STATUS"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapeEngineInnodbStatus) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	rows, err := db.Query(engineInnodbStatusQuery)
 	if err != nil {
 		return err

--- a/collector/engine_innodb_test.go
+++ b/collector/engine_innodb_test.go
@@ -140,7 +140,7 @@ END OF INNODB MONITOR OUTPUT
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = ScrapeEngineInnodbStatus(db, ch); err != nil {
+		if err = (ScrapeEngineInnodbStatus{}).Scrape(db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/engine_tokudb.go
+++ b/collector/engine_tokudb.go
@@ -16,26 +16,21 @@ const (
 	engineTokudbStatusQuery = `SHOW ENGINE TOKUDB STATUS`
 )
 
-func sanitizeTokudbMetric(metricName string) string {
-	replacements := map[string]string{
-		">": "",
-		",": "",
-		":": "",
-		"(": "",
-		")": "",
-		" ": "_",
-		"-": "_",
-		"+": "and",
-		"/": "and",
-	}
-	for r := range replacements {
-		metricName = strings.Replace(metricName, r, replacements[r], -1)
-	}
-	return metricName
+// ScrapeEngineTokudbStatus scrapes from `SHOW ENGINE TOKUDB STATUS`.
+type ScrapeEngineTokudbStatus struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapeEngineTokudbStatus) Name() string {
+	return "engine_tokudb_status"
 }
 
-// ScrapeEngineTokudbStatus scrapes from `SHOW ENGINE TOKUDB STATUS`.
-func ScrapeEngineTokudbStatus(db *sql.DB, ch chan<- prometheus.Metric) error {
+// Help describes the role of the Scraper.
+func (ScrapeEngineTokudbStatus) Help() string {
+	return "Collect from SHOW ENGINE TOKUDB STATUS"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapeEngineTokudbStatus) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	tokudbRows, err := db.Query(engineTokudbStatusQuery)
 	if err != nil {
 		return err
@@ -59,4 +54,22 @@ func ScrapeEngineTokudbStatus(db *sql.DB, ch chan<- prometheus.Metric) error {
 		}
 	}
 	return nil
+}
+
+func sanitizeTokudbMetric(metricName string) string {
+	replacements := map[string]string{
+		">": "",
+		",": "",
+		":": "",
+		"(": "",
+		")": "",
+		" ": "_",
+		"-": "_",
+		"+": "and",
+		"/": "and",
+	}
+	for r := range replacements {
+		metricName = strings.Replace(metricName, r, replacements[r], -1)
+	}
+	return metricName
 }

--- a/collector/engine_tokudb_test.go
+++ b/collector/engine_tokudb_test.go
@@ -44,7 +44,7 @@ func TestScrapeEngineTokudbStatus(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = ScrapeEngineTokudbStatus(db, ch); err != nil {
+		if err = (ScrapeEngineTokudbStatus{}).Scrape(db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/exporter_test.go
+++ b/collector/exporter_test.go
@@ -15,8 +15,8 @@ func TestExporter(t *testing.T) {
 		t.Skip("-short is passed, skipping test")
 	}
 
-	exporter := New(dsn, Collect{
-		GlobalStatus: true,
+	exporter := New(dsn, []Scraper{
+		ScrapeGlobalStatus{},
 	})
 
 	convey.Convey("Metrics describing", t, func() {

--- a/collector/global_status.go
+++ b/collector/global_status.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	// Scrape query
+	// Scrape query.
 	globalStatusQuery = `SHOW GLOBAL STATUS`
 	// Subsystem.
 	globalStatus = "global_status"
@@ -20,6 +20,7 @@ const (
 // Regexp to match various groups of status vars.
 var globalStatusRE = regexp.MustCompile(`^(com|handler|connection_errors|innodb_buffer_pool_pages|innodb_rows|performance_schema)_(.*)$`)
 
+// Metric descriptors.
 var (
 	globalCommandsDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, globalStatus, "commands_total"),
@@ -59,7 +60,20 @@ var (
 )
 
 // ScrapeGlobalStatus collects from `SHOW GLOBAL STATUS`.
-func ScrapeGlobalStatus(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapeGlobalStatus struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapeGlobalStatus) Name() string {
+	return globalStatus
+}
+
+// Help describes the role of the Scraper.
+func (ScrapeGlobalStatus) Help() string {
+	return "Collect from SHOW GLOBAL STATUS"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapeGlobalStatus) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	globalStatusRows, err := db.Query(globalStatusQuery)
 	if err != nil {
 		return err

--- a/collector/global_status_test.go
+++ b/collector/global_status_test.go
@@ -38,7 +38,7 @@ func TestScrapeGlobalStatus(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = ScrapeGlobalStatus(db, ch); err != nil {
+		if err = (ScrapeGlobalStatus{}).Scrape(db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/global_variables.go
+++ b/collector/global_variables.go
@@ -19,7 +19,20 @@ const (
 )
 
 // ScrapeGlobalVariables collects from `SHOW GLOBAL VARIABLES`.
-func ScrapeGlobalVariables(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapeGlobalVariables struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapeGlobalVariables) Name() string {
+	return globalVariables
+}
+
+// Help describes the role of the Scraper.
+func (ScrapeGlobalVariables) Help() string {
+	return "Collect from SHOW GLOBAL VARIABLES"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapeGlobalVariables) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	globalVariablesRows, err := db.Query(globalVariablesQuery)
 	if err != nil {
 		return err

--- a/collector/global_variables_test.go
+++ b/collector/global_variables_test.go
@@ -37,7 +37,7 @@ func TestScrapeGlobalVariables(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = ScrapeGlobalVariables(db, ch); err != nil {
+		if err = (ScrapeGlobalVariables{}).Scrape(db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/heartbeat_test.go
+++ b/collector/heartbeat_test.go
@@ -7,9 +7,18 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/smartystreets/goconvey/convey"
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 func TestScrapeHeartbeat(t *testing.T) {
+	_, err := kingpin.CommandLine.Parse([]string{
+		"--collect.heartbeat.database", "heartbeat-test",
+		"--collect.heartbeat.table", "heartbeat-test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("error opening a stub database connection: %s", err)
@@ -19,13 +28,11 @@ func TestScrapeHeartbeat(t *testing.T) {
 	columns := []string{"UNIX_TIMESTAMP(ts)", "UNIX_TIMESTAMP(NOW(6))", "server_id"}
 	rows := sqlmock.NewRows(columns).
 		AddRow("1487597613.001320", "1487598113.448042", 1)
-	mock.ExpectQuery(sanitizeQuery("SELECT UNIX_TIMESTAMP(ts), UNIX_TIMESTAMP(NOW(6)), server_id from `heartbeat`.`heartbeat`")).WillReturnRows(rows)
+	mock.ExpectQuery(sanitizeQuery("SELECT UNIX_TIMESTAMP(ts), UNIX_TIMESTAMP(NOW(6)), server_id from `heartbeat-test`.`heartbeat-test`")).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		database := "heartbeat"
-		table := "heartbeat"
-		if err = ScrapeHeartbeat(db, ch, database, table); err != nil {
+		if err = (ScrapeHeartbeat{}).Scrape(db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_auto_increment.go
+++ b/collector/info_schema_auto_increment.go
@@ -22,6 +22,7 @@ const infoSchemaAutoIncrementQuery = `
 		  WHERE c.extra = 'auto_increment' AND t.auto_increment IS NOT NULL
 		`
 
+// Metric descriptors.
 var (
 	globalInfoSchemaAutoIncrementDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, informationSchema, "auto_increment_column"),
@@ -36,7 +37,20 @@ var (
 )
 
 // ScrapeAutoIncrementColumns collects auto_increment column information.
-func ScrapeAutoIncrementColumns(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapeAutoIncrementColumns struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapeAutoIncrementColumns) Name() string {
+	return "auto_increment.columns"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapeAutoIncrementColumns) Help() string {
+	return "Collect auto_increment columns and max values from information_schema"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapeAutoIncrementColumns) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	autoIncrementRows, err := db.Query(infoSchemaAutoIncrementQuery)
 	if err != nil {
 		return err

--- a/collector/info_schema_clientstats.go
+++ b/collector/info_schema_clientstats.go
@@ -128,7 +128,20 @@ var (
 )
 
 // ScrapeClientStat collects from `information_schema.client_statistics`.
-func ScrapeClientStat(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapeClientStat struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapeClientStat) Name() string {
+	return "info_schema.clientstats"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapeClientStat) Help() string {
+	return "If running with userstat=1, set to true to collect client statistics"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapeClientStat) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	var varName, varVal string
 	err := db.QueryRow(userstatCheckQuery).Scan(&varName, &varVal)
 	if err != nil {

--- a/collector/info_schema_clientstats_test.go
+++ b/collector/info_schema_clientstats_test.go
@@ -26,7 +26,7 @@ func TestScrapeClientStat(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = ScrapeClientStat(db, ch); err != nil {
+		if err = (ScrapeClientStat{}).Scrape(db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_innodb_cmp.go
+++ b/collector/info_schema_innodb_cmp.go
@@ -14,6 +14,7 @@ const innodbCmpQuery = `
 		  FROM information_schema.innodb_cmp
 		`
 
+// Metric descriptors.
 var (
 	infoSchemaInnodbCmpCompressOps = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, informationSchema, "innodb_cmp_compress_ops_total"),
@@ -43,7 +44,20 @@ var (
 )
 
 // ScrapeInnodbCmp collects from `information_schema.innodb_cmp`.
-func ScrapeInnodbCmp(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapeInnodbCmp struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapeInnodbCmp) Name() string {
+	return informationSchema + ".innodb_cmp"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapeInnodbCmp) Help() string {
+	return "Collect metrics from information_schema.innodb_cmp"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapeInnodbCmp) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 
 	informationSchemaInnodbCmpRows, err := db.Query(innodbCmpQuery)
 	if err != nil {

--- a/collector/info_schema_innodb_cmp_test.go
+++ b/collector/info_schema_innodb_cmp_test.go
@@ -23,7 +23,7 @@ func TestScrapeInnodbCmp(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = ScrapeInnodbCmp(db, ch); err != nil {
+		if err = (ScrapeInnodbCmp{}).Scrape(db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_innodb_cmpmem.go
+++ b/collector/info_schema_innodb_cmpmem.go
@@ -14,6 +14,7 @@ const innodbCmpMemQuery = `
                   FROM information_schema.innodb_cmpmem
                 `
 
+// Metric descriptors.
 var (
 	infoSchemaInnodbCmpMemPagesRead = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, informationSchema, "innodb_cmpmem_pages_used_total"),
@@ -38,7 +39,20 @@ var (
 )
 
 // ScrapeInnodbCmp collects from `information_schema.innodb_cmp`.
-func ScrapeInnodbCmpMem(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapeInnodbCmpMem struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapeInnodbCmpMem) Name() string {
+	return informationSchema + ".innodb_cmpmem"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapeInnodbCmpMem) Help() string {
+	return "Collect metrics from information_schema.innodb_cmpmem"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapeInnodbCmpMem) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 
 	informationSchemaInnodbCmpMemRows, err := db.Query(innodbCmpMemQuery)
 	if err != nil {

--- a/collector/info_schema_innodb_cmpmem_test.go
+++ b/collector/info_schema_innodb_cmpmem_test.go
@@ -23,7 +23,7 @@ func TestScrapeInnodbCmpMem(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = ScrapeInnodbCmpMem(db, ch); err != nil {
+		if err = (ScrapeInnodbCmpMem{}).Scrape(db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_innodb_metrics.go
+++ b/collector/info_schema_innodb_metrics.go
@@ -49,7 +49,20 @@ var (
 )
 
 // ScrapeInnodbMetrics collects from `information_schema.innodb_metrics`.
-func ScrapeInnodbMetrics(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapeInnodbMetrics struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapeInnodbMetrics) Name() string {
+	return informationSchema + ".innodb_metrics"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapeInnodbMetrics) Help() string {
+	return "Collect metrics from information_schema.innodb_metrics"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapeInnodbMetrics) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	innodbMetricsRows, err := db.Query(infoSchemaInnodbMetricsQuery)
 	if err != nil {
 		return err

--- a/collector/info_schema_innodb_metrics_test.go
+++ b/collector/info_schema_innodb_metrics_test.go
@@ -40,7 +40,7 @@ func TestScrapeInnodbMetrics(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = ScrapeInnodbMetrics(db, ch); err != nil {
+		if err = (ScrapeInnodbMetrics{}).Scrape(db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_innodb_sys_tablespaces.go
+++ b/collector/info_schema_innodb_sys_tablespaces.go
@@ -20,6 +20,7 @@ const innodbTablespacesQuery = `
 	  FROM information_schema.innodb_sys_tablespaces
 	`
 
+// Metric descriptors.
 var (
 	infoSchemaInnodbTablesspaceInfoDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, informationSchema, "innodb_tablespace_space_info"),
@@ -39,7 +40,20 @@ var (
 )
 
 // ScrapeInfoSchemaInnodbTablespaces collects from `information_schema.innodb_sys_tablespaces`.
-func ScrapeInfoSchemaInnodbTablespaces(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapeInfoSchemaInnodbTablespaces struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapeInfoSchemaInnodbTablespaces) Name() string {
+	return informationSchema + ".innodb_tablespaces"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapeInfoSchemaInnodbTablespaces) Help() string {
+	return "Collect metrics from information_schema.innodb_sys_tablespaces"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapeInfoSchemaInnodbTablespaces) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	tablespacesRows, err := db.Query(innodbTablespacesQuery)
 	if err != nil {
 		return err

--- a/collector/info_schema_innodb_sys_tablespaces_test.go
+++ b/collector/info_schema_innodb_sys_tablespaces_test.go
@@ -24,7 +24,7 @@ func TestScrapeInfoSchemaInnodbTablespaces(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = ScrapeInfoSchemaInnodbTablespaces(db, ch); err != nil {
+		if err = (ScrapeInfoSchemaInnodbTablespaces{}).Scrape(db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_query_response_time.go
+++ b/collector/info_schema_query_response_time.go
@@ -86,7 +86,20 @@ func processQueryResponseTimeTable(db *sql.DB, ch chan<- prometheus.Metric, quer
 }
 
 // ScrapeQueryResponseTime collects from `information_schema.query_response_time`.
-func ScrapeQueryResponseTime(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapeQueryResponseTime struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapeQueryResponseTime) Name() string {
+	return "info_schema.query_response_time"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapeQueryResponseTime) Help() string {
+	return "Collect query response time distribution if query_response_time_stats is ON."
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapeQueryResponseTime) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	var queryStats uint8
 	err := db.QueryRow(queryResponseCheckQuery).Scan(&queryStats)
 	if err != nil {

--- a/collector/info_schema_query_response_time_test.go
+++ b/collector/info_schema_query_response_time_test.go
@@ -37,7 +37,7 @@ func TestScrapeQueryResponseTime(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = ScrapeQueryResponseTime(db, ch); err != nil {
+		if err = (ScrapeQueryResponseTime{}).Scrape(db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_tables.go
+++ b/collector/info_schema_tables.go
@@ -36,11 +36,16 @@ const (
 		`
 )
 
+// Tunable flags.
 var (
 	tableSchemaDatabases = kingpin.Flag(
 		"collect.info_schema.tables.databases",
 		"The list of databases to collect table stats for, or '*' for all",
 	).Default("*").String()
+)
+
+// Metric descriptors.
+var (
 	infoSchemaTablesVersionDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, informationSchema, "table_version"),
 		"The version number of the table's .frm file",
@@ -59,7 +64,20 @@ var (
 )
 
 // ScrapeTableSchema collects from `information_schema.tables`.
-func ScrapeTableSchema(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapeTableSchema struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapeTableSchema) Name() string {
+	return informationSchema + ".tables"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapeTableSchema) Help() string {
+	return "Collect metrics from information_schema.tables"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapeTableSchema) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	var dbList []string
 	if *tableSchemaDatabases == "*" {
 		dbListRows, err := db.Query(dbListQuery)

--- a/collector/info_schema_tablestats.go
+++ b/collector/info_schema_tablestats.go
@@ -19,6 +19,7 @@ const tableStatQuery = `
 		  FROM information_schema.table_statistics
 		`
 
+// Metric descriptors.
 var (
 	infoSchemaTableStatsRowsReadDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, informationSchema, "table_statistics_rows_read_total"),
@@ -38,7 +39,20 @@ var (
 )
 
 // ScrapeTableStat collects from `information_schema.table_statistics`.
-func ScrapeTableStat(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapeTableStat struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapeTableStat) Name() string {
+	return "info_schema.tablestats"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapeTableStat) Help() string {
+	return "If running with userstat=1, set to true to collect table statistics"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapeTableStat) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	var varName, varVal string
 	err := db.QueryRow(userstatCheckQuery).Scan(&varName, &varVal)
 	if err != nil {

--- a/collector/info_schema_tablestats_test.go
+++ b/collector/info_schema_tablestats_test.go
@@ -27,7 +27,7 @@ func TestScrapeTableStat(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = ScrapeTableStat(db, ch); err != nil {
+		if err = (ScrapeTableStat{}).Scrape(db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_userstats.go
+++ b/collector/info_schema_userstats.go
@@ -124,7 +124,20 @@ var (
 )
 
 // ScrapeUserStat collects from `information_schema.user_statistics`.
-func ScrapeUserStat(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapeUserStat struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapeUserStat) Name() string {
+	return "info_schema.userstats"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapeUserStat) Help() string {
+	return "If running with userstat=1, set to true to collect user statistics"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapeUserStat) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	var varName, varVal string
 	err := db.QueryRow(userstatCheckQuery).Scan(&varName, &varVal)
 	if err != nil {

--- a/collector/info_schema_userstats_test.go
+++ b/collector/info_schema_userstats_test.go
@@ -26,7 +26,7 @@ func TestScrapeUserStat(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = ScrapeUserStat(db, ch); err != nil {
+		if err = (ScrapeUserStat{}).Scrape(db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/perf_schema_events_statements.go
+++ b/collector/perf_schema_events_statements.go
@@ -54,7 +54,7 @@ const perfEventsStatementsQuery = `
 	  LIMIT %d
 	`
 
-// Tuning flags.
+// Tunable flags.
 var (
 	perfEventsStatementsLimit = kingpin.Flag(
 		"collect.perf_schema.eventsstatements.limit",
@@ -135,7 +135,20 @@ var (
 )
 
 // ScrapePerfEventsStatements collects from `performance_schema.events_statements_summary_by_digest`.
-func ScrapePerfEventsStatements(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapePerfEventsStatements struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapePerfEventsStatements) Name() string {
+	return "perf_schema.eventsstatements"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapePerfEventsStatements) Help() string {
+	return "Collect metrics from performance_schema.events_statements_summary_by_digest"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapePerfEventsStatements) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	perfQuery := fmt.Sprintf(
 		perfEventsStatementsQuery,
 		*perfEventsStatementsDigestTextLimit,

--- a/collector/perf_schema_events_waits.go
+++ b/collector/perf_schema_events_waits.go
@@ -28,7 +28,20 @@ var (
 )
 
 // ScrapePerfEventsWaits collects from `performance_schema.events_waits_summary_global_by_event_name`.
-func ScrapePerfEventsWaits(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapePerfEventsWaits struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapePerfEventsWaits) Name() string {
+	return "perf_schema.eventswaits"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapePerfEventsWaits) Help() string {
+	return "Collect metrics from performance_schema.events_waits_summary_global_by_event_name"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapePerfEventsWaits) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	// Timers here are returned in picoseconds.
 	perfSchemaEventsWaitsRows, err := db.Query(perfEventsWaitsQuery)
 	if err != nil {

--- a/collector/perf_schema_file_events.go
+++ b/collector/perf_schema_file_events.go
@@ -37,7 +37,20 @@ var (
 )
 
 // ScrapePerfFileEvents collects from `performance_schema.file_summary_by_event_name`.
-func ScrapePerfFileEvents(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapePerfFileEvents struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapePerfFileEvents) Name() string {
+	return "perf_schema.file_events"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapePerfFileEvents) Help() string {
+	return "Collect metrics from performance_schema.file_summary_by_event_name"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapePerfFileEvents) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	// Timers here are returned in picoseconds.
 	perfSchemaFileEventsRows, err := db.Query(perfFileEventsQuery)
 	if err != nil {

--- a/collector/perf_schema_file_instances.go
+++ b/collector/perf_schema_file_instances.go
@@ -19,13 +19,16 @@ const perfFileInstancesQuery = `
 	     where FILE_NAME REGEXP ?
 	`
 
-// Metric descriptors.
+// Tunable flags.
 var (
 	performanceSchemaFileInstancesFilter = kingpin.Flag(
 		"collect.perf_schema.file_instances.filter",
 		"RegEx file_name filter for performance_schema.file_summary_by_instance",
 	).Default(".*").String()
+)
 
+// Metric descriptors.
+var (
 	performanceSchemaFileInstancesRemovePrefix = kingpin.Flag(
 		"collect.perf_schema.file_instances.remove_prefix",
 		"Remove path prefix in performance_schema.file_summary_by_instance",
@@ -43,8 +46,21 @@ var (
 	)
 )
 
-// ScrapePerfFileEvents collects from `performance_schema.file_summary_by_event_name`.
-func ScrapePerfFileInstances(db *sql.DB, ch chan<- prometheus.Metric) error {
+// ScrapePerfFileInstances collects from `performance_schema.file_summary_by_instance`.
+type ScrapePerfFileInstances struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapePerfFileInstances) Name() string {
+	return "perf_schema.file_instances"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapePerfFileInstances) Help() string {
+	return "Collect metrics from performance_schema.file_summary_by_instance"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapePerfFileInstances) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	// Timers here are returned in picoseconds.
 	perfSchemaFileInstancesRows, err := db.Query(perfFileInstancesQuery, *performanceSchemaFileInstancesFilter)
 	if err != nil {

--- a/collector/perf_schema_file_instances_test.go
+++ b/collector/perf_schema_file_instances_test.go
@@ -33,7 +33,7 @@ func TestScrapePerfFileInstances(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = ScrapePerfFileInstances(db, ch); err != nil {
+		if err = (ScrapePerfFileInstances{}).Scrape(db, ch); err != nil {
 			panic(fmt.Sprintf("error calling function on test: %s", err))
 		}
 		close(ch)

--- a/collector/perf_schema_index_io_waits.go
+++ b/collector/perf_schema_index_io_waits.go
@@ -31,7 +31,20 @@ var (
 )
 
 // ScrapePerfIndexIOWaits collects for `performance_schema.table_io_waits_summary_by_index_usage`.
-func ScrapePerfIndexIOWaits(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapePerfIndexIOWaits struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapePerfIndexIOWaits) Name() string {
+	return "perf_schema.indexiowaits"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapePerfIndexIOWaits) Help() string {
+	return "Collect metrics from performance_schema.table_io_waits_summary_by_index_usage"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapePerfIndexIOWaits) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	perfSchemaIndexWaitsRows, err := db.Query(perfIndexIOWaitsQuery)
 	if err != nil {
 		return err

--- a/collector/perf_schema_index_io_waits_test.go
+++ b/collector/perf_schema_index_io_waits_test.go
@@ -25,7 +25,7 @@ func TestScrapePerfIndexIOWaits(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = ScrapePerfIndexIOWaits(db, ch); err != nil {
+		if err = (ScrapePerfIndexIOWaits{}).Scrape(db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/perf_schema_replication_group_member_stats.go
+++ b/collector/perf_schema_replication_group_member_stats.go
@@ -37,7 +37,20 @@ var (
 )
 
 // ScrapeReplicationGroupMemberStats collects from `performance_schema.replication_group_member_stats`.
-func ScrapeReplicationGroupMemberStats(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapePerfReplicationGroupMemberStats struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapePerfReplicationGroupMemberStats) Name() string {
+	return performanceSchema + ".replication_group_member_stats"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapePerfReplicationGroupMemberStats) Help() string {
+	return "Collect metrics from performance_schema.replication_group_member_stats"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapePerfReplicationGroupMemberStats) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	perfReplicationGroupMemeberStatsRows, err := db.Query(perfReplicationGroupMemeberStatsQuery)
 	if err != nil {
 		return err
@@ -58,19 +71,19 @@ func ScrapeReplicationGroupMemberStats(db *sql.DB, ch chan<- prometheus.Metric) 
 			return err
 		}
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaTableWaitsDesc, prometheus.CounterValue, float64(countTransactionsInQueue),
+			performanceSchemaReplicationGroupMemberStatsTransInQueueDesc, prometheus.CounterValue, float64(countTransactionsInQueue),
 			memberId,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaTableWaitsDesc, prometheus.CounterValue, float64(countTransactionsChecked),
+			performanceSchemaReplicationGroupMemberStatsTransCheckedDesc, prometheus.CounterValue, float64(countTransactionsChecked),
 			memberId,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaTableWaitsDesc, prometheus.CounterValue, float64(countConflictsDetected),
+			performanceSchemaReplicationGroupMemberStatsConflictsDetectedDesc, prometheus.CounterValue, float64(countConflictsDetected),
 			memberId,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaTableWaitsDesc, prometheus.CounterValue, float64(countTransactionsRowsValidating),
+			performanceSchemaReplicationGroupMemberStatsTransRowValidatingDesc, prometheus.CounterValue, float64(countTransactionsRowsValidating),
 			memberId,
 		)
 	}

--- a/collector/perf_schema_table_io_waits.go
+++ b/collector/perf_schema_table_io_waits.go
@@ -32,7 +32,20 @@ var (
 )
 
 // ScrapePerfTableIOWaits collects from `performance_schema.table_io_waits_summary_by_table`.
-func ScrapePerfTableIOWaits(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapePerfTableIOWaits struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapePerfTableIOWaits) Name() string {
+	return "perf_schema.tableiowaits"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapePerfTableIOWaits) Help() string {
+	return "Collect metrics from performance_schema.table_io_waits_summary_by_table"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapePerfTableIOWaits) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	perfSchemaTableWaitsRows, err := db.Query(perfTableIOWaitsQuery)
 	if err != nil {
 		return err

--- a/collector/perf_schema_table_lock_waits.go
+++ b/collector/perf_schema_table_lock_waits.go
@@ -61,7 +61,20 @@ var (
 )
 
 // ScrapePerfTableLockWaits collects from `performance_schema.table_lock_waits_summary_by_table`.
-func ScrapePerfTableLockWaits(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapePerfTableLockWaits struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapePerfTableLockWaits) Name() string {
+	return "perf_schema.tablelocks"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapePerfTableLockWaits) Help() string {
+	return "Collect metrics from performance_schema.table_lock_waits_summary_by_table"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapePerfTableLockWaits) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	perfSchemaTableLockWaitsRows, err := db.Query(perfTableLockWaitsQuery)
 	if err != nil {
 		return err

--- a/collector/scraper.go
+++ b/collector/scraper.go
@@ -1,0 +1,19 @@
+package collector
+
+import (
+	"database/sql"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Scraper is minimal interface that let's you add new prometheus metrics to mysqld_exporter.
+type Scraper interface {
+	// Name of the Scraper. Should be unique.
+	Name() string
+	// Help describes the role of the Scraper.
+	// Example: "Collect from SHOW ENGINE INNODB STATUS"
+	Help() string
+	// Scrape collects data from database connection and sends it over channel as prometheus metric.
+	Scrape(db *sql.DB, ch chan<- prometheus.Metric) error
+}

--- a/collector/slave_status.go
+++ b/collector/slave_status.go
@@ -36,7 +36,20 @@ func columnValue(scanArgs []interface{}, slaveCols []string, colName string) str
 }
 
 // ScrapeSlaveStatus collects from `SHOW SLAVE STATUS`.
-func ScrapeSlaveStatus(db *sql.DB, ch chan<- prometheus.Metric) error {
+type ScrapeSlaveStatus struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapeSlaveStatus) Name() string {
+	return slaveStatus
+}
+
+// Help describes the role of the Scraper.
+func (ScrapeSlaveStatus) Help() string {
+	return "Collect from SHOW SLAVE STATUS"
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapeSlaveStatus) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	var (
 		slaveStatusRows *sql.Rows
 		err             error

--- a/collector/slave_status_test.go
+++ b/collector/slave_status_test.go
@@ -23,7 +23,7 @@ func TestScrapeSlaveStatus(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = ScrapeSlaveStatus(db, ch); err != nil {
+		if err = (ScrapeSlaveStatus{}).Scrape(db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)


### PR DESCRIPTION
# Introduces Scraper interface:
```go
type Scraper interface {
	Scrape(db *sql.DB, ch chan<- prometheus.Metric) error
	Name() string
	Help() string
}
```

# Changes:
- Decouple exporter from scrapes. Pass scrapes instead of configuration to exporter. This should also allow easier extending in forks with new scrapes.
  ```patch
  -func New(dsn string, collect Collect) *Exporter {
  +func New(dsn string, scrapers []Scraper) *Exporter {
  ```
- Run in parallel all scrapes (still using single db connection).
  ```go
  wg := &sync.WaitGroup{}
  defer wg.Wait()
  for _, scraper := range e.scrapers {
  	wg.Add(1)
  	go func(scraper Scraper) {
  		defer wg.Done()
  		label := "collect." + scraper.Name()
  		scrapeTime := time.Now()
  		if err := scraper.Scrape(db, ch); err != nil {
  			log.Errorln("Error scraping for "+label+":", err)
  			e.scrapeErrors.WithLabelValues(label).Inc()
  			e.error.Set(1)
  		}
  		ch <- prometheus.MustNewConstMetric(scrapeDurationDesc, prometheus.GaugeValue, time.Since(scrapeTime).Seconds(), label)
  	}(scraper)
   }
  ```
- Writing new scrape means just implementing `collector.Scraper` interface e.g. like this:
  ```go
  // ScrapeEngineTokudbStatus scrapes from `SHOW ENGINE TOKUDB STATUS`.
  type ScrapeEngineTokudbStatus struct{}
  
  // Name of the Scraper.
  func (ScrapeEngineTokudbStatus) Name() string {
  	return "engine_tokudb_status"
  }
  
  // Help returns additional information about Scraper.
  func (ScrapeEngineTokudbStatus) Help() string {
  	return "Collect from SHOW ENGINE TOKUDB STATUS"
  }
  
  // Scrape collects data.
  func (ScrapeEngineTokudbStatus) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
  	...
  	return nil
  }
  ```
  and adding it in `main.go` to the list of available `scrapers` with information if it should be enabled by default:
  ```go
  // scrapers lists all possible collection methods and if they should be enabled by default.
  var scrapers = map[collector.Scraper]bool{
  	collector.ScrapeGlobalStatus{}:                true,
  	collector.ScrapeGlobalVariables{}:             true,
  	collector.ScrapeSlaveStatus{}:                 true,
  	collector.ScrapeProcesslist{}:                 false,
  	collector.ScrapeTableSchema{}:                 true,
  	collector.ScrapeInfoSchemaInnodbTablespaces{}: false,
  	collector.ScrapeInnodbMetrics{}:               false,
  	collector.ScrapeAutoIncrementColumns{}:        false,
  	collector.ScrapeBinlogSize{}:                  false,
  	collector.ScrapePerfTableIOWaits{}:            false,
  	collector.ScrapePerfIndexIOWaits{}:            false,
  	collector.ScrapePerfTableLockWaits{}:          false,
  	collector.ScrapePerfEventsStatements{}:        false,
  	collector.ScrapePerfEventsWaits{}:             false,
  	collector.ScrapePerfFileEvents{}:              false,
  	collector.ScrapePerfFileInstances{}:           false,
  	collector.ScrapeUserStat{}:                    false,
  	collector.ScrapeClientStat{}:                  false,
  	collector.ScrapeTableStat{}:                   false,
  	collector.ScrapeQueryResponseTime{}:           false,
  	collector.ScrapeEngineTokudbStatus{}:          false,
  	collector.ScrapeEngineInnodbStatus{}:          false,
  	collector.ScrapeHeartbeat{}:                   false,
  }
  ```
- Flags to enable/disable scrapes are generated from info provided by scraper.
- Alternative approach to #254 (https://github.com/prometheus/mysqld_exporter/pull/254#issuecomment-356876468).
- Covers partially #253 (without one db pool, db pool can be introduced in another PR).
- Covers partially #236, there is few things we can still merge from there.
- `scrapeTime` was not reset for `e.collect.InnodbMetrics`
- Fixed metric descriptors in new collector/perf_schema_replication_group_member_stats.go https://github.com/prometheus/mysqld_exporter/pull/265/files#diff-85361993ed6875151aa631eae17ceaa6L61