### PR TITLE
Allow to keep connections between scrapes plus various config options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Example format for flags for version <= 0.10.0:
 Name                                                   | MySQL Version | Description
 -------------------------------------------------------|---------------|------------------------------------------------------------------------------------
 collect.auto_increment.columns                         | 5.1           | Collect auto_increment columns and max values from information_schema.
-collect.binlog_size                                    | 5.1           | Collect the current size of all registered binlog files
+collect.binlog_size                                    | 5.1           | Collect the current size of all registered binlog files.
 collect.engine_innodb_status                           | 5.1           | Collect from SHOW ENGINE INNODB STATUS.
 collect.engine_tokudb_status                           | 5.6           | Collect from SHOW ENGINE TOKUDB STATUS.
 collect.global_status                                  | 5.1           | Collect from SHOW GLOBAL STATUS (Enabled by default)
@@ -82,7 +82,7 @@ collect.slave_status                                   | 5.1           | Collect
 collect.heartbeat                                      | 5.1           | Collect from [heartbeat](#heartbeat).
 collect.heartbeat.database                             | 5.1           | Database from where to collect heartbeat data. (default: heartbeat)
 collect.heartbeat.table                                | 5.1           | Table from where to collect heartbeat data. (default: heartbeat)
-
+collect.all                                            | -             | Collect all metrics.
 
 ### General Flags
 Name                                       | Description
@@ -91,6 +91,10 @@ config.my-cnf                              | Path to .my.cnf file to read MySQL 
 log.level                                  | Logging verbosity (default: info)
 exporter.lock_wait_timeout                 | Set a lock_wait_timeout on the connection to avoid long metadata locking. (default: 2 seconds)
 exporter.log_slow_filter                   | Add a log_slow_filter to avoid slow query logging of scrapes.  NOTE: Not supported by Oracle MySQL.
+exporter.global-conn-pool                  | Use global connection pool instead of creating new pool for each http request.
+exporter.max-open-conns                    | Maximum number of open connections to the database. https://golang.org/pkg/database/sql/#DB.SetMaxOpenConns
+exporter.max-idle-conns                    | Maximum number of connections in the idle connection pool. https://golang.org/pkg/database/sql/#DB.SetMaxIdleConns
+exporter.conn-max-lifetime                 | Maximum amount of time a connection may be reused. https://golang.org/pkg/database/sql/#DB.SetConnMaxLifetime
 web.listen-address                         | Address to listen on for web interface and telemetry.
 web.telemetry-path                         | Path under which to expose metrics.
 version                                    | Print the version information.

--- a/collector/exporter_test.go
+++ b/collector/exporter_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"database/sql"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -15,7 +16,13 @@ func TestExporter(t *testing.T) {
 		t.Skip("-short is passed, skipping test")
 	}
 
-	exporter := New(dsn, []Scraper{
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	exporter := New(db, []Scraper{
 		ScrapeGlobalStatus{},
 	})
 


### PR DESCRIPTION
New options:
* `exporter.global-conn-pool`: Use global connection pool instead of creating new pool for each http request. Disabled by default - keeps original behavior.
* `exporter.max-open-conns`: Maximum number of open connections to the database (https://golang.org/pkg/database/sql/#DB.SetMaxOpenConns). By default `1` - keeps original behavior.
* `exporter.max-idle-conns`: Maximum number of connections in the idle connection pool (https://golang.org/pkg/database/sql/#DB.SetMaxIdleConns). By default `1` - keeps original behavior.
* `exporter.conn-max-lifetime`: Maximum amount of time a connection may be reused (https://golang.org/pkg/database/sql/#DB.SetConnMaxLifetime). By default `60s` - keeps original behavior.
* `collect.all`: Collect all metrics. Unrelated change but really handy especially for debug purposes.
* This covers https://github.com/prometheus/mysqld_exporter/pull/253 except parallel processing of userstats.

I think this could settle the issue with global connection pool vs connection pool per scrape. Also it gives full control over the number of connections and with https://github.com/prometheus/mysqld_exporter/pull/265 it improves parallel processing of scrapers. We also had some requests for that so it's already in https://github.com/percona/mysqld_exporter