### PR TITLE
Ignore boolean keys in my.cnf.

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -64,7 +64,11 @@ var scrapers = map[collector.Scraper]bool{
 
 func parseMycnf(config interface{}) (string, error) {
 	var dsn string
-	cfg, err := ini.Load(config)
+	opts := ini.LoadOptions{
+		// MySQL ini file can have boolean keys.
+		AllowBooleanKeys: true,
+	}
+	cfg, err := ini.LoadSources(opts, config)
 	if err != nil {
 		return dsn, fmt.Errorf("failed reading ini file: %s", err)
 	}


### PR DESCRIPTION
Below is valid MySQL config however mysqld_exporter fails to read it,
because of the boolean keys.
Config:
```
[client]
user = root
password = abc123

[mysql]
skip-auto-rehash
```

For reference: https://jira.percona.com/browse/PMM-2469