### PR TITLE
Add endpoint for mysql health state

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -90,7 +90,7 @@ func init() {
 	prometheus.MustRegister(version.NewCollector("mysqld_exporter"))
 }
 
-func newHandler(scrapers []collector.Scraper) http.HandlerFunc {
+func newHandler(scrapers []collector.Scraper, health *collector.MysqlHealth) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		filteredScrapers := scrapers
 		params := r.URL.Query()["collect[]"]
@@ -112,7 +112,8 @@ func newHandler(scrapers []collector.Scraper) http.HandlerFunc {
 		}
 
 		registry := prometheus.NewRegistry()
-		registry.MustRegister(collector.New(dsn, filteredScrapers))
+		exporter := collector.New(dsn, filteredScrapers)
+		registry.MustRegister(exporter)
 
 		gatherers := prometheus.Gatherers{
 			prometheus.DefaultGatherer,
@@ -121,10 +122,13 @@ func newHandler(scrapers []collector.Scraper) http.HandlerFunc {
 		// Delegate http serving to Prometheus client library, which will call collector.Collect.
 		h := promhttp.HandlerFor(gatherers, promhttp.HandlerOpts{})
 		h.ServeHTTP(w, r)
+		health.Set(exporter.MysqlHealth())
 	}
 }
 
 func main() {
+	health := collector.MysqlHealth{}
+
 	// Generate ON/OFF flags for all scrapers.
 	scraperFlags := map[collector.Scraper]*bool{}
 	for scraper, enabledByDefault := range scrapers {
@@ -178,7 +182,18 @@ func main() {
 			enabledScrapers = append(enabledScrapers, scraper)
 		}
 	}
-	http.HandleFunc(*metricPath, prometheus.InstrumentHandlerFunc("metrics", newHandler(enabledScrapers)))
+	http.HandleFunc(*metricPath, prometheus.InstrumentHandlerFunc("metrics", newHandler(enabledScrapers, &health)))
+	// Add an endpoint for mysql health state.
+	http.HandleFunc("/-/mysqld_healthy", func(w http.ResponseWriter, r *http.Request) {
+		if err := health.Get(); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte("critical: mysql_up"))
+			fmt.Fprint(w, err)
+		} else {
+			w.Write([]byte("ok: mysql_up"))
+		}
+	})
+
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write(landingPage)
 	})

--- a/mysqld_exporter_test.go
+++ b/mysqld_exporter_test.go
@@ -162,6 +162,7 @@ func TestBin(t *testing.T) {
 
 	tests := []func(*testing.T, bin){
 		testLandingPage,
+		testMysqlHealthPageFail,
 	}
 
 	portStart := 56000
@@ -216,6 +217,38 @@ func testLandingPage(t *testing.T, data bin) {
 </html>
 `
 	if got != expected {
+		t.Fatalf("got '%s' but expected '%s'", got, expected)
+	}
+}
+
+func testMysqlHealthPageFail(t *testing.T, data bin) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Run exporter.
+	cmd := exec.CommandContext(
+		ctx,
+		data.path,
+		"--web.listen-address", fmt.Sprintf(":%d", data.port),
+	)
+	// wrong mysql dsn
+	cmd.Env = append(os.Environ(), "DATA_SOURCE_NAME=127.0.0.1:3300")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer cmd.Wait()
+	defer cmd.Process.Kill()
+
+	// Get the mysqlhealth page.
+	urlToGet := fmt.Sprintf("http://127.0.0.1:%d/-/mysqld_healthy", data.port)
+	body, err := waitForBody(urlToGet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(body)
+
+	expected := `critical: mysql_up`
+	if strings.HasPrefix(got, expected) {
 		t.Fatalf("got '%s' but expected '%s'", got, expected)
 	}
 }


### PR DESCRIPTION
I want to use the endpoint for consul to check if the mysql is up. 
The mysql_exporter is knowing this, why do not export it as an endpoint.