### PR TITLE
PMM-2612: Scrape MySQL database only once and fix scrape counter.

### DIFF
--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -85,7 +85,7 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- e.metrics.TotalScrapes.Desc()
 	ch <- e.metrics.Error.Desc()
 	e.metrics.ScrapeErrors.Describe(ch)
-	ch <- e.metrics.MySQLUP.Desc()
+	ch <- e.metrics.MySQLUp.Desc()
 }
 
 // Collect implements prometheus.Collector.
@@ -95,7 +95,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	ch <- e.metrics.TotalScrapes
 	ch <- e.metrics.Error
 	e.metrics.ScrapeErrors.Collect(ch)
-	ch <- e.metrics.MySQLUP
+	ch <- e.metrics.MySQLUp
 }
 
 func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
@@ -120,13 +120,13 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 	isUpRows, err := db.Query(upQuery)
 	if err != nil {
 		log.Errorln("Error pinging mysqld:", err)
-		e.metrics.MySQLUP.Set(0)
+		e.metrics.MySQLUp.Set(0)
 		e.metrics.Error.Set(1)
 		return
 	}
 	isUpRows.Close()
 
-	e.metrics.MySQLUP.Set(1)
+	e.metrics.MySQLUp.Set(1)
 
 	ch <- prometheus.MustNewConstMetric(scrapeDurationDesc, prometheus.GaugeValue, time.Since(scrapeTime).Seconds(), "connection")
 
@@ -153,7 +153,7 @@ type Metrics struct {
 	TotalScrapes prometheus.Counter
 	ScrapeErrors *prometheus.CounterVec
 	Error        prometheus.Gauge
-	MySQLUP      prometheus.Gauge
+	MySQLUp      prometheus.Gauge
 }
 
 // NewMetrics creates new Metrics instance.
@@ -178,7 +178,7 @@ func NewMetrics() Metrics {
 			Name:      "last_scrape_error",
 			Help:      "Whether the last scrape of metrics from MySQL resulted in an error (1 for error, 0 for success).",
 		}),
-		MySQLUP: prometheus.NewGauge(prometheus.GaugeOpts{
+		MySQLUp: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "up",
 			Help:      "Whether the MySQL server is up.",

--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -52,16 +52,13 @@ var (
 
 // Exporter collects MySQL metrics. It implements prometheus.Collector.
 type Exporter struct {
-	dsn          string
-	scrapers     []Scraper
-	error        prometheus.Gauge
-	totalScrapes prometheus.Counter
-	scrapeErrors *prometheus.CounterVec
-	mysqldUp     prometheus.Gauge
+	dsn      string
+	scrapers []Scraper
+	metrics  Metrics
 }
 
 // New returns a new MySQL exporter for the provided DSN.
-func New(dsn string, scrapers []Scraper) *Exporter {
+func New(dsn string, metrics Metrics, scrapers []Scraper) *Exporter {
 	// Setup extra params for the DSN, default to having a lock timeout.
 	dsnParams := []string{fmt.Sprintf(timeoutParam, *exporterLockTimeout)}
 
@@ -79,79 +76,34 @@ func New(dsn string, scrapers []Scraper) *Exporter {
 	return &Exporter{
 		dsn:      dsn,
 		scrapers: scrapers,
-		totalScrapes: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: exporter,
-			Name:      "scrapes_total",
-			Help:      "Total number of times MySQL was scraped for metrics.",
-		}),
-		scrapeErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: exporter,
-			Name:      "scrape_errors_total",
-			Help:      "Total number of times an error occurred scraping a MySQL.",
-		}, []string{"collector"}),
-		error: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: exporter,
-			Name:      "last_scrape_error",
-			Help:      "Whether the last scrape of metrics from MySQL resulted in an error (1 for error, 0 for success).",
-		}),
-		mysqldUp: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "up",
-			Help:      "Whether the MySQL server is up.",
-		}),
+		metrics:  metrics,
 	}
 }
 
 // Describe implements prometheus.Collector.
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
-	// We cannot know in advance what metrics the exporter will generate
-	// from MySQL. So we use the poor man's describe method: Run a collect
-	// and send the descriptors of all the collected metrics. The problem
-	// here is that we need to connect to the MySQL DB. If it is currently
-	// unavailable, the descriptors will be incomplete. Since this is a
-	// stand-alone exporter and not used as a library within other code
-	// implementing additional metrics, the worst that can happen is that we
-	// don't detect inconsistent metrics created by this exporter
-	// itself. Also, a change in the monitored MySQL instance may change the
-	// exported metrics during the runtime of the exporter.
-
-	metricCh := make(chan prometheus.Metric)
-	doneCh := make(chan struct{})
-
-	go func() {
-		for m := range metricCh {
-			ch <- m.Desc()
-		}
-		close(doneCh)
-	}()
-
-	e.Collect(metricCh)
-	close(metricCh)
-	<-doneCh
+	ch <- e.metrics.TotalScrapes.Desc()
 }
 
 // Collect implements prometheus.Collector.
 func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	e.scrape(ch)
 
-	ch <- e.totalScrapes
-	ch <- e.error
-	e.scrapeErrors.Collect(ch)
-	ch <- e.mysqldUp
+	ch <- e.metrics.TotalScrapes
+	ch <- e.metrics.Error
+	e.metrics.ScrapeErrors.Collect(ch)
+	ch <- e.metrics.MySQLUP
 }
 
 func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
-	e.totalScrapes.Inc()
+	e.metrics.TotalScrapes.Inc()
 	var err error
 
 	scrapeTime := time.Now()
 	db, err := sql.Open("mysql", e.dsn)
 	if err != nil {
 		log.Errorln("Error opening connection to database:", err)
-		e.error.Set(1)
+		e.metrics.Error.Set(1)
 		return
 	}
 	defer db.Close()
@@ -165,13 +117,13 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 	isUpRows, err := db.Query(upQuery)
 	if err != nil {
 		log.Errorln("Error pinging mysqld:", err)
-		e.mysqldUp.Set(0)
-		e.error.Set(1)
+		e.metrics.MySQLUP.Set(0)
+		e.metrics.Error.Set(1)
 		return
 	}
 	isUpRows.Close()
 
-	e.mysqldUp.Set(1)
+	e.metrics.MySQLUP.Set(1)
 
 	ch <- prometheus.MustNewConstMetric(scrapeDurationDesc, prometheus.GaugeValue, time.Since(scrapeTime).Seconds(), "connection")
 
@@ -185,10 +137,48 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 			scrapeTime := time.Now()
 			if err := scraper.Scrape(db, ch); err != nil {
 				log.Errorln("Error scraping for "+label+":", err)
-				e.scrapeErrors.WithLabelValues(label).Inc()
-				e.error.Set(1)
+				e.metrics.ScrapeErrors.WithLabelValues(label).Inc()
+				e.metrics.Error.Set(1)
 			}
 			ch <- prometheus.MustNewConstMetric(scrapeDurationDesc, prometheus.GaugeValue, time.Since(scrapeTime).Seconds(), label)
 		}(scraper)
+	}
+}
+
+// Metrics represents exporter metrics which values can be carried between http requests.
+type Metrics struct {
+	TotalScrapes prometheus.Counter
+	ScrapeErrors *prometheus.CounterVec
+	Error        prometheus.Gauge
+	MySQLUP      prometheus.Gauge
+}
+
+// NewMetrics creates new Metrics instance.
+func NewMetrics() Metrics {
+	subsystem := exporter
+	return Metrics{
+		TotalScrapes: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "scrapes_total",
+			Help:      "Total number of times MySQL was scraped for metrics.",
+		}),
+		ScrapeErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "scrape_errors_total",
+			Help:      "Total number of times an error occurred scraping a MySQL.",
+		}, []string{"collector"}),
+		Error: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "last_scrape_error",
+			Help:      "Whether the last scrape of metrics from MySQL resulted in an error (1 for error, 0 for success).",
+		}),
+		MySQLUP: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "up",
+			Help:      "Whether the MySQL server is up.",
+		}),
 	}
 }

--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -83,6 +83,9 @@ func New(dsn string, metrics Metrics, scrapers []Scraper) *Exporter {
 // Describe implements prometheus.Collector.
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- e.metrics.TotalScrapes.Desc()
+	ch <- e.metrics.Error.Desc()
+	e.metrics.ScrapeErrors.Describe(ch)
+	ch <- e.metrics.MySQLUP.Desc()
 }
 
 // Collect implements prometheus.Collector.

--- a/collector/exporter_test.go
+++ b/collector/exporter_test.go
@@ -15,9 +15,12 @@ func TestExporter(t *testing.T) {
 		t.Skip("-short is passed, skipping test")
 	}
 
-	exporter := New(dsn, []Scraper{
-		ScrapeGlobalStatus{},
-	})
+	exporter := New(
+		dsn,
+		NewMetrics(),
+		[]Scraper{
+			ScrapeGlobalStatus{},
+		})
 
 	convey.Convey("Metrics describing", t, func() {
 		ch := make(chan *prometheus.Desc)


### PR DESCRIPTION
There are two issues with scrapping I would like to address:
* `mysql_exporter_scrapes_total` never increases
  ```
  $ curl --silent localhost:9104/metrics | grep scrapes_total | grep -v '#'
  mysql_exporter_scrapes_total 2
  $ curl --silent localhost:9104/metrics | grep scrapes_total | grep -v '#'
  mysql_exporter_scrapes_total 2
  $ curl --silent localhost:9104/metrics | grep scrapes_total | grep -v '#'
  mysql_exporter_scrapes_total 2
  ```
  https://github.com/prometheus/mysqld_exporter/pull/235#discussion_r173890280
  
* `mysqld_exporter` every request scrapes source database twice - this means double load for MySQL database itself. The scrape is done twice because `Describe()` also runs `Collect()`. Additionally, every request we register new collector so every request we call `Describe()` and `Collect()`. This is different than in other exporters where exporter is registered only once so `Describe()` is called only on first http request but not on subsequent. This was also true for this exporter up to this change https://github.com/prometheus/mysqld_exporter/pull/235/files#r198540277
  In our fork we fixed first issue already, but this resulted in:
  ```
  $ curl --silent localhost:9104/metrics | grep scrapes_total | grep -v '#'
  mysql_exporter_scrapes_total 2
  $ curl --silent localhost:9104/metrics | grep scrapes_total | grep -v '#'
  mysql_exporter_scrapes_total 4
  $ curl --silent localhost:9104/metrics | grep scrapes_total | grep -v '#'
  mysql_exporter_scrapes_total 6
  ```
  Which clearly shows problem that database is now scrapped twice for every request.

This PR fixes both issues so it results in:
  ```
  $ curl --silent localhost:9104/metrics | grep scrapes_total | grep -v '#'
  mysql_exporter_scrapes_total 1
  $ curl --silent localhost:9104/metrics | grep scrapes_total | grep -v '#'
  mysql_exporter_scrapes_total 2
  $ curl --silent localhost:9104/metrics | grep scrapes_total | grep -v '#'
  mysql_exporter_scrapes_total 3
  ```

And internally database is indeed scrapped only once per http request.