### PR TITLE
Refactor generation of data source name

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -68,27 +68,31 @@ var scrapers = map[collector.Scraper]bool{
 }
 
 func parseMycnf(config interface{}) (string, error) {
-	var dsn string
+	mysqlConfig := mysql.NewConfig()
 	opts := ini.LoadOptions{
 		// MySQL ini file can have boolean keys.
 		AllowBooleanKeys: true,
 	}
 	cfg, err := ini.LoadSources(opts, config)
 	if err != nil {
-		return dsn, fmt.Errorf("failed reading ini file: %s", err)
+		return "", fmt.Errorf("failed reading ini file: %s", err)
 	}
 	user := cfg.Section("client").Key("user").String()
 	password := cfg.Section("client").Key("password").String()
 	if (user == "") || (password == "") {
-		return dsn, fmt.Errorf("no user or password specified under [client] in %s", config)
+		return "", fmt.Errorf("no user or password specified under [client] in %s", config)
 	}
+	mysqlConfig.User = user
+	mysqlConfig.Passwd = password
 	host := cfg.Section("client").Key("host").MustString("localhost")
 	port := cfg.Section("client").Key("port").MustUint(3306)
 	socket := cfg.Section("client").Key("socket").String()
 	if socket != "" {
-		dsn = fmt.Sprintf("%s:%s@unix(%s)/", user, password, socket)
+		mysqlConfig.Net = "unix"
+		mysqlConfig.Addr = socket
 	} else {
-		dsn = fmt.Sprintf("%s:%s@tcp(%s:%d)/", user, password, host, port)
+		mysqlConfig.Net = "tcp"
+		mysqlConfig.Addr = fmt.Sprintf("%s:%d", host, port)
 	}
 	sslCA := cfg.Section("client").Key("ssl-ca").String()
 	sslCert := cfg.Section("client").Key("ssl-cert").String()
@@ -96,13 +100,13 @@ func parseMycnf(config interface{}) (string, error) {
 	if sslCA != "" {
 		if tlsErr := customizeTLS(sslCA, sslCert, sslKey); tlsErr != nil {
 			tlsErr = fmt.Errorf("failed to register a custom TLS configuration for mysql dsn: %s", tlsErr)
-			return dsn, tlsErr
+			return mysqlConfig.FormatDSN(), tlsErr
 		}
-		dsn = fmt.Sprintf("%s?tls=custom", dsn)
+		mysqlConfig.TLSConfig = "custom"
 	}
 
-	log.Debugln(dsn)
-	return dsn, nil
+	log.Debugln(mysqlConfig.FormatDSN())
+	return mysqlConfig.FormatDSN(), nil
 }
 
 func customizeTLS(sslCA string, sslCert string, sslKey string) error {
@@ -169,6 +173,16 @@ func newHandler(metrics collector.Metrics, scrapers []collector.Scraper) http.Ha
 	}
 }
 
+func getDSN() (string, error) {
+	dsn := os.Getenv("DATA_SOURCE_NAME")
+	if len(dsn) != 0 {
+		mysqlConfig, err := mysql.ParseDSN(dsn)
+		log.Infoln("", mysqlConfig)
+		return mysqlConfig.FormatDSN(), err
+	}
+	return parseMycnf(*configMycnf)
+}
+
 func main() {
 	// Generate ON/OFF flags for all scrapers.
 	scraperFlags := map[collector.Scraper]*bool{}
@@ -206,12 +220,9 @@ func main() {
 	log.Infoln("Starting mysqld_exporter", version.Info())
 	log.Infoln("Build context", version.BuildContext())
 
-	dsn = os.Getenv("DATA_SOURCE_NAME")
-	if len(dsn) == 0 {
-		var err error
-		if dsn, err = parseMycnf(*configMycnf); err != nil {
-			log.Fatal(err)
-		}
+	var err error
+	if dsn, err = getDSN(); err != nil {
+		log.Fatal(err)
 	}
 
 	// Register only scrapers enabled by flag.

--- a/mysqld_exporter_test.go
+++ b/mysqld_exporter_test.go
@@ -201,7 +201,7 @@ func testLandingPage(t *testing.T, data bin) {
 		data.path,
 		"--web.listen-address", fmt.Sprintf(":%d", data.port),
 	)
-	cmd.Env = append(os.Environ(), "DATA_SOURCE_NAME=127.0.0.1:3306")
+	cmd.Env = append(os.Environ(), "DATA_SOURCE_NAME=tcp(127.0.0.1:3306)/")
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}

--- a/mysqld_exporter_test.go
+++ b/mysqld_exporter_test.go
@@ -79,28 +79,28 @@ func TestParseMycnf(t *testing.T) {
 	)
 	convey.Convey("Various .my.cnf configurations", t, func() {
 		convey.Convey("Local tcp connection", func() {
-			dsn, _ := parseMycnf([]byte(tcpConfig))
-			convey.So(dsn, convey.ShouldEqual, "root:abc123@tcp(localhost:3306)/")
+			config, _ := parseMycnf([]byte(tcpConfig))
+			convey.So(config.FormatDSN(), convey.ShouldEqual, "root:abc123@tcp(localhost:3306)/")
 		})
 		convey.Convey("Local tcp connection on non-default port", func() {
-			dsn, _ := parseMycnf([]byte(tcpConfig2))
-			convey.So(dsn, convey.ShouldEqual, "root:abc123@tcp(localhost:3308)/")
+			config, _ := parseMycnf([]byte(tcpConfig2))
+			convey.So(config.FormatDSN(), convey.ShouldEqual, "root:abc123@tcp(localhost:3308)/")
 		})
 		convey.Convey("Socket connection", func() {
-			dsn, _ := parseMycnf([]byte(socketConfig))
-			convey.So(dsn, convey.ShouldEqual, "user:pass@unix(/var/lib/mysql/mysql.sock)/")
+			config, _ := parseMycnf([]byte(socketConfig))
+			convey.So(config.FormatDSN(), convey.ShouldEqual, "user:pass@unix(/var/lib/mysql/mysql.sock)/")
 		})
 		convey.Convey("Socket connection ignoring defined host", func() {
-			dsn, _ := parseMycnf([]byte(socketConfig2))
-			convey.So(dsn, convey.ShouldEqual, "dude:nopassword@unix(/var/lib/mysql/mysql.sock)/")
+			config, _ := parseMycnf([]byte(socketConfig2))
+			convey.So(config.FormatDSN(), convey.ShouldEqual, "dude:nopassword@unix(/var/lib/mysql/mysql.sock)/")
 		})
 		convey.Convey("Remote connection", func() {
-			dsn, _ := parseMycnf([]byte(remoteConfig))
-			convey.So(dsn, convey.ShouldEqual, "dude:nopassword@tcp(1.2.3.4:3307)/")
+			config, _ := parseMycnf([]byte(remoteConfig))
+			convey.So(config.FormatDSN(), convey.ShouldEqual, "dude:nopassword@tcp(1.2.3.4:3307)/")
 		})
 		convey.Convey("Ignore boolean keys", func() {
-			dsn, _ := parseMycnf([]byte(ignoreBooleanKeys))
-			convey.So(dsn, convey.ShouldEqual, "root:abc123@tcp(localhost:3306)/")
+			config, _ := parseMycnf([]byte(ignoreBooleanKeys))
+			convey.So(config.FormatDSN(), convey.ShouldEqual, "root:abc123@tcp(localhost:3306)/")
 		})
 		convey.Convey("Missed user", func() {
 			_, err := parseMycnf([]byte(badConfig))


### PR DESCRIPTION
I have the intention to contribute to this project so that the data source configuration
optionally can be provided in multiple environment variables rather than one, `DATA_SOURCE_NAME`.
To achieve that I figured that it would make sense to get some refactoring in first.