### PR TITLE
PMM-2576: Fix prometheus metric names for SHOW GLOBAL VARIABLES.

### DIFF
--- a/collector/global_variables.go
+++ b/collector/global_variables.go
@@ -115,7 +115,8 @@ func parseWsrepProviderOptions(opts string) float64 {
 }
 
 func validPrometheusName(s string) string {
+	nameRe := regexp.MustCompile("([^a-zA-Z0-9_])")
+	s = nameRe.ReplaceAllString(s, "_")
 	s = strings.ToLower(s)
-	s = strings.Replace(s, ".", "_", -1)
 	return s
 }

--- a/collector/global_variables.go
+++ b/collector/global_variables.go
@@ -53,7 +53,7 @@ func (ScrapeGlobalVariables) Scrape(db *sql.DB, ch chan<- prometheus.Metric) err
 		if err := globalVariablesRows.Scan(&key, &val); err != nil {
 			return err
 		}
-		key = strings.ToLower(key)
+		key = validPrometheusName(key)
 		if floatVal, ok := parseStatus(val); ok {
 			ch <- prometheus.MustNewConstMetric(
 				newDesc(globalVariables, key, "Generic gauge metric from SHOW GLOBAL VARIABLES."),
@@ -112,4 +112,10 @@ func parseWsrepProviderOptions(opts string) float64 {
 	}
 
 	return val
+}
+
+func validPrometheusName(s string) string {
+	s = strings.ToLower(s)
+	s = strings.Replace(s, ".", "_", -1)
+	return s
 }


### PR DESCRIPTION
> "mysql_global_variables_validate_password.check_user_name" is not a valid metric name
* replace `.` with `_`
```
2018/05/21 20:04:06 http: panic serving 10.10.11.50:59840: descriptor Desc{fqName: "mysql_global_variables_validate_password.check_user_name", help: "Generic gauge metric from SHOW GLOBAL VARIABLES.", constLabels: {}, variableLabels: []} is invalid: "mysql_global_variables_validate_password.check_user_name" is not a valid metric name
goroutine 295 [running]:
net/http.(*conn).serve.func1(0xc42007c140)
	/usr/lib/golang/src/net/http/server.go:1697 +0xd0
panic(0x82f6c0, 0xc4205db530)
	/usr/lib/golang/src/runtime/panic.go:491 +0x283
github.com/percona/mysqld_exporter/vendor/github.com/prometheus/client_golang/prometheus.(*Registry).MustRegister(0xc420135880, 0xc42004db58, 0x1, 0x1)
	/tmp/go/src/github.com/percona/mysqld_exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:404 +0x9e
main.newHandler.func1(0xae6de0, 0xc420508000, 0xc420506000)
	/tmp/go/src/github.com/percona/mysqld_exporter/mysqld_exporter.go:237 +0x683
net/http.HandlerFunc.ServeHTTP(0xc4201355c0, 0xae6de0, 0xc420508000, 0xc420506000)
	/usr/lib/golang/src/net/http/server.go:1918 +0x44
net/http.(*ServeMux).ServeHTTP(0xc420188c60, 0xae6de0, 0xc420508000, 0xc420506000)
	/usr/lib/golang/src/net/http/server.go:2254 +0x130
net/http.serverHandler.ServeHTTP(0xc420116c30, 0xae6de0, 0xc420508000, 0xc420506000)
	/usr/lib/golang/src/net/http/server.go:2619 +0xb4
net/http.(*conn).serve(0xc42007c140, 0xae76e0, 0xc4201340c0)
	/usr/lib/golang/src/net/http/server.go:1801 +0x71d
created by net/http.(*Server).Serve
	/usr/lib/golang/src/net/http/server.go:2720 +0x288
```

Closes: https://github.com/prometheus/mysqld_exporter/issues/308