### PR TITLE
Fix flag name in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 * Flags now use the Kingpin library, and require double-dashes. #222
 
 This also changes the behavior of boolean flags.
-* Enable: `--collector.global_status`
-* Disable: `--no-collector.global_status`
+* Enable: `--collect.global_status`
+* Disable: `--no-collect.global_status`
 
 ### Changes:
 * [CHANGE] Limit number and lifetime of connections #208


### PR DESCRIPTION
Fix typo of `collect` flag example in the CHANGELOG.

Signed-off-by: Ben Kochie <superq@gmail.com>

Fixes: https://github.com/prometheus/mysqld_exporter/issues/312