### PR TITLE
Abort on timeout.

### DIFF
--- a/collector/binlog.go
+++ b/collector/binlog.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"strconv"
 	"strings"
@@ -51,9 +52,9 @@ func (ScrapeBinlogSize) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeBinlogSize) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapeBinlogSize) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	var logBin uint8
-	err := db.QueryRow(logbinQuery).Scan(&logBin)
+	err := db.QueryRowContext(ctx, logbinQuery).Scan(&logBin)
 	if err != nil {
 		return err
 	}
@@ -62,7 +63,7 @@ func (ScrapeBinlogSize) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 		return nil
 	}
 
-	masterLogRows, err := db.Query(binlogQuery)
+	masterLogRows, err := db.QueryContext(ctx, binlogQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/binlog_test.go
+++ b/collector/binlog_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,7 +28,7 @@ func TestScrapeBinlogSize(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeBinlogSize{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeBinlogSize{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/engine_innodb.go
+++ b/collector/engine_innodb.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"regexp"
 	"strconv"
@@ -32,8 +33,8 @@ func (ScrapeEngineInnodbStatus) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeEngineInnodbStatus) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	rows, err := db.Query(engineInnodbStatusQuery)
+func (ScrapeEngineInnodbStatus) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	rows, err := db.QueryContext(ctx, engineInnodbStatusQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/engine_innodb_test.go
+++ b/collector/engine_innodb_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -140,7 +141,7 @@ END OF INNODB MONITOR OUTPUT
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeEngineInnodbStatus{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeEngineInnodbStatus{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/engine_tokudb.go
+++ b/collector/engine_tokudb.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"strings"
 
@@ -30,8 +31,8 @@ func (ScrapeEngineTokudbStatus) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeEngineTokudbStatus) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	tokudbRows, err := db.Query(engineTokudbStatusQuery)
+func (ScrapeEngineTokudbStatus) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	tokudbRows, err := db.QueryContext(ctx, engineTokudbStatusQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/engine_tokudb_test.go
+++ b/collector/engine_tokudb_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -44,7 +45,7 @@ func TestScrapeEngineTokudbStatus(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeEngineTokudbStatus{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeEngineTokudbStatus{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/exporter_test.go
+++ b/collector/exporter_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -16,6 +17,7 @@ func TestExporter(t *testing.T) {
 	}
 
 	exporter := New(
+		context.Background(),
 		dsn,
 		NewMetrics(),
 		[]Scraper{

--- a/collector/global_status.go
+++ b/collector/global_status.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"regexp"
 	"strings"
@@ -73,8 +74,8 @@ func (ScrapeGlobalStatus) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeGlobalStatus) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	globalStatusRows, err := db.Query(globalStatusQuery)
+func (ScrapeGlobalStatus) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	globalStatusRows, err := db.QueryContext(ctx, globalStatusQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/global_status_test.go
+++ b/collector/global_status_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -38,7 +39,7 @@ func TestScrapeGlobalStatus(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeGlobalStatus{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeGlobalStatus{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/global_variables.go
+++ b/collector/global_variables.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"regexp"
 	"strconv"
@@ -32,8 +33,8 @@ func (ScrapeGlobalVariables) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeGlobalVariables) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	globalVariablesRows, err := db.Query(globalVariablesQuery)
+func (ScrapeGlobalVariables) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	globalVariablesRows, err := db.QueryContext(ctx, globalVariablesQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/global_variables_test.go
+++ b/collector/global_variables_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -37,7 +38,7 @@ func TestScrapeGlobalVariables(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeGlobalVariables{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeGlobalVariables{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/heartbeat.go
+++ b/collector/heartbeat.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strconv"
@@ -66,9 +67,9 @@ func (ScrapeHeartbeat) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeHeartbeat) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapeHeartbeat) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	query := fmt.Sprintf(heartbeatQuery, *collectHeartbeatDatabase, *collectHeartbeatTable)
-	heartbeatRows, err := db.Query(query)
+	heartbeatRows, err := db.QueryContext(ctx, query)
 	if err != nil {
 		return err
 	}

--- a/collector/heartbeat_test.go
+++ b/collector/heartbeat_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -32,7 +33,7 @@ func TestScrapeHeartbeat(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeHeartbeat{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeHeartbeat{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_auto_increment.go
+++ b/collector/info_schema_auto_increment.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -50,8 +51,8 @@ func (ScrapeAutoIncrementColumns) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeAutoIncrementColumns) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	autoIncrementRows, err := db.Query(infoSchemaAutoIncrementQuery)
+func (ScrapeAutoIncrementColumns) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	autoIncrementRows, err := db.QueryContext(ctx, infoSchemaAutoIncrementQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/info_schema_clientstats.go
+++ b/collector/info_schema_clientstats.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -141,9 +142,9 @@ func (ScrapeClientStat) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeClientStat) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapeClientStat) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	var varName, varVal string
-	err := db.QueryRow(userstatCheckQuery).Scan(&varName, &varVal)
+	err := db.QueryRowContext(ctx, userstatCheckQuery).Scan(&varName, &varVal)
 	if err != nil {
 		log.Debugln("Detailed client stats are not available.")
 		return nil
@@ -153,7 +154,7 @@ func (ScrapeClientStat) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 		return nil
 	}
 
-	informationSchemaClientStatisticsRows, err := db.Query(clientStatQuery)
+	informationSchemaClientStatisticsRows, err := db.QueryContext(ctx, clientStatQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/info_schema_clientstats_test.go
+++ b/collector/info_schema_clientstats_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,7 +27,7 @@ func TestScrapeClientStat(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeClientStat{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeClientStat{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_innodb_cmp.go
+++ b/collector/info_schema_innodb_cmp.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -57,9 +58,8 @@ func (ScrapeInnodbCmp) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeInnodbCmp) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-
-	informationSchemaInnodbCmpRows, err := db.Query(innodbCmpQuery)
+func (ScrapeInnodbCmp) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	informationSchemaInnodbCmpRows, err := db.QueryContext(ctx, innodbCmpQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/info_schema_innodb_cmp_test.go
+++ b/collector/info_schema_innodb_cmp_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -23,7 +24,7 @@ func TestScrapeInnodbCmp(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeInnodbCmp{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeInnodbCmp{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_innodb_cmpmem.go
+++ b/collector/info_schema_innodb_cmpmem.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -52,9 +53,8 @@ func (ScrapeInnodbCmpMem) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeInnodbCmpMem) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-
-	informationSchemaInnodbCmpMemRows, err := db.Query(innodbCmpMemQuery)
+func (ScrapeInnodbCmpMem) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	informationSchemaInnodbCmpMemRows, err := db.QueryContext(ctx, innodbCmpMemQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/info_schema_innodb_cmpmem_test.go
+++ b/collector/info_schema_innodb_cmpmem_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -23,7 +24,7 @@ func TestScrapeInnodbCmpMem(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeInnodbCmpMem{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeInnodbCmpMem{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_innodb_metrics.go
+++ b/collector/info_schema_innodb_metrics.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"regexp"
 
@@ -62,8 +63,8 @@ func (ScrapeInnodbMetrics) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeInnodbMetrics) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	innodbMetricsRows, err := db.Query(infoSchemaInnodbMetricsQuery)
+func (ScrapeInnodbMetrics) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	innodbMetricsRows, err := db.QueryContext(ctx, infoSchemaInnodbMetricsQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/info_schema_innodb_metrics_test.go
+++ b/collector/info_schema_innodb_metrics_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -40,7 +41,7 @@ func TestScrapeInnodbMetrics(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeInnodbMetrics{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeInnodbMetrics{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_innodb_sys_tablespaces.go
+++ b/collector/info_schema_innodb_sys_tablespaces.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -53,8 +54,8 @@ func (ScrapeInfoSchemaInnodbTablespaces) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeInfoSchemaInnodbTablespaces) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	tablespacesRows, err := db.Query(innodbTablespacesQuery)
+func (ScrapeInfoSchemaInnodbTablespaces) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	tablespacesRows, err := db.QueryContext(ctx, innodbTablespacesQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/info_schema_innodb_sys_tablespaces_test.go
+++ b/collector/info_schema_innodb_sys_tablespaces_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -24,7 +25,7 @@ func TestScrapeInfoSchemaInnodbTablespaces(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeInfoSchemaInnodbTablespaces{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeInfoSchemaInnodbTablespaces{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_processlist.go
+++ b/collector/info_schema_processlist.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -135,12 +136,12 @@ func (ScrapeProcesslist) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeProcesslist) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapeProcesslist) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	processQuery := fmt.Sprintf(
 		infoSchemaProcesslistQuery,
 		*processlistMinTime,
 	)
-	processlistRows, err := db.Query(processQuery)
+	processlistRows, err := db.QueryContext(ctx, processQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/info_schema_query_response_time_test.go
+++ b/collector/info_schema_query_response_time_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -37,7 +38,7 @@ func TestScrapeQueryResponseTime(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeQueryResponseTime{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeQueryResponseTime{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_tables.go
+++ b/collector/info_schema_tables.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -77,10 +78,10 @@ func (ScrapeTableSchema) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeTableSchema) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapeTableSchema) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	var dbList []string
 	if *tableSchemaDatabases == "*" {
-		dbListRows, err := db.Query(dbListQuery)
+		dbListRows, err := db.QueryContext(ctx, dbListQuery)
 		if err != nil {
 			return err
 		}
@@ -101,7 +102,7 @@ func (ScrapeTableSchema) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	}
 
 	for _, database := range dbList {
-		tableSchemaRows, err := db.Query(fmt.Sprintf(tableSchemaQuery, database))
+		tableSchemaRows, err := db.QueryContext(ctx, fmt.Sprintf(tableSchemaQuery, database))
 		if err != nil {
 			return err
 		}

--- a/collector/info_schema_tablestats.go
+++ b/collector/info_schema_tablestats.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -52,9 +53,9 @@ func (ScrapeTableStat) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeTableStat) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapeTableStat) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	var varName, varVal string
-	err := db.QueryRow(userstatCheckQuery).Scan(&varName, &varVal)
+	err := db.QueryRowContext(ctx, userstatCheckQuery).Scan(&varName, &varVal)
 	if err != nil {
 		log.Debugln("Detailed table stats are not available.")
 		return nil
@@ -64,7 +65,7 @@ func (ScrapeTableStat) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 		return nil
 	}
 
-	informationSchemaTableStatisticsRows, err := db.Query(tableStatQuery)
+	informationSchemaTableStatisticsRows, err := db.QueryContext(ctx, tableStatQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/info_schema_tablestats_test.go
+++ b/collector/info_schema_tablestats_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,7 +28,7 @@ func TestScrapeTableStat(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeTableStat{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeTableStat{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_userstats.go
+++ b/collector/info_schema_userstats.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -137,9 +138,9 @@ func (ScrapeUserStat) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeUserStat) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapeUserStat) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	var varName, varVal string
-	err := db.QueryRow(userstatCheckQuery).Scan(&varName, &varVal)
+	err := db.QueryRowContext(ctx, userstatCheckQuery).Scan(&varName, &varVal)
 	if err != nil {
 		log.Debugln("Detailed user stats are not available.")
 		return nil
@@ -149,7 +150,7 @@ func (ScrapeUserStat) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 		return nil
 	}
 
-	informationSchemaUserStatisticsRows, err := db.Query(userStatQuery)
+	informationSchemaUserStatisticsRows, err := db.QueryContext(ctx, userStatQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/info_schema_userstats_test.go
+++ b/collector/info_schema_userstats_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,7 +27,7 @@ func TestScrapeUserStat(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeUserStat{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeUserStat{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/perf_schema_events_statements.go
+++ b/collector/perf_schema_events_statements.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 
@@ -148,7 +149,7 @@ func (ScrapePerfEventsStatements) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapePerfEventsStatements) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapePerfEventsStatements) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	perfQuery := fmt.Sprintf(
 		perfEventsStatementsQuery,
 		*perfEventsStatementsDigestTextLimit,
@@ -156,7 +157,7 @@ func (ScrapePerfEventsStatements) Scrape(db *sql.DB, ch chan<- prometheus.Metric
 		*perfEventsStatementsLimit,
 	)
 	// Timers here are returned in picoseconds.
-	perfSchemaEventsStatementsRows, err := db.Query(perfQuery)
+	perfSchemaEventsStatementsRows, err := db.QueryContext(ctx, perfQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/perf_schema_events_waits.go
+++ b/collector/perf_schema_events_waits.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -41,9 +42,9 @@ func (ScrapePerfEventsWaits) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapePerfEventsWaits) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapePerfEventsWaits) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	// Timers here are returned in picoseconds.
-	perfSchemaEventsWaitsRows, err := db.Query(perfEventsWaitsQuery)
+	perfSchemaEventsWaitsRows, err := db.QueryContext(ctx, perfEventsWaitsQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/perf_schema_file_events.go
+++ b/collector/perf_schema_file_events.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -50,9 +51,9 @@ func (ScrapePerfFileEvents) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapePerfFileEvents) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapePerfFileEvents) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	// Timers here are returned in picoseconds.
-	perfSchemaFileEventsRows, err := db.Query(perfFileEventsQuery)
+	perfSchemaFileEventsRows, err := db.QueryContext(ctx, perfFileEventsQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/perf_schema_file_instances.go
+++ b/collector/perf_schema_file_instances.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"strings"
 
@@ -60,9 +61,9 @@ func (ScrapePerfFileInstances) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapePerfFileInstances) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapePerfFileInstances) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	// Timers here are returned in picoseconds.
-	perfSchemaFileInstancesRows, err := db.Query(perfFileInstancesQuery, *performanceSchemaFileInstancesFilter)
+	perfSchemaFileInstancesRows, err := db.QueryContext(ctx, perfFileInstancesQuery, *performanceSchemaFileInstancesFilter)
 	if err != nil {
 		return err
 	}

--- a/collector/perf_schema_file_instances_test.go
+++ b/collector/perf_schema_file_instances_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -33,7 +34,7 @@ func TestScrapePerfFileInstances(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapePerfFileInstances{}).Scrape(db, ch); err != nil {
+		if err = (ScrapePerfFileInstances{}).Scrape(context.Background(), db, ch); err != nil {
 			panic(fmt.Sprintf("error calling function on test: %s", err))
 		}
 		close(ch)

--- a/collector/perf_schema_index_io_waits.go
+++ b/collector/perf_schema_index_io_waits.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -44,8 +45,8 @@ func (ScrapePerfIndexIOWaits) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapePerfIndexIOWaits) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	perfSchemaIndexWaitsRows, err := db.Query(perfIndexIOWaitsQuery)
+func (ScrapePerfIndexIOWaits) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	perfSchemaIndexWaitsRows, err := db.QueryContext(ctx, perfIndexIOWaitsQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/perf_schema_index_io_waits_test.go
+++ b/collector/perf_schema_index_io_waits_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -25,7 +26,7 @@ func TestScrapePerfIndexIOWaits(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapePerfIndexIOWaits{}).Scrape(db, ch); err != nil {
+		if err = (ScrapePerfIndexIOWaits{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/perf_schema_replication_group_member_stats.go
+++ b/collector/perf_schema_replication_group_member_stats.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -50,8 +51,8 @@ func (ScrapePerfReplicationGroupMemberStats) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapePerfReplicationGroupMemberStats) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	perfReplicationGroupMemeberStatsRows, err := db.Query(perfReplicationGroupMemeberStatsQuery)
+func (ScrapePerfReplicationGroupMemberStats) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	perfReplicationGroupMemeberStatsRows, err := db.QueryContext(ctx, perfReplicationGroupMemeberStatsQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/perf_schema_table_io_waits.go
+++ b/collector/perf_schema_table_io_waits.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -45,8 +46,8 @@ func (ScrapePerfTableIOWaits) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapePerfTableIOWaits) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	perfSchemaTableWaitsRows, err := db.Query(perfTableIOWaitsQuery)
+func (ScrapePerfTableIOWaits) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	perfSchemaTableWaitsRows, err := db.QueryContext(ctx, perfTableIOWaitsQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/perf_schema_table_lock_waits.go
+++ b/collector/perf_schema_table_lock_waits.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -74,8 +75,8 @@ func (ScrapePerfTableLockWaits) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapePerfTableLockWaits) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	perfSchemaTableLockWaitsRows, err := db.Query(perfTableLockWaitsQuery)
+func (ScrapePerfTableLockWaits) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	perfSchemaTableLockWaitsRows, err := db.QueryContext(ctx, perfTableLockWaitsQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/scraper.go
+++ b/collector/scraper.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -15,5 +16,5 @@ type Scraper interface {
 	// Example: "Collect from SHOW ENGINE INNODB STATUS"
 	Help() string
 	// Scrape collects data from database connection and sends it over channel as prometheus metric.
-	Scrape(db *sql.DB, ch chan<- prometheus.Metric) error
+	Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error
 }

--- a/collector/slave_hosts.go
+++ b/collector/slave_hosts.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -42,8 +43,8 @@ func (ScrapeSlaveHosts) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeSlaveHosts) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
-	slaveHostsRows, err := db.Query(slaveHostsQuery)
+func (ScrapeSlaveHosts) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	slaveHostsRows, err := db.QueryContext(ctx, slaveHostsQuery)
 	if err != nil {
 		return err
 	}

--- a/collector/slave_hosts_test.go
+++ b/collector/slave_hosts_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -24,7 +25,7 @@ func TestScrapeSlaveHostsOldFormat(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeSlaveHosts{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeSlaveHosts{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)
@@ -62,7 +63,7 @@ func TestScrapeSlaveHostsNewFormat(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeSlaveHosts{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeSlaveHosts{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/slave_status.go
+++ b/collector/slave_status.go
@@ -3,6 +3,7 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -49,18 +50,18 @@ func (ScrapeSlaveStatus) Help() string {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeSlaveStatus) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
+func (ScrapeSlaveStatus) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
 	var (
 		slaveStatusRows *sql.Rows
 		err             error
 	)
 	// Try the both syntax for MySQL/Percona and MariaDB
 	for _, query := range slaveStatusQueries {
-		slaveStatusRows, err = db.Query(query)
+		slaveStatusRows, err = db.QueryContext(ctx, query)
 		if err != nil { // MySQL/Percona
 			// Leverage lock-free SHOW SLAVE STATUS by guessing the right suffix
 			for _, suffix := range slaveStatusQuerySuffixes {
-				slaveStatusRows, err = db.Query(fmt.Sprint(query, suffix))
+				slaveStatusRows, err = db.QueryContext(ctx, fmt.Sprint(query, suffix))
 				if err == nil {
 					break
 				}

--- a/collector/slave_status_test.go
+++ b/collector/slave_status_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -23,7 +24,7 @@ func TestScrapeSlaveStatus(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeSlaveStatus{}).Scrape(db, ch); err != nil {
+		if err = (ScrapeSlaveStatus{}).Scrape(context.Background(), db, ch); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -8,6 +9,8 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strconv"
+	"time"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/prometheus/client_golang/prometheus"
@@ -29,6 +32,10 @@ var (
 		"web.telemetry-path",
 		"Path under which to expose metrics.",
 	).Default("/metrics").String()
+	timeoutOffset = kingpin.Flag(
+		"timeout-offset",
+		"Offset to subtract from timeout in seconds.",
+	).Default("0.5").Float64()
 	configMycnf = kingpin.Flag(
 		"config.my-cnf",
 		"Path to .my.cnf file to read MySQL credentials from.",
@@ -139,6 +146,25 @@ func newHandler(metrics collector.Metrics, scrapers []collector.Scraper) http.Ha
 	return func(w http.ResponseWriter, r *http.Request) {
 		filteredScrapers := scrapers
 		params := r.URL.Query()["collect[]"]
+		// Use request context for cancellation when connection gets closed.
+		ctx := r.Context()
+		// If a timeout is configured via the Prometheus header, add it to the context.
+		if v := r.Header.Get("X-Prometheus-Scrape-Timeout-Seconds"); v != "" {
+			timeoutSeconds, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				log.Errorf("Failed to parse timeout from Prometheus header: %s", err)
+			} else {
+				if timeoutSeconds-*timeoutOffset > 0 {
+					timeoutSeconds -= *timeoutOffset
+				}
+				// Create new timeout context with request context as parent.
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, time.Duration(timeoutSeconds*float64(time.Second)))
+				defer cancel()
+				// Overwrite request with timeout context.
+				r = r.WithContext(ctx)
+			}
+		}
 		log.Debugln("collect query:", params)
 
 		// Check if we have some "collect[]" query parameters.
@@ -157,7 +183,7 @@ func newHandler(metrics collector.Metrics, scrapers []collector.Scraper) http.Ha
 		}
 
 		registry := prometheus.NewRegistry()
-		registry.MustRegister(collector.New(dsn, metrics, filteredScrapers))
+		registry.MustRegister(collector.New(ctx, dsn, metrics, filteredScrapers))
 
 		gatherers := prometheus.Gatherers{
 			prometheus.DefaultGatherer,

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -35,7 +35,7 @@ var (
 	timeoutOffset = kingpin.Flag(
 		"timeout-offset",
 		"Offset to subtract from timeout in seconds.",
-	).Default("0.1").Float64()
+	).Default("0.25").Float64()
 	configMycnf = kingpin.Flag(
 		"config.my-cnf",
 		"Path to .my.cnf file to read MySQL credentials from.",

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -154,7 +154,15 @@ func newHandler(metrics collector.Metrics, scrapers []collector.Scraper) http.Ha
 			if err != nil {
 				log.Errorf("Failed to parse timeout from Prometheus header: %s", err)
 			} else {
-				if timeoutSeconds-*timeoutOffset > 0 {
+				if *timeoutOffset >= timeoutSeconds {
+					// Ignore timeout offset if it doesn't leave time to scrape.
+					log.Errorf(
+						"Timeout offset (--timeout-offset=%.2f) should be lower than prometheus scrape time (X-Prometheus-Scrape-Timeout-Seconds=%.2f).",
+						*timeoutOffset,
+						timeoutSeconds,
+					)
+				} else {
+					// Subtract timeout offset from timeout.
 					timeoutSeconds -= *timeoutOffset
 				}
 				// Create new timeout context with request context as parent.

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -35,7 +35,7 @@ var (
 	timeoutOffset = kingpin.Flag(
 		"timeout-offset",
 		"Offset to subtract from timeout in seconds.",
-	).Default("0.5").Float64()
+	).Default("0.1").Float64()
 	configMycnf = kingpin.Flag(
 		"config.my-cnf",
 		"Path to .my.cnf file to read MySQL credentials from.",


### PR DESCRIPTION
# Abort data collection: 
* when connection gets closed
* on prometheus scrape timeout `X-Prometheus-Scrape-Timeout-Seconds`
  * give exporter time to finish and send data with `--timeout-offset`. Default `0.1` second.

Tested manually. Returns metrics even if scraping was canceled. Example errors:
```console
ERRO[0014] Error scraping for collect.global_status: context deadline exceeded  source="exporter.go:104"
ERRO[0014] Error scraping for collect.info_schema.innodb_metrics: context deadline exceeded  source="exporter.go:104"
```

Based on https://github.com/prometheus/blackbox_exporter/blob/master/main.go#L74-L83

Let me know what you think.