### PR TITLE
add metrics to monitor processes by user and host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The minimum supported MySQL version is now 5.5.
 
 * [CHANGE] Update defaults for MySQL 5.5 #318
 * [BUGFIX] Sanitize metric names in global variables #307
+* [FEATURE] Add by_user and by_host metrics to info_schema.processlist collector (PR #333) #334
 
 ## 0.11.0 / 2018-06-29
 

--- a/collector/info_schema_processlist.go
+++ b/collector/info_schema_processlist.go
@@ -64,7 +64,6 @@ var (
 		prometheus.BuildFQName(namespace, informationSchema, "processes_by_host"),
 		"The number of processes by host.",
 		[]string{"src_host"}, nil)
-
 )
 
 // whitelist for connection/process states in SHOW PROCESSLIST
@@ -151,14 +150,14 @@ var (
 func processesByUser(db *sql.DB, ch chan<- prometheus.Metric, query string, i int) error {
 	connectionsByUserRows, err := db.Query(infoSchemaProcessesByUserQuery)
 	if err != nil {
-                return err
-        }
+		return err
+	}
 	defer connectionsByUserRows.Close()
 
-        var (
-                user      string
-                processes uint32
-        )
+	var (
+		user      string
+		processes uint32
+	)
 
 	for connectionsByUserRows.Next() {
 		err = connectionsByUserRows.Scan(&user, &processes)
@@ -174,14 +173,14 @@ func processesByUser(db *sql.DB, ch chan<- prometheus.Metric, query string, i in
 func processesByHost(db *sql.DB, ch chan<- prometheus.Metric, query string, i int) error {
 	connectionsByHostRows, err := db.Query(infoSchemaProcessesByHostQuery)
 	if err != nil {
-                return err
-        }
+		return err
+	}
 	defer connectionsByHostRows.Close()
 
-        var (
-                host      string
-                processes uint32
-        )
+	var (
+		host      string
+		processes uint32
+	)
 
 	for connectionsByHostRows.Next() {
 		err = connectionsByHostRows.Scan(&host, &processes)

--- a/collector/info_schema_processlist.go
+++ b/collector/info_schema_processlist.go
@@ -147,7 +147,7 @@ var (
 	}
 )
 
-func processesByUser(db *sql.DB, ch chan<- prometheus.Metric, query string, i int) error {
+func processesByUser(db *sql.DB, ch chan<- prometheus.Metric) error {
 	connectionsByUserRows, err := db.Query(infoSchemaProcessesByUserQuery)
 	if err != nil {
 		return err
@@ -170,7 +170,7 @@ func processesByUser(db *sql.DB, ch chan<- prometheus.Metric, query string, i in
 	return nil
 }
 
-func processesByHost(db *sql.DB, ch chan<- prometheus.Metric, query string, i int) error {
+func processesByHost(db *sql.DB, ch chan<- prometheus.Metric) error {
 	connectionsByHostRows, err := db.Query(infoSchemaProcessesByHostQuery)
 	if err != nil {
 		return err
@@ -209,10 +209,10 @@ func (ScrapeProcesslist) Help() string {
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
 func (ScrapeProcesslist) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 	if *processesByUserFlag == true {
-		processesByUser(db, ch, infoSchemaProcessesByUserQuery, 1)
+		processesByUser(db, ch)
 	}
 	if *processesByHostFlag == true {
-		processesByHost(db, ch, infoSchemaProcessesByHostQuery, 1)
+		processesByHost(db, ch)
 	}
 
 	processQuery := fmt.Sprintf(

--- a/collector/info_schema_processlist.go
+++ b/collector/info_schema_processlist.go
@@ -32,14 +32,14 @@ var (
 		"collect.info_schema.processlist.min_time",
 		"Minimum time a thread must be in each state to be counted",
 	).Default("0").Int()
-	processesDisableByUserFlag = kingpin.Flag(
-		"collect.info_schema.processlist.disable_processes_by_user",
-		"Disable collecting the number of processes by user",
-	).Default("false").Bool()
-	processesDisableByHostFlag = kingpin.Flag(
-		"collect.info_schema.processlist.disable_processes_by_host",
-		"Disable collecting the number of processes by host",
-	).Default("false").Bool()
+	processesByUserFlag = kingpin.Flag(
+		"collect.info_schema.processlist.processes_by_user",
+		"Enable collecting the number of processes by user",
+	).Default("true").Bool()
+	processesByHostFlag = kingpin.Flag(
+		"collect.info_schema.processlist.processes_by_host",
+		"Enable collecting the number of processes by host",
+	).Default("true").Bool()
 )
 
 // Metric descriptors.
@@ -197,13 +197,13 @@ func (ScrapeProcesslist) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error {
 		userCount[user] = userCount[user] + processes
 	}
 
-	if *processesDisableByHostFlag == false {
+	if *processesByHostFlag == true {
 		for host, processes := range hostCount {
 			ch <- prometheus.MustNewConstMetric(processesByHostDesc, prometheus.GaugeValue, float64(processes), host)
 		}
 	}
 
-	if *processesDisableByUserFlag == false {
+	if *processesByUserFlag == true {
 		for user, processes := range userCount {
 			ch <- prometheus.MustNewConstMetric(processesByUserDesc, prometheus.GaugeValue, float64(processes), user)
 		}

--- a/collector/info_schema_processlist.go
+++ b/collector/info_schema_processlist.go
@@ -27,7 +27,7 @@ const infoSchemaProcessesByUserQuery = `
 const infoSchemaProcessesByHostQuery = `
 		SELECT LEFT(host, LOCATE(':', host) - 1) host, count(*) processes
 		FROM information_schema.processlist
-		GROUP BY host
+		GROUP BY LEFT(host, LOCATE(':', host) - 1)
 	`
 
 // Tunable flags.

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -17,7 +17,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 	"gopkg.in/ini.v1"
 
-	"github.com/peterloeffler/mysqld_exporter/collector"
+	"github.com/prometheus/mysqld_exporter/collector"
 )
 
 var (

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -17,7 +17,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 	"gopkg.in/ini.v1"
 
-	"github.com/prometheus/mysqld_exporter/collector"
+	"github.com/peterloeffler/mysqld_exporter/collector"
 )
 
 var (


### PR DESCRIPTION
Added 2 new flags --collect.info_schema.processlist.processes_by_user and --collect.info_schema.processlist.processes_by_host which are needed in addition to --collect.info_schema.processlist.
By using them you get 2 new metrics:
- mysql_info_schema_processes_by_user{src_user=""}
- mysql_info_schema_processes_by_host{src_host=""}

Found it very useful to have this metrics and thought it could be interesting to have it in place for many people.

Closes: https://github.com/prometheus/mysqld_exporter/issues/334