### PR TITLE
Use GLOBAL to prevent mysql deadlock

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -15,7 +15,7 @@ const (
 	// Math constant for picoseconds to seconds.
 	picoSeconds = 1e12
 	// Query to check whether user/table/client stats are enabled.
-	userstatCheckQuery = `SHOW VARIABLES WHERE Variable_Name='userstat'
+	userstatCheckQuery = `SHOW GLOBAL VARIABLES WHERE Variable_Name='userstat'
 		OR Variable_Name='userstat_running'`
 )
 


### PR DESCRIPTION
@SuperQ 
In mysql 5.7.22 we encountered an issue where the entire process would completely lock up. We were able to solve it by modifying this one file and also removing the '--collect.binlog_size' param from the mysqld exporter.

Here is the bug report: https://bugs.mysql.com/bug.php?id=92108
