### PR TITLE
Fix global status metric names

### DIFF
--- a/collector/global_status.go
+++ b/collector/global_status.go
@@ -5,7 +5,6 @@ package collector
 import (
 	"database/sql"
 	"regexp"
-	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -93,7 +92,7 @@ func (ScrapeGlobalStatus) Scrape(db *sql.DB, ch chan<- prometheus.Metric) error 
 			return err
 		}
 		if floatVal, ok := parseStatus(val); ok { // Unparsable values are silently skipped.
-			key = strings.ToLower(key)
+			key = validPrometheusName(key)
 			match := globalStatusRE.FindStringSubmatch(key)
 			if match == nil {
 				ch <- prometheus.MustNewConstMetric(

--- a/collector/global_status_test.go
+++ b/collector/global_status_test.go
@@ -30,6 +30,7 @@ func TestScrapeGlobalStatus(t *testing.T) {
 		AddRow("Slave_running", "OFF").
 		AddRow("Ssl_version", "").
 		AddRow("Uptime", "10").
+		AddRow("validate_password.dictionary_file_words_count", "11").
 		AddRow("wsrep_cluster_status", "Primary").
 		AddRow("wsrep_local_state_uuid", "6c06e583-686f-11e6-b9e3-8336ad58138c").
 		AddRow("wsrep_cluster_state_uuid", "6c06e583-686f-11e6-b9e3-8336ad58138c").
@@ -56,6 +57,7 @@ func TestScrapeGlobalStatus(t *testing.T) {
 		{labels: labelMap{"instrumentation": "users_lost"}, value: 9, metricType: dto.MetricType_COUNTER},
 		{labels: labelMap{}, value: 0, metricType: dto.MetricType_UNTYPED},
 		{labels: labelMap{}, value: 10, metricType: dto.MetricType_UNTYPED},
+		{labels: labelMap{}, value: 11, metricType: dto.MetricType_UNTYPED},
 		{labels: labelMap{}, value: 1, metricType: dto.MetricType_UNTYPED},
 		{labels: labelMap{"wsrep_local_state_uuid": "6c06e583-686f-11e6-b9e3-8336ad58138c", "wsrep_cluster_state_uuid": "6c06e583-686f-11e6-b9e3-8336ad58138c", "wsrep_provider_version": "3.16(r5c765eb)"}, value: 1, metricType: dto.MetricType_GAUGE},
 	}


### PR DESCRIPTION
Apply `validPrometheusName()` to global status collector.

Closes: https://github.com/prometheus/mysqld_exporter/issues/325

Signed-off-by: Ben Kochie <superq@gmail.com>