### PR TITLE
Add perf_schema.eventsstatementssum collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ Running using ~/.my.cnf:
     ./mysqld_exporter <flags>
 
 Example format for flags for version > 0.10.0:
-  
+
     --collect.auto_increment.columns
     --no-collect.auto_increment.columns
-  
+
 Example format for flags for version <= 0.10.0:
-  
+
     -collect.auto_increment.columns
     -collect.auto_increment.columns=[true|false]
 
@@ -74,6 +74,7 @@ collect.perf_schema.eventsstatements                         | 5.6           | C
 collect.perf_schema.eventsstatements.digest_text_limit       | 5.6           | Maximum length of the normalized statement text. (default: 120)
 collect.perf_schema.eventsstatements.limit                   | 5.6           | Limit the number of events statements digests by response time. (default: 250)
 collect.perf_schema.eventsstatements.timelimit               | 5.6           | Limit how old the 'last_seen' events statements can be, in seconds. (default: 86400)
+collect.perf_schema.eventsstatementssum                      | 5.7           | Collect metrics from performance_schema.events_statements_summary_by_digest summed.
 collect.perf_schema.eventswaits                              | 5.5           | Collect metrics from performance_schema.events_waits_summary_global_by_event_name.
 collect.perf_schema.file_events                              | 5.6           | Collect metrics from performance_schema.file_summary_by_event_name.
 collect.perf_schema.file_instances                           | 5.5           | Collect metrics from performance_schema.file_summary_by_instance.
@@ -114,7 +115,7 @@ if The MySQL server supports SSL, you may need to specify a CA truststore to ver
 ssl-ca=/path/to/ca/file
 ```
 
-To specify the client SSL keypair, add the following to the cnf. 
+To specify the client SSL keypair, add the following to the cnf.
 
 ```
 ssl-key=/path/to/ssl/client/key

--- a/collector/perf_schema_events_statements_sum.go
+++ b/collector/perf_schema_events_statements_sum.go
@@ -1,0 +1,275 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Scrape `performance_schema.events_statements_summary_by_digest`.
+
+package collector
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const perfEventsStatementsSumQuery = `
+	SELECT
+		SUM(COUNT_STAR) AS SUM_COUNT_STAR,
+		SUM(SUM_CREATED_TMP_DISK_TABLES) AS SUM_SUM_CREATED_TMP_DISK_TABLES,
+		SUM(SUM_CREATED_TMP_TABLES) AS SUM_SUM_CREATED_TMP_TABLES,
+		SUM(SUM_ERRORS) AS SUM_SUM_ERRORS,
+		SUM(SUM_LOCK_TIME) AS SUM_SUM_LOCK_TIME,
+		SUM(SUM_NO_GOOD_INDEX_USED) AS SUM_SUM_NO_GOOD_INDEX_USED,
+		SUM(SUM_NO_INDEX_USED) AS SUM_SUM_NO_INDEX_USED,
+		SUM(SUM_ROWS_AFFECTED) AS SUM_SUM_ROWS_AFFECTED,
+		SUM(SUM_ROWS_EXAMINED) AS SUM_SUM_ROWS_EXAMINED,
+		SUM(SUM_ROWS_SENT) AS SUM_SUM_ROWS_SENT,
+		SUM(SUM_SELECT_FULL_JOIN) AS SUM_SUM_SELECT_FULL_JOIN,
+		SUM(SUM_SELECT_FULL_RANGE_JOIN) AS SUM_SUM_SELECT_FULL_RANGE_JOIN,
+		SUM(SUM_SELECT_RANGE) AS SUM_SUM_SELECT_RANGE,
+		SUM(SUM_SELECT_RANGE_CHECK) AS SUM_SUM_SELECT_RANGE_CHECK,
+		SUM(SUM_SELECT_SCAN) AS SUM_SUM_SELECT_SCAN,
+		SUM(SUM_SORT_MERGE_PASSES) AS SUM_SUM_SORT_MERGE_PASSES,
+		SUM(SUM_SORT_RANGE) AS SUM_SUM_SORT_RANGE,
+		SUM(SUM_SORT_ROWS) AS SUM_SUM_SORT_ROWS,
+		SUM(SUM_SORT_SCAN) AS SUM_SUM_SORT_SCAN,
+		SUM(SUM_TIMER_WAIT) AS SUM_SUM_TIMER_WAIT,
+		SUM(SUM_WARNINGS) AS SUM_SUM_WARNINGS
+	FROM performance_schema.events_statements_summary_by_digest;
+	`
+
+// Metric descriptors.
+var (
+	performanceSchemaEventsStatementsSumTotalDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_sum_total"),
+		"The total count of events statements.",
+		nil, nil,
+	)
+	performanceSchemaEventsStatementsSumCreatedTmpDiskTablesDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_sum_created_tmp_disk_tables"),
+		"The number of on-disk temporary tables created.",
+		nil, nil,
+	)
+	performanceSchemaEventsStatementsSumCreatedTmpTablesDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_sum_created_tmp_tables"),
+		"The number of temporary tables created.",
+		nil, nil,
+	)
+	performanceSchemaEventsStatementsSumErrorsDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_sum_errors"),
+		"Number of errors.",
+		nil, nil,
+	)
+	performanceSchemaEventsStatementsSumLockTimeDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_sum_lock_time"),
+		"Time in picoseconds spent waiting for locks.",
+		nil, nil,
+	)
+	performanceSchemaEventsStatementsSumNoGoodIndexUsedDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_sum_no_good_index_used"),
+		"Number of times no good index was found.",
+		nil, nil,
+	)
+	performanceSchemaEventsStatementsSumNoIndexUsedDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_sum_no_index_used"),
+		"Number of times no index was found.",
+		nil, nil,
+	)
+	performanceSchemaEventsStatementsSumRowsAffectedDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_sum_rows_affected"),
+		"Number of rows affected by statements.",
+		nil, nil,
+	)
+	performanceSchemaEventsStatementsSumRowsExaminedDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_sum_rows_examined"),
+		"Number of rows read during statements' execution.",
+		nil, nil,
+	)
+	performanceSchemaEventsStatementsSumRowsSentDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_sum_rows_sent"),
+		"Number of rows returned.",
+		nil, nil,
+	)
+	performanceSchemaEventsStatementsSumSelectFullJoinDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_sum_select_full_join"),
+		"Number of joins performed by statements which did not use an index.",
+		nil, nil,
+	)
+	performanceSchemaEventsStatementsSumSelectFullRangeJoinDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_sum_select_full_range_join"),
+		"Number of joins performed by statements which used a range search of the first table.",
+		nil, nil,
+	)
+	performanceSchemaEventsStatementsSumSelectRangeDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_sum_select_range"),
+		"Number of joins performed by statements which used a range of the first table.",
+		nil, nil,
+	)
+	performanceSchemaEventsStatementsSumSelectRangeCheckDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_sum_select_range_check"),
+		"Number of joins without keys performed by statements that check for key usage after each row.",
+		nil, nil,
+	)
+	performanceSchemaEventsStatementsSumSelectScanDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_sum_select_scan"),
+		"Number of joins performed by statements which used a full scan of the first table.",
+		nil, nil,
+	)
+	performanceSchemaEventsStatementsSumSortMergePassesDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_sum_sort_merge_passes"),
+		"Number of merge passes by the sort algorithm performed by statements.",
+		nil, nil,
+	)
+	performanceSchemaEventsStatementsSumSortRangeDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_sum_sort_range"),
+		"Number of sorts performed by statements which used a range.",
+		nil, nil,
+	)
+	performanceSchemaEventsStatementsSumSortRowsDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_sum_sort_rows"),
+		"Number of rows sorted.",
+		nil, nil,
+	)
+	performanceSchemaEventsStatementsSumSortScanDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_sum_sort_scan"),
+		"Number of sorts performed by statements which used a full table scan.",
+		nil, nil,
+	)
+	performanceSchemaEventsStatementsSumTimerWaitDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_sum_timer_wait"),
+		"Total wait time of the summarized events that are timed.",
+		nil, nil,
+	)
+	performanceSchemaEventsStatementsSumWarningsDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_sum_warnings"),
+		"Number of warnings.",
+		nil, nil,
+	)
+)
+
+// ScrapePerfEventsStatementsSum collects from `performance_schema.events_statements_summary_by_digest`.
+type ScrapePerfEventsStatementsSum struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapePerfEventsStatementsSum) Name() string {
+	return "perf_schema.eventsstatementssum"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapePerfEventsStatementsSum) Help() string {
+	return "Collect metrics of grand sums from performance_schema.events_statements_summary_by_digest"
+}
+
+// Version of MySQL from which scraper is available.
+func (ScrapePerfEventsStatementsSum) Version() float64 {
+	return 5.7
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapePerfEventsStatementsSum) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	// Timers here are returned in picoseconds.
+	perfEventsStatementsSumRows, err := db.QueryContext(ctx, perfEventsStatementsSumQuery)
+	if err != nil {
+		return err
+	}
+	defer perfEventsStatementsSumRows.Close()
+
+	var (
+		total, createdTmpDiskTables, createdTmpTables, errors uint64
+		lockTime, noGoodIndexUsed, noIndexUsed, rowsAffected  uint64
+		rowsExamined, rowsSent, selectFullJoin                uint64
+		selectFullRangeJoin, selectRange, selectRangeCheck    uint64
+		selectScan, sortMergePasses, sortRange, sortRows      uint64
+		sortScan, timerWait, warnings                         uint64
+	)
+
+	for perfEventsStatementsSumRows.Next() {
+		if err := perfEventsStatementsSumRows.Scan(
+			&total, &createdTmpDiskTables, &createdTmpTables, &errors,
+			&lockTime, &noGoodIndexUsed, &noIndexUsed, &rowsAffected,
+			&rowsExamined, &rowsSent, &selectFullJoin,
+			&selectFullRangeJoin, &selectRange, &selectRangeCheck,
+			&selectScan, &sortMergePasses, &sortRange, &sortRows,
+			&sortScan, &timerWait, &warnings,
+		); err != nil {
+			return err
+		}
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsSumTotalDesc, prometheus.CounterValue, float64(total),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsSumCreatedTmpDiskTablesDesc, prometheus.CounterValue, float64(createdTmpDiskTables),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsSumCreatedTmpTablesDesc, prometheus.CounterValue, float64(createdTmpTables),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsSumErrorsDesc, prometheus.CounterValue, float64(errors),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsSumLockTimeDesc, prometheus.CounterValue, float64(lockTime),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsSumNoGoodIndexUsedDesc, prometheus.CounterValue, float64(noGoodIndexUsed),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsSumNoIndexUsedDesc, prometheus.CounterValue, float64(noIndexUsed),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsSumRowsAffectedDesc, prometheus.CounterValue, float64(rowsAffected),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsSumRowsExaminedDesc, prometheus.CounterValue, float64(rowsExamined),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsSumRowsSentDesc, prometheus.CounterValue, float64(rowsSent),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsSumSelectFullJoinDesc, prometheus.CounterValue, float64(selectFullJoin),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsSumSelectFullRangeJoinDesc, prometheus.CounterValue, float64(selectFullRangeJoin),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsSumSelectRangeDesc, prometheus.CounterValue, float64(selectRange),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsSumSelectRangeCheckDesc, prometheus.CounterValue, float64(selectRangeCheck),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsSumSelectScanDesc, prometheus.CounterValue, float64(selectScan),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsSumSortMergePassesDesc, prometheus.CounterValue, float64(sortMergePasses),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsSumSortRangeDesc, prometheus.CounterValue, float64(sortRange),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsSumSortRowsDesc, prometheus.CounterValue, float64(sortRows),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsSumSortScanDesc, prometheus.CounterValue, float64(sortScan),
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsSumTimerWaitDesc, prometheus.CounterValue, float64(timerWait)/picoSeconds,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsSumWarningsDesc, prometheus.CounterValue, float64(warnings),
+		)
+	}
+	return nil
+}
+
+// check interface
+var _ Scraper = ScrapePerfEventsStatementsSum{}

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -72,6 +72,7 @@ var scrapers = map[collector.Scraper]bool{
 	collector.ScrapePerfIndexIOWaits{}:                    false,
 	collector.ScrapePerfTableLockWaits{}:                  false,
 	collector.ScrapePerfEventsStatements{}:                false,
+	collector.ScrapePerfEventsStatementsSum{}:             false,
 	collector.ScrapePerfEventsWaits{}:                     false,
 	collector.ScrapePerfFileEvents{}:                      false,
 	collector.ScrapePerfFileInstances{}:                   false,


### PR DESCRIPTION
This PR adds collector with aggregated perf_schema.eventstatements metrics (when it makes sense).

The reason why I did this is that we have a lot of MySQL servers with different SQL queries and multiplication X by Y gives us an enormous number of series. We would like to monitor this values still, but it requires either complex setup of Prometheus servers with the federation, either switching off this collector on most of the servers.

Having this collector enables allows us to have an overview of all performance events, and thanks to `collect[]` parameter feature easily enable extra verbose collector on problematic ones.

Basically, this code is copied and modified `collector/perf_schema_events_statements.go` one.