### PR TITLE
Clear last_scrape_error on every scrape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The minimum supported MySQL version is now 5.5.
 
 * [CHANGE] Update defaults for MySQL 5.5 #318
 * [BUGFIX] Sanitize metric names in global variables #307
+* [BUGFIX] Clear last_scrape_error on every scrape (PR #368) #367
 * [FEATURE] Add by_user and by_host metrics to info_schema.processlist collector (PR #333) #334
 * [FEATURE] Add wsrep_evs_repl_latency metric collecting. (PR #338)
 * [FEATURE] Add collector for mysql.user (PR #341)

--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -150,6 +150,7 @@ func (e *Exporter) scrape(ctx context.Context, ch chan<- prometheus.Metric) {
 	}
 
 	e.metrics.MySQLUp.Set(1)
+	e.metrics.Error.Set(0)
 
 	ch <- prometheus.MustNewConstMetric(scrapeDurationDesc, prometheus.GaugeValue, time.Since(scrapeTime).Seconds(), "connection")
 


### PR DESCRIPTION
Clear last_scrape_error on every scrape, otherwise last_scrape_error
remains to be set to 1 despite the fact issue which has caused the error
in the first place is gone.

Fixes #367 