### PR TITLE
fix info_schema_processlist collector, binlog dump may cause ‘write to net‘ a huge number 

### DIFF
--- a/collector/info_schema_processlist.go
+++ b/collector/info_schema_processlist.go
@@ -135,8 +135,8 @@ var (
 		"other":                     uint32(0),
 	}
 	threadStateMapping = map[string]string{
-		"user sleep":                               "idle",
-		"creating index":                           "altering table",
+		"user sleep":     "idle",
+		"creating index": "altering table",
 		"committing alter table to storage engine": "altering table",
 		"discard or import tablespace":             "altering table",
 		"rename":                                   "altering table",


### PR DESCRIPTION
when binlog dump thread in 'writing to net' state, the value of metric `'mysql_info_schema_threads_seconds_by_user{state='writing to net'}' `can be a very huge number, which firing meaningless alerts.

move binlog dump cmd check before nomrmal state checker.