### PR TITLE
Update codespell settings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
     - checkout
     - run: sudo pip install codespell
-    - run: codespell --skip=".git,./vendor,ttar" -L uint
+    - run: codespell --skip=".git,./vendor,ttar,Makefile.common" -L uint,ist
 
   build:
     machine: true


### PR DESCRIPTION
This is a quick fix to unblock https://github.com/prometheus/mysqld_exporter/pull/387. `codespell` released a new version a few days ago that probably includes new checks.