### PR TITLE
fix binlog_size collection on mysql8

### DIFF
--- a/collector/binlog.go
+++ b/collector/binlog.go
@@ -88,17 +88,20 @@ func (ScrapeBinlogSize) Scrape(ctx context.Context, db *sql.DB, ch chan<- promet
 	defer masterLogRows.Close()
 
 	var (
-		size     uint64
-		count    uint64
-		filename string
-		filesize uint64
+		size      uint64
+		count     uint64
+		filename  string
+		filesize  uint64
+		encrypted string
 	)
 	size = 0
 	count = 0
 
 	for masterLogRows.Next() {
 		if err := masterLogRows.Scan(&filename, &filesize); err != nil {
-			return nil
+			if err := masterLogRows.Scan(&filename, &filesize, &encrypted); err != nil {
+				return nil
+			}
 		}
 		size += filesize
 		count++


### PR DESCRIPTION
As of [MySQL 8.0.14](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-14.html) the 'SHOW BINARY LOGS' command now has an additional column indicating the encrypted status of each binlog file. This extra column is breaking collector.binlog_size so that it no longer returns any data.

This PR will continue collecting the data the old way, but if it encounters an error unpacking the query results into 2 variables it will try again with 3 variables. I don't know if there is a better way to accomplish this, but it works fine in my tests.