### PR TITLE
Remove deprecated usage of prometheus/client_golang

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -274,8 +274,7 @@ func main() {
 		}
 	}
 	handlerFunc := newHandler(collector.NewMetrics(), enabledScrapers)
-	//lint:ignore SA1019 relax staticcheck verification.
-	http.HandleFunc(*metricPath, prometheus.InstrumentHandlerFunc("metrics", handlerFunc))
+	http.Handle(*metricPath, promhttp.InstrumentMetricHandler(prometheus.DefaultRegisterer, handlerFunc))
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write(landingPage)
 	})


### PR DESCRIPTION
Note that the next release of client_golang will remove all deprecated
features.

Note that this _will_ change the metrics about the exposition itself.