### PR TITLE
fixing deprecated MAINTAINER parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG ARCH="amd64"
 ARG OS="linux"
-FROM        quay.io/prometheus/busybox:latest
-MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
+FROM   quay.io/prometheus/busybox:latest
+LABEL  maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
 ARG ARCH="amd64"
 ARG OS="linux"


### PR DESCRIPTION
`MAINTAINER` parameter is deprecated. `LABEL "key=value` must be used.