### PR TITLE
Add option to skip tls hostname verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * [ENHANCEMENT]
 * [FEATURE]
 
+* [FEATURE] Add `tls.insecure-skip-verify` flag to ignore tls verification errors (PR #417) #348
+
 ## 0.12.1 / 2019-07-10
 
 ### Changes:

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -53,6 +53,10 @@ var (
 		"config.my-cnf",
 		"Path to .my.cnf file to read MySQL credentials from.",
 	).Default(path.Join(os.Getenv("HOME"), ".my.cnf")).String()
+	tlsSkipVerify = kingpin.Flag(
+		"tls.skip-verify",
+		"Ignore hostname verification when using a tls connection.",
+	).Bool()
 	dsn string
 )
 
@@ -150,6 +154,10 @@ func customizeTLS(sslCA string, sslCert string, sslKey string) error {
 		}
 		certPairs = append(certPairs, keypair)
 		tlsCfg.Certificates = certPairs
+
+		if *tlsSkipVerify {
+			tlsCfg.InsecureSkipVerify = true
+		}
 	}
 	mysql.RegisterTLSConfig("custom", &tlsCfg)
 	return nil

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -53,9 +53,9 @@ var (
 		"config.my-cnf",
 		"Path to .my.cnf file to read MySQL credentials from.",
 	).Default(path.Join(os.Getenv("HOME"), ".my.cnf")).String()
-	tlsSkipVerify = kingpin.Flag(
-		"tls.skip-verify",
-		"Ignore hostname verification when using a tls connection.",
+	tlsInsecureSkipVerify = kingpin.Flag(
+		"tls.insecure-skip-verify",
+		"Ignore certificate and server verification when using a tls connection.",
 	).Bool()
 	dsn string
 )
@@ -155,7 +155,7 @@ func customizeTLS(sslCA string, sslCert string, sslKey string) error {
 		certPairs = append(certPairs, keypair)
 		tlsCfg.Certificates = certPairs
 
-		if *tlsSkipVerify {
+		if *tlsInsecureSkipVerify {
 			tlsCfg.InsecureSkipVerify = true
 		}
 	}

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -154,10 +154,7 @@ func customizeTLS(sslCA string, sslCert string, sslKey string) error {
 		}
 		certPairs = append(certPairs, keypair)
 		tlsCfg.Certificates = certPairs
-
-		if *tlsInsecureSkipVerify {
-			tlsCfg.InsecureSkipVerify = true
-		}
+		tlsCfg.InsecureSkipVerify = *tlsInsecureSkipVerify
 	}
 	mysql.RegisterTLSConfig("custom", &tlsCfg)
 	return nil


### PR DESCRIPTION
This is useful in cases where the provided certs do not include hostname
information, such as GCP's SQL instances.

Closes #348