### PR TITLE
Only build in travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,5 @@ before_script:
 - docker-compose up -d
 
 script:
-- make
+- make build
 - make test


### PR DESCRIPTION
No need to run the full test suite in Travis, this is handled by
CircleCI.

Signed-off-by: Ben Kochie <superq@gmail.com>