### PR TITLE
README.md: mention MariaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 Prometheus exporter for MySQL server metrics.
 
-Supported MySQL versions: 5.5 and up.
+Supported MySQL & MariaDB versions: 5.5 and up.
 
-NOTE: Not all collection methods are supported on MySQL < 5.6
+NOTE: Not all collection methods are supported on MySQL/MariaDB < 5.6
 
 ## Building and running
 


### PR DESCRIPTION
As mentioned in #187, it makes sense to mention explicitly that this exporter supports MariaDB in addition to MySQL.