### PR TITLE
Add collector for AWS Aurora information_schema.replica_host_status

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ collect.info_schema.innodb_cmpmem                            | 5.5           | C
 collect.info_schema.processlist                              | 5.1           | Collect thread state counts from information_schema.processlist.
 collect.info_schema.processlist.min_time                     | 5.1           | Minimum time a thread must be in each state to be counted. (default: 0)
 collect.info_schema.query_response_time                      | 5.5           | Collect query response time distribution if query_response_time_stats is ON.
+collect.info_schema.replica_host                             | 5.6           | Collect metrics from information_schema.replica_host_status.
 collect.info_schema.tables                                   | 5.1           | Collect metrics from information_schema.tables.
 collect.info_schema.tables.databases                         | 5.1           | The list of databases to collect table stats for, or '`*`' for all.
 collect.info_schema.tablestats                               | 5.1           | If running with userstat=1, set to true to collect table statistics.

--- a/collector/info_schema_replica_host.go
+++ b/collector/info_schema_replica_host.go
@@ -1,0 +1,156 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Scrape `information_schema.replica_host_status`.
+
+package collector
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
+)
+
+const (
+	replicaHostCheckQuery = `
+	  SELECT count(*)
+		FROM information_schema.tables
+	   WHERE table_schema='information_schema'
+		 AND table_name='replica_host_status'
+	`
+	replicaHostQuery = `
+	  SELECT SERVER_ID
+		   , if(SESSION_ID='MASTER_SESSION_ID','writer','reader') AS ROLE
+		   , CPU
+		   , MASTER_SLAVE_LATENCY_IN_MICROSECONDS
+		   , REPLICA_LAG_IN_MILLISECONDS
+		   , LOG_STREAM_SPEED_IN_KiB_PER_SECOND
+		   , CURRENT_REPLAY_LATENCY_IN_MICROSECONDS
+		FROM information_schema.replica_host_status
+	`
+)
+
+// Metric descriptors.
+var (
+	infoSchemaReplicaHostCpuDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, informationSchema, "replica_host_cpu_percent"),
+		"The CPU usage as a percentage.",
+		[]string{"server_id", "role"}, nil,
+	)
+	infoSchemaReplicaHostSlaveLatencyDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, informationSchema, "replica_host_slave_latency_seconds"),
+		"The master-slave latency in seconds.",
+		[]string{"server_id", "role"}, nil,
+	)
+	infoSchemaReplicaHostLagDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, informationSchema, "replica_host_lag_seconds"),
+		"The replica lag in seconds.",
+		[]string{"server_id", "role"}, nil,
+	)
+	infoSchemaReplicaHostLogStreamSpeedDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, informationSchema, "replica_host_log_stream_speed"),
+		"The log stream speed in kilobytes per second.",
+		[]string{"server_id", "role"}, nil,
+	)
+	infoSchemaReplicaHostReplayLatencyDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, informationSchema, "replica_host_replay_latency_seconds"),
+		"The current replay latency in seconds.",
+		[]string{"server_id", "role"}, nil,
+	)
+)
+
+// ScrapeReplicaHost collects from `information_schema.replica_host_status`.
+type ScrapeReplicaHost struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapeReplicaHost) Name() string {
+	return "info_schema.replica_host"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapeReplicaHost) Help() string {
+	return "Collect metrics from information_schema.replica_host_status"
+}
+
+// Version of MySQL from which scraper is available.
+func (ScrapeReplicaHost) Version() float64 {
+	return 5.6
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapeReplicaHost) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric) error {
+	var count int64
+	err := db.QueryRowContext(ctx, replicaHostCheckQuery).Scan(&count)
+	if err != nil {
+		return err
+	}
+	if count == 0 {
+		log.Debug("information_schema.replica_host_status is not available")
+		return nil
+	}
+
+	replicaHostRows, err := db.QueryContext(ctx, replicaHostQuery)
+	if err != nil {
+		return err
+	}
+	defer replicaHostRows.Close()
+
+	var (
+		serverId       string
+		role           string
+		cpu            float64
+		slaveLatency   uint64
+		replicaLag     float64
+		logStreamSpeed float64
+		replayLatency  uint64
+	)
+	for replicaHostRows.Next() {
+		if err := replicaHostRows.Scan(
+			&serverId,
+			&role,
+			&cpu,
+			&slaveLatency,
+			&replicaLag,
+			&logStreamSpeed,
+			&replayLatency,
+		); err != nil {
+			return err
+		}
+		ch <- prometheus.MustNewConstMetric(
+			infoSchemaReplicaHostCpuDesc, prometheus.GaugeValue, cpu,
+			serverId, role,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			infoSchemaReplicaHostSlaveLatencyDesc, prometheus.GaugeValue, float64(slaveLatency)*0.000001,
+			serverId, role,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			infoSchemaReplicaHostLagDesc, prometheus.GaugeValue, replicaLag*0.001,
+			serverId, role,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			infoSchemaReplicaHostLogStreamSpeedDesc, prometheus.GaugeValue, logStreamSpeed,
+			serverId, role,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			infoSchemaReplicaHostReplayLatencyDesc, prometheus.GaugeValue, float64(replayLatency)*0.000001,
+			serverId, role,
+		)
+	}
+	return nil
+}
+
+// check interface
+var _ Scraper = ScrapeReplicaHost{}

--- a/collector/info_schema_replica_host_test.go
+++ b/collector/info_schema_replica_host_test.go
@@ -1,0 +1,74 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/smartystreets/goconvey/convey"
+)
+
+func TestScrapeReplicaHost(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("error opening a stub database connection: %s", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(sanitizeQuery(replicaHostCheckQuery)).WillReturnRows(sqlmock.NewRows([]string{"count(*)"}).
+		AddRow(1))
+
+	columns := []string{"SERVER_ID", "ROLE", "CPU", "MASTER_SLAVE_LATENCY_IN_MICROSECONDS", "REPLICA_LAG_IN_MILLISECONDS", "LOG_STREAM_SPEED_IN_KiB_PER_SECOND", "CURRENT_REPLAY_LATENCY_IN_MICROSECONDS"}
+	rows := sqlmock.NewRows(columns).
+		AddRow("dbtools-cluster-us-west-2c", "reader", 1.2531328201293945, 250000, 20.069000244140625, 2.0368164549078225, 500000).
+		AddRow("dbtools-cluster-writer", "writer", 1.9607843160629272, 250000, 0, 2.0368164549078225, 0)
+	mock.ExpectQuery(sanitizeQuery(replicaHostQuery)).WillReturnRows(rows)
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		if err = (ScrapeReplicaHost{}).Scrape(context.Background(), db, ch); err != nil {
+			t.Errorf("error calling function on test: %s", err)
+		}
+		close(ch)
+	}()
+
+	expected := []MetricResult{
+		{labels: labelMap{"server_id": "dbtools-cluster-us-west-2c", "role": "reader"}, value: 1.2531328201293945, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"server_id": "dbtools-cluster-us-west-2c", "role": "reader"}, value: 0.25, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"server_id": "dbtools-cluster-us-west-2c", "role": "reader"}, value: 0.020069000244140625, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"server_id": "dbtools-cluster-us-west-2c", "role": "reader"}, value: 2.0368164549078225, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"server_id": "dbtools-cluster-us-west-2c", "role": "reader"}, value: 0.5, metricType: dto.MetricType_GAUGE},
+
+		{labels: labelMap{"server_id": "dbtools-cluster-writer", "role": "writer"}, value: 1.9607843160629272, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"server_id": "dbtools-cluster-writer", "role": "writer"}, value: 0.25, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"server_id": "dbtools-cluster-writer", "role": "writer"}, value: 0.0, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"server_id": "dbtools-cluster-writer", "role": "writer"}, value: 2.0368164549078225, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"server_id": "dbtools-cluster-writer", "role": "writer"}, value: 0.0, metricType: dto.MetricType_GAUGE},
+	}
+	convey.Convey("Metrics comparison", t, func() {
+		for _, expect := range expected {
+			got := readMetric(<-ch)
+			convey.So(expect, convey.ShouldResemble, got)
+		}
+	})
+
+	// Ensure all SQL queries were executed
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled exceptions: %s", err)
+	}
+}

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -96,6 +96,7 @@ var scrapers = map[collector.Scraper]bool{
 	collector.ScrapeEngineInnodbStatus{}:                  false,
 	collector.ScrapeHeartbeat{}:                           false,
 	collector.ScrapeSlaveHosts{}:                          false,
+	collector.ScrapeReplicaHost{}:                         false,
 }
 
 func parseMycnf(config interface{}) (string, error) {


### PR DESCRIPTION
This adds a collector for metrics in Amazon Aurora's information_schema.replica_host_status table, that are suitable for Prometheus:

mysql_info_schema_replica_host_cpu_percent The CPU usage as a percentage.
mysql_info_schema_replica_host_lag_seconds The replica lag in seconds.
mysql_info_schema_replica_host_log_stream_speed The log stream speed in kilobytes per second.
mysql_info_schema_replica_host_replay_latency_seconds The current replay latency in seconds.
mysql_info_schema_replica_host_slave_latency_seconds The master - slave latency in seconds.
