### PR TITLE
Add target params to inject DSN from Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ The MySQL server's [data source name](http://en.wikipedia.org/wiki/Data_source_n
 must be set via the `DATA_SOURCE_NAME` environment variable.
 The format of this variable is described at https://github.com/go-sql-driver/mysql#dsn-data-source-name.
 
+`DATA_SOURCE_NAME` can overwrite via `target` query parameter.
+`http://localhost:9104/metrics?target=user:password@tcp(my-mysql-network:3306)/` will return metrics for a MySQL against `my-mysql-network:3306`.
 
 ## Customizing Configuration for a SSL Connection
 if The MySQL server supports SSL, you may need to specify a CA truststore to verify the server's chain-of-trust. You may also need to specify a SSL keypair for the client side of the SSL connection. To configure the mysqld exporter to use a custom CA certificate, add the following to the mysql cnf file:

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -211,6 +211,11 @@ func newHandler(metrics collector.Metrics, scrapers []collector.Scraper, logger 
 			}
 		}
 
+		target := r.URL.Query().Get("target")
+		if target != "" {
+			dsn = target
+		}
+
 		registry := prometheus.NewRegistry()
 		registry.MustRegister(collector.New(ctx, dsn, metrics, filteredScrapers, logger))
 


### PR DESCRIPTION
This makes it possible to overwrite `DATA_SOURCE_NAME` via `target` params like [blackbox_exporter](https://github.com/prometheus/blackbox_exporter).

## Motivation 

We want to monitor multiple MySQL databases (e.g. AWS RDS) with one mysqld_exporter.
Motivation is the same as https://github.com/prometheus/mysqld_exporter/pull/412 (We have 100+ RDSs, so we don't feel like managing 100+ mysqld_exporters).

And we also want to discover and monitor MySQL databases using Prometheus's service discovery.

## Prometheus configuration

Prometheus configuration is similar to the blackbox_exporter's one.

```
scrape_configs:
  - job_name: 'mysqld_exporter'
    static_configs:
      - targets:
        - user:password@tcp(my-mysql-network-1:3306)/
        - user:password@tcp(my-mysql-network-2:3306)/
    relabel_configs:
      - source_labels: [__address__]
        target_label: __param_target
      - source_labels: [__param_target]
        target_label: instance
      - target_label: __address__
        replacement: 127.0.0.1:9115  # The mysqld_exporter's real hostname:port.
```