### PR TITLE
Add collector for replication_group_members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [FEATURE]
 
 * [FEATURE] Add `tls.insecure-skip-verify` flag to ignore tls verification errors (PR #417) #348
+* [FEATURE] Add collector for replication_group_members (PR #459) #362
 
 ## 0.12.1 / 2019-07-10
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ collect.perf_schema.file_instances                           | 5.5           | C
 collect.perf_schema.indexiowaits                             | 5.6           | Collect metrics from performance_schema.table_io_waits_summary_by_index_usage.
 collect.perf_schema.tableiowaits                             | 5.6           | Collect metrics from performance_schema.table_io_waits_summary_by_table.
 collect.perf_schema.tablelocks                               | 5.6           | Collect metrics from performance_schema.table_lock_waits_summary_by_table.
-collect.perf_schema.replication_group_members                | 8.0           | Collect metrics from performance_schema.replication_group_members.
+collect.perf_schema.replication_group_members                | 5.7           | Collect metrics from performance_schema.replication_group_members.
 collect.perf_schema.replication_group_member_stats           | 5.7           | Collect metrics from performance_schema.replication_group_member_stats.
 collect.perf_schema.replication_applier_status_by_worker     | 5.7           | Collect metrics from performance_schema.replication_applier_status_by_worker.
 collect.slave_status                                         | 5.1           | Collect from SHOW SLAVE STATUS (Enabled by default)

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ collect.perf_schema.file_instances                           | 5.5           | C
 collect.perf_schema.indexiowaits                             | 5.6           | Collect metrics from performance_schema.table_io_waits_summary_by_index_usage.
 collect.perf_schema.tableiowaits                             | 5.6           | Collect metrics from performance_schema.table_io_waits_summary_by_table.
 collect.perf_schema.tablelocks                               | 5.6           | Collect metrics from performance_schema.table_lock_waits_summary_by_table.
+collect.perf_schema.replication_group_members                | 8.0           | Collect metrics from performance_schema.replication_group_members.
 collect.perf_schema.replication_group_member_stats           | 5.7           | Collect metrics from performance_schema.replication_group_member_stats.
 collect.perf_schema.replication_applier_status_by_worker     | 5.7           | Collect metrics from performance_schema.replication_applier_status_by_worker.
 collect.slave_status                                         | 5.1           | Collect from SHOW SLAVE STATUS (Enabled by default)

--- a/collector/perf_schema_replication_group_members.go
+++ b/collector/perf_schema_replication_group_members.go
@@ -1,0 +1,106 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const perfReplicationGroupMemebersQuery = `
+	SELECT CHANNEL_NAME,MEMBER_ID,MEMBER_HOST,MEMBER_PORT,MEMBER_STATE,MEMBER_ROLE,MEMBER_VERSION
+	  FROM performance_schema.replication_group_members
+	`
+
+// Metric descriptors.
+var (
+	performanceSchemaReplicationGroupMembersMemberDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "replication_group_member"),
+		"Information about the replication group member: "+
+			"channel_name, member_id, member_host, member_port, member_state, member_role, member_version. ",
+
+		/*	channel_name: Name of the Group Replication channel.
+			member_id:  The member server UUID. This has a different value for each member in the group. This also serves as a key because it is unique to each member.
+			member_host:  Network address of this member (host name or IP address). Retrieved from the member's hostname variable.
+				This is the address which clients connect to, unlike the group_replication_local_address which is used for internal group communication.
+			member_port: Port on which the server is listening. Retrieved from the member's port variable.
+			member_state: Current state of this member; can be any one of the following:
+				ONLINE: The member is in a fully functioning state.
+				RECOVERING: The server has joined a group from which it is retrieving data.
+				OFFLINE: The group replication plugin is installed but has not been started.
+				ERROR: The member has encountered an error, either during applying transactions or during the recovery phase, and is not participating in the group's transactions.
+				UNREACHABLE: The failure detection process suspects that this member cannot be contacted, because the group messages have timed out.
+			member_role: Role of the member in the group, either PRIMARY or SECONDARY.
+			member_version: MySQL version of the member.
+		*/
+
+		[]string{"channel_name", "member_id", "member_host", "member_port", "member_state", "member_role", "member_version"}, nil,
+	)
+)
+
+// ScrapeReplicationGroupMembers collects from `performance_schema.replication_group_members`.
+type ScrapePerfReplicationGroupMembers struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapePerfReplicationGroupMembers) Name() string {
+	return performanceSchema + ".replication_group_members"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapePerfReplicationGroupMembers) Help() string {
+	return "Collect metrics from performance_schema.replication_group_members"
+}
+
+// Version of MySQL from which scraper is available.
+func (ScrapePerfReplicationGroupMembers) Version() float64 {
+	return 8.0
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapePerfReplicationGroupMembers) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric, logger log.Logger) error {
+	perfReplicationGroupMembersRows, err := db.QueryContext(ctx, perfReplicationGroupMemebersQuery)
+	if err != nil {
+		return err
+	}
+	defer perfReplicationGroupMembersRows.Close()
+
+	var (
+		channelName   string
+		memberId      string
+		memberHost    string
+		memberPort    string
+		memberState   string
+		memberRole    string
+		memberVersion string
+	)
+
+	for perfReplicationGroupMembersRows.Next() {
+		if err := perfReplicationGroupMembersRows.Scan(
+			&channelName, &memberId, &memberHost, &memberPort, &memberState, &memberRole, &memberVersion,
+		); err != nil {
+			return err
+		}
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaReplicationGroupMembersMemberDesc, prometheus.GaugeValue, 1,
+			channelName, memberId, memberHost, memberPort, memberState, memberRole, memberVersion,
+		)
+	}
+	return nil
+}
+
+// check interface
+var _ Scraper = ScrapePerfReplicationGroupMembers{}

--- a/collector/perf_schema_replication_group_members.go
+++ b/collector/perf_schema_replication_group_members.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Prometheus Authors
+// Copyright 2020 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -24,13 +24,24 @@ import (
 )
 
 const perfReplicationGroupMembersQueryWithAdditionalCols = `
-	SELECT CHANNEL_NAME,MEMBER_ID,MEMBER_HOST,MEMBER_PORT,MEMBER_STATE,MEMBER_ROLE,MEMBER_VERSION
-	  FROM performance_schema.replication_group_members
+  SELECT
+    CHANNEL_NAME,
+    MEMBER_ID,
+    MEMBER_HOST,
+    MEMBER_PORT,
+    MEMBER_STATE,
+    MEMBER_ROLE,
+    MEMBER_VERSION
+  FROM performance_schema.replication_group_members
 	`
-
 const perfReplicationGroupMembersQuery = `
-	SELECT CHANNEL_NAME,MEMBER_ID,MEMBER_HOST,MEMBER_PORT,MEMBER_STATE
-	  FROM performance_schema.replication_group_members
+  SELECT 
+    CHANNEL_NAME,
+    MEMBER_ID,
+    MEMBER_HOST,
+    MEMBER_PORT,
+    MEMBER_STATE
+  FROM performance_schema.replication_group_members
 	`
 
 // Metric descriptors.
@@ -134,7 +145,7 @@ func getPerfReplicationGroupMembersQuery(ctx context.Context, db *sql.DB, logger
 		_, err := db.QueryContext(ctx, activeQuery)
 		if err != nil {
 			if mysqlErr, ok := err.(*MySQL.MySQLError); ok { // Now the error number is accessible directly
-				// Check for error 1054: Unknown column
+				// Check for error 1054: Unknown column.
 				if mysqlErr.Number == 1054 {
 					level.Debug(logger).Log("msg", "Additional columns for performance_schema.replication_group_members are not available.")
 					activeQuery = perfReplicationGroupMembersQuery

--- a/collector/perf_schema_replication_group_members.go
+++ b/collector/perf_schema_replication_group_members.go
@@ -66,17 +66,19 @@ func (ScrapePerfReplicationGroupMembers) Scrape(ctx context.Context, db *sql.DB,
 			return err
 		}
 
+		var labelNames = make([]string, len(columnNames))
 		var values = make([]string, len(columnNames))
-		for i := range columnNames {
+		for i, columnName := range columnNames {
+			labelNames[i] = strings.ToLower(columnName)
 			values[i] = string(*scanArgs[i].(*sql.RawBytes))
 		}
 
 		var performanceSchemaReplicationGroupMembersMemberDesc = prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, performanceSchema, "replication_group_member"),
+			prometheus.BuildFQName(namespace, performanceSchema, "replication_group_member_info"),
 			"Information about the replication group member: "+
 				"channel_name, member_id, member_host, member_port, member_state. "+
 				"(member_role and member_version where available)",
-			toLowerCase(columnNames), nil,
+			labelNames, nil,
 		)
 
 		ch <- prometheus.MustNewConstMetric(performanceSchemaReplicationGroupMembersMemberDesc,
@@ -84,14 +86,6 @@ func (ScrapePerfReplicationGroupMembers) Scrape(ctx context.Context, db *sql.DB,
 	}
 	return nil
 
-}
-
-func toLowerCase(original []string) []string {
-	lowerCase := make([]string, len(original))
-	for i, v := range original {
-		lowerCase[i] = strings.ToLower(v)
-	}
-	return lowerCase
 }
 
 // check interface

--- a/collector/perf_schema_replication_group_members_test.go
+++ b/collector/perf_schema_replication_group_members_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Prometheus Authors
+// Copyright 2020 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -73,7 +73,8 @@ func TestScrapePerfReplicationGroupMembers(t *testing.T) {
 		}
 	})
 
-	// Ensure all SQL queries were executed
+	// Ensure all SQL queries were executed.
+	// Ensure all SQL queries were executed.
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled exceptions: %s", err)
 	}
@@ -129,7 +130,7 @@ func TestScrapePerfReplicationGroupMembersMySQL57(t *testing.T) {
 		}
 	})
 
-	// Ensure all SQL queries were executed
+	// Ensure all SQL queries were executed.
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled exceptions: %s", err)
 	}

--- a/collector/perf_schema_replication_group_members_test.go
+++ b/collector/perf_schema_replication_group_members_test.go
@@ -1,0 +1,76 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"context"
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+func TestScrapePerfReplicationGroupMembers(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("error opening a stub database connection: %s", err)
+	}
+	defer db.Close()
+
+	columns := []string{
+		"CHANNEL_NAME",
+		"MEMBER_ID",
+		"MEMBER_HOST",
+		"MEMBER_PORT",
+		"MEMBER_STATE",
+		"MEMBER_ROLE",
+		"MEMBER_VERSION",
+	}
+
+	rows := sqlmock.NewRows(columns).
+		AddRow("group_replication_applier", "uuid1", "hostname1", "3306", "ONLINE", "PRIMARY", "8.0.19").
+		AddRow("group_replication_applier", "uuid2", "hostname2", "3306", "ONLINE", "SECONDARY", "8.0.19").
+		AddRow("group_replication_applier", "uuid3", "hostname3", "3306", "ONLINE", "SECONDARY", "8.0.19")
+	mock.ExpectQuery(sanitizeQuery(perfReplicationGroupMemebersQuery)).WillReturnRows(rows)
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		if err = (ScrapePerfReplicationGroupMembers{}).Scrape(context.Background(), db, ch, log.NewNopLogger()); err != nil {
+			t.Errorf("error calling function on test: %s", err)
+		}
+		close(ch)
+	}()
+
+	metricExpected := []MetricResult{
+		{labels: labelMap{"channel_name": "group_replication_applier", "member_id": "uuid1", "member_host": "hostname1", "member_port": "3306",
+			"member_state": "ONLINE", "member_role": "PRIMARY", "member_version": "8.0.19"}, value: 1, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"channel_name": "group_replication_applier", "member_id": "uuid2", "member_host": "hostname2", "member_port": "3306",
+			"member_state": "ONLINE", "member_role": "SECONDARY", "member_version": "8.0.19"}, value: 1, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"channel_name": "group_replication_applier", "member_id": "uuid3", "member_host": "hostname3", "member_port": "3306",
+			"member_state": "ONLINE", "member_role": "SECONDARY", "member_version": "8.0.19"}, value: 1, metricType: dto.MetricType_GAUGE},
+	}
+	convey.Convey("Metrics comparison", t, func() {
+		for _, expect := range metricExpected {
+			got := readMetric(<-ch)
+			convey.So(got, convey.ShouldResemble, expect)
+		}
+	})
+
+	// Ensure all SQL queries were executed
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled exceptions: %s", err)
+	}
+}

--- a/collector/perf_schema_replication_group_members_test.go
+++ b/collector/perf_schema_replication_group_members_test.go
@@ -71,7 +71,6 @@ func TestScrapePerfReplicationGroupMembers(t *testing.T) {
 	})
 
 	// Ensure all SQL queries were executed.
-	// Ensure all SQL queries were executed.
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled exceptions: %s", err)
 	}

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -83,6 +83,7 @@ var scrapers = map[collector.Scraper]bool{
 	collector.ScrapePerfEventsWaits{}:                     false,
 	collector.ScrapePerfFileEvents{}:                      false,
 	collector.ScrapePerfFileInstances{}:                   false,
+	collector.ScrapePerfReplicationGroupMembers{}:         false,
 	collector.ScrapePerfReplicationGroupMemberStats{}:     false,
 	collector.ScrapePerfReplicationApplierStatsByWorker{}: false,
 	collector.ScrapeUserStat{}:                            false,


### PR DESCRIPTION
Fixes #362 

The scraper sends a new Gauge metric with a static value of 1 and labels corresponding to columns of the replication_group_members table. I made this choice because the labels are very much static - if there's an idea for something more elegant I'm quite happy to change it :relaxed: 

Both 5.7 and 8.0 are supported, by way of a different query for each. The first query sent is used to determine whether the additional columns present in the 8.0 schema are there, and falls back to the 5.7 schema.

Hope this makes sense..
