### PR TITLE
Support heartbeats in UTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ collect.slave_hosts                                          | 5.1           | C
 collect.heartbeat                                            | 5.1           | Collect from [heartbeat](#heartbeat).
 collect.heartbeat.database                                   | 5.1           | Database from where to collect heartbeat data. (default: heartbeat)
 collect.heartbeat.table                                      | 5.1           | Table from where to collect heartbeat data. (default: heartbeat)
+collect.heartbeat.utc                                        | 5.1           | Use UTC for timestamps of the current server (`pt-heartbeat` is called with `--utc`). (default: false)
 
 
 ### General Flags


### PR DESCRIPTION
`pt-heartbeat` supports UTC for heartbeat timestamps.

> The heartbeat table requires at least one row. If you manually create the heartbeat table, then you must insert a row by doing:
> 
> ```sql
> INSERT INTO heartbeat (ts, server_id) VALUES (NOW(), N);
> ```
> or if using `--utc`:
> ```sql
> INSERT INTO heartbeat (ts, server_id) VALUES (UTC_TIMESTAMP(), N);
> ```

https://www.percona.com/doc/percona-toolkit/LATEST/pt-heartbeat.html#cmdoption-pt-heartbeat-utc

When I started playing with `mysqld_exporter` I noticed 7200 second gap between heartbeat metrics. I understood that MySQL server was using the system timezone (https://time.is/CET), but the heartbeat timestamps were in UTC. 

This patch allows configuring the heartbeat collector to be consistent in such cases.