### PR TITLE
Add tls.insecure-skip-verify flag to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ config.my-cnf                              | Path to .my.cnf file to read MySQL 
 log.level                                  | Logging verbosity (default: info)
 exporter.lock_wait_timeout                 | Set a lock_wait_timeout on the connection to avoid long metadata locking. (default: 2 seconds)
 exporter.log_slow_filter                   | Add a log_slow_filter to avoid slow query logging of scrapes.  NOTE: Not supported by Oracle MySQL.
+tls.insecure-skip-verify                   | Ignore tls verification errors.
 web.listen-address                         | Address to listen on for web interface and telemetry.
 web.telemetry-path                         | Path under which to expose metrics.
 version                                    | Print the version information.


### PR DESCRIPTION
This flag isn't documented. I needed it to be able to connect to a Google CloudSQL instance that requires SSL. The flag was add to the code in Aug. 2019.