### PR TITLE
Add heartbeat lag metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Changes related to `replication_group_member_stats` collector:
 * renamed 3 metrics starting with `mysql_perf_schema_transaction_` to start with `mysql_perf_schema_transactions_` to be consistent with column names
 * exposing only server's own stats by matching MEMBER_ID with @@server_uuid resulting "member_id" label to be dropped.
 
+Changes related to `heartbeat` collector:
+* metric "mysql_heartbeat_lag_seconds" replaced "mysql_heartbeat_now_timestamp_seconds" #479
+
 ## 0.12.1 / 2019-07-10
 
 ### Changes:

--- a/collector/heartbeat.go
+++ b/collector/heartbeat.go
@@ -63,6 +63,11 @@ var (
 		"Timestamp of the current server.",
 		[]string{"server_id"}, nil,
 	)
+	HeartbeatLagDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, heartbeat, "lag_seconds"),
+		"Heartbeat lag of the current server.",
+		[]string{"server_id"}, nil,
+	)
 )
 
 // ScrapeHeartbeat scrapes from the heartbeat table.
@@ -138,6 +143,12 @@ func (ScrapeHeartbeat) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometh
 			HeartbeatStoredDesc,
 			prometheus.GaugeValue,
 			tsFloatVal,
+			serverId,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			HeartbeatLagDesc,
+			prometheus.GaugeValue,
+			nowFloatVal-tsFloatVal,
 			serverId,
 		)
 	}

--- a/collector/heartbeat_test.go
+++ b/collector/heartbeat_test.go
@@ -78,9 +78,12 @@ func TestScrapeHeartbeat(t *testing.T) {
 				close(ch)
 			}()
 
+			tsVal, nowVal := 1487597613.00132, 1487598113.448042
+
 			counterExpected := []MetricResult{
-				{labels: labelMap{"server_id": "1"}, value: 1487598113.448042, metricType: dto.MetricType_GAUGE},
-				{labels: labelMap{"server_id": "1"}, value: 1487597613.00132, metricType: dto.MetricType_GAUGE},
+				{labels: labelMap{"server_id": "1"}, value: nowVal, metricType: dto.MetricType_GAUGE},
+				{labels: labelMap{"server_id": "1"}, value: tsVal, metricType: dto.MetricType_GAUGE},
+				{labels: labelMap{"server_id": "1"}, value: nowVal - tsVal, metricType: dto.MetricType_GAUGE},
 			}
 			convey.Convey("Metrics comparison", t, func() {
 				for _, expect := range counterExpected {

--- a/example.rules
+++ b/example.rules
@@ -12,9 +12,6 @@
 # `mysql_slave_status_sql_delay` into account
 mysql_slave_lag_seconds = mysql_slave_status_seconds_behind_master - mysql_slave_status_sql_delay
 
-# Record slave lag via heartbeat method
-mysql_heartbeat_lag_seconds = mysql_heartbeat_now_timestamp_seconds - mysql_heartbeat_stored_timestamp_seconds
-
 # Record "Transactions per second"
 # See: https://dev.mysql.com/doc/refman/5.7/en/glossary.html#glos_transaction
 job:mysql_transactions:rate5m = sum(rate(mysql_global_status_commands_total{command=~"(commit|rollback)"}[5m])) without (command)

--- a/example.rules.yml
+++ b/example.rules.yml
@@ -3,8 +3,6 @@ groups:
   rules:
   - record: mysql_slave_lag_seconds
     expr: mysql_slave_status_seconds_behind_master - mysql_slave_status_sql_delay
-  - record: mysql_heartbeat_lag_seconds
-    expr: mysql_heartbeat_now_timestamp_seconds - mysql_heartbeat_stored_timestamp_seconds
   - record: job:mysql_transactions:rate5m
     expr: sum(rate(mysql_global_status_commands_total{command=~"(commit|rollback)"}[5m]))
       WITHOUT (command)


### PR DESCRIPTION
Heartbeats are used to measure replication delay and alert on that.

While starting using `mysqld_exporter` I decided to create a recording rule to calculate an actual lag. But later I realized that the approach is completely incorrect - having multiple tiers of aggregation the recorded metric had "strange" values - it's unclear which samples were used in calculation.

```yaml
- record: mysql_heartbeat_lag_seconds
  expr: >
    mysql_heartbeat_now_timestamp_seconds - 
    mysql_heartbeat_stored_timestamp_seconds
```

<img width="400" alt="mysqld_exporter_repl" src="https://user-images.githubusercontent.com/3383891/84920144-14112280-b0c3-11ea-9cfd-bcf075fcacaa.png">

_The recorded metric at the top. A common metric at the bottom._

I suggest adding another metric `mysql_heartbeat_lag_seconds` which is calculated by the collector at each scrape so that the metric could be processed anyhow without correctness loss.

The metric can be used in an alerting rule right away. For example:

```yam
- alert: HighReplicationDelay
  expr: quantile_over_time(0.8, mysql_heartbeat_lag_seconds[5m]) > 5
```