### PR TITLE
Fix handling of DSN extra arguments

### DIFF
--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -92,7 +92,10 @@ func New(ctx context.Context, dsn string, metrics Metrics, scrapers []Scraper, l
 		dsnParams = append(dsnParams, sessionSettingsParam)
 	}
 
-	if strings.Contains(dsn, "?") {
+	dsnParts := strings.Split(dsn, "/")
+	lastDsnPart := dsnParts[len(dsnParts)-1]
+
+	if strings.Contains(lastDsnPart, "?") {
 		dsn = dsn + "&"
 	} else {
 		dsn = dsn + "?"


### PR DESCRIPTION
I believe this addresses the following issues

#458  #303  #376 

```
DATA_SOURCE_NAME="my-user:my-password-with&?-chars@(127.0.0.1:3306)/ ./mysqld_exporter
```

This fix will just look for `?` by checking only the chars that appear after the final `/` .

If there is no `/` in the DSN, then it's already being treated as an invalid DSN

```
invalid DSN: missing the slash separating the database name
```