### PR TITLE
Set InsecureSkipVerify always

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -158,8 +158,8 @@ func customizeTLS(sslCA string, sslCert string, sslKey string) error {
 		}
 		certPairs = append(certPairs, keypair)
 		tlsCfg.Certificates = certPairs
-		tlsCfg.InsecureSkipVerify = *tlsInsecureSkipVerify
 	}
+	tlsCfg.InsecureSkipVerify = *tlsInsecureSkipVerify
 	mysql.RegisterTLSConfig("custom", &tlsCfg)
 	return nil
 }


### PR DESCRIPTION
`tls.Config.InsecureSkipVerify` should be set always regardless of `sslCert` & `sslKey` when the flag is passed.

Otherwise, it causes an error when MySQL runs with enabled [require_secure_transport](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_require_secure_transport):

```
msg="Error pinging mysqld" err="Error 3159: Connections using insecure transport are prohibited while --require_secure_transport=ON."
```