### PR TITLE
fix log output of collect[] params

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -195,7 +196,7 @@ func newHandler(metrics collector.Metrics, scrapers []collector.Scraper, logger 
 				r = r.WithContext(ctx)
 			}
 		}
-		level.Debug(logger).Log("msg", "collect[] params", "params", params)
+		level.Debug(logger).Log("msg", "collect[] params", "params", strings.Join(params, "+"))
 
 		// Check if we have some "collect[]" query parameters.
 		if len(params) > 0 {

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -196,7 +196,7 @@ func newHandler(metrics collector.Metrics, scrapers []collector.Scraper, logger 
 				r = r.WithContext(ctx)
 			}
 		}
-		level.Debug(logger).Log("msg", "collect[] params", "params", strings.Join(params, "+"))
+		level.Debug(logger).Log("msg", "collect[] params", "params", strings.Join(params, ","))
 
 		// Check if we have some "collect[]" query parameters.
 		if len(params) > 0 {


### PR DESCRIPTION
The following codes always output 'msg="collect[] params" params="unsupported value type"'.
```
level.Debug(logger).Log("msg", "collect[] params", "params", params)
```

This "params" variable is slice, so should be split to string.

This is example log output by modified code.
```
msg="collect[] params" params=info_schema.innodb_cmp+nfo_schema.query_response_time
```
