### PR TITLE
Feat add ps memory collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
 * [FEATURE] Add `tls.insecure-skip-verify` flag to ignore tls verification errors (PR #417) #348
 * [FEATURE] Add new metrics to `replication_group_member_stats` collector to support MySQL 8.x.
 * [FEATURE] Add collector for `replication_group_members` (PR #459) #362
-* [BUGFIX] Fixed output value of wsrep_cluster_status #473
 * [FEATURE] Add collector for `performance_schema.memory_summary_global_by_event_name` (PR #515) #75
+* [BUGFIX] Fixed output value of wsrep_cluster_status #473
 
 ### BREAKING CHANGES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [FEATURE] Add new metrics to `replication_group_member_stats` collector to support MySQL 8.x.
 * [FEATURE] Add collector for `replication_group_members` (PR #459) #362
 * [BUGFIX] Fixed output value of wsrep_cluster_status #473
+* [FEATURE] Add collector for `performance_schema.memory_summary_global_by_event_name` (PR #515) #75
 
 ### BREAKING CHANGES:
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,10 @@ collect.perf_schema.eventsstatementssum                      | 5.7           | C
 collect.perf_schema.eventswaits                              | 5.5           | Collect metrics from performance_schema.events_waits_summary_global_by_event_name.
 collect.perf_schema.file_events                              | 5.6           | Collect metrics from performance_schema.file_summary_by_event_name.
 collect.perf_schema.file_instances                           | 5.5           | Collect metrics from performance_schema.file_summary_by_instance.
+collect.perf_schema.file_instances.remove_prefix             | 5.5           | Remove path prefix in performance_schema.file_summary_by_instance.
 collect.perf_schema.indexiowaits                             | 5.6           | Collect metrics from performance_schema.table_io_waits_summary_by_index_usage.
+collect.perf_schema.memory_events                            | 5.7           | Collect metrics from performance_schema.memory_summary_global_by_event_name.
+collect.perf_schema.memory_events.remove_prefix              | 5.7           | Remove instrument prefix in performance_schema.memory_summary_global_by_event_name.
 collect.perf_schema.tableiowaits                             | 5.6           | Collect metrics from performance_schema.table_io_waits_summary_by_table.
 collect.perf_schema.tablelocks                               | 5.6           | Collect metrics from performance_schema.table_lock_waits_summary_by_table.
 collect.perf_schema.replication_group_members                | 5.7           | Collect metrics from performance_schema.replication_group_members.

--- a/collector/perf_schema_file_instances.go
+++ b/collector/perf_schema_file_instances.go
@@ -40,15 +40,15 @@ var (
 		"collect.perf_schema.file_instances.filter",
 		"RegEx file_name filter for performance_schema.file_summary_by_instance",
 	).Default(".*").String()
-)
 
-// Metric descriptors.
-var (
 	performanceSchemaFileInstancesRemovePrefix = kingpin.Flag(
 		"collect.perf_schema.file_instances.remove_prefix",
 		"Remove path prefix in performance_schema.file_summary_by_instance",
 	).Default("/var/lib/mysql/").String()
+)
 
+// Metric descriptors.
+var (
 	performanceSchemaFileInstancesBytesDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, performanceSchema, "file_instances_bytes"),
 		"The number of bytes processed by file read/write operations.",

--- a/collector/perf_schema_memory_events.go
+++ b/collector/perf_schema_memory_events.go
@@ -44,12 +44,12 @@ var (
 // Metric descriptors.
 var (
 	performanceSchemaMemoryBytesAllocDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, performanceSchema, "memory_events_bytes_alloc_total"),
+		prometheus.BuildFQName(namespace, performanceSchema, "memory_events_alloc_bytes_total"),
 		"The total number of bytes allocated by events.",
 		[]string{"event_name"}, nil,
 	)
 	performanceSchemaMemoryBytesFreeDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, performanceSchema, "memory_events_bytes_free_total"),
+		prometheus.BuildFQName(namespace, performanceSchema, "memory_events_free_bytes_total"),
 		"The total number of bytes freed by events.",
 		[]string{"event_name"}, nil,
 	)

--- a/collector/perf_schema_memory_events.go
+++ b/collector/perf_schema_memory_events.go
@@ -1,0 +1,91 @@
+package collector
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const perfMemoryEventsQuery = `
+	SELECT
+		EVENT_NAME, SUM_NUMBER_OF_BYTES_ALLOC, SUM_NUMBER_OF_BYTES_FREE,
+		CURRENT_NUMBER_OF_BYTES_USED
+	FROM performance_schema.memory_summary_global_by_event_name
+		where COUNT_ALLOC > 0;
+`
+
+var (
+	performanceSchemaMemoryBytesAllocDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "memory_events_bytes_alloc_total"),
+		"The total number of bytes allocated by events.",
+		[]string{"event_name"}, nil,
+	)
+	performanceSchemaMemoryBytesFreeDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "memory_events_bytes_free_total"),
+		"The total number of bytes freed by events.",
+		[]string{"event_name"}, nil,
+	)
+	perforanceSchemaMemoryUsedBytesDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "memory_events_used_bytes"),
+		"The number of bytes currently allocated by events.",
+		[]string{"event_name"}, nil,
+	)
+)
+
+// ScrapePerfMemoryEvents collects from `performance_schema.memory_summary_global_by_event_name`.
+type ScrapePerfMemoryEvents struct{}
+
+// Name of the Scraper. Should be unique.
+func (ScrapePerfMemoryEvents) Name() string {
+	return "perf_schema.memory_events"
+}
+
+// Help describes the role of the Scraper.
+func (ScrapePerfMemoryEvents) Help() string {
+	return "Collect metrics from performance_schema.memory_summary_global_by_event_name"
+}
+
+// Version of MySQL from which scraper is available.
+func (ScrapePerfMemoryEvents) Version() float64 {
+	return 5.6
+}
+
+// Scrape collects data from database connection and sends it over channel as prometheus metric.
+func (ScrapePerfMemoryEvents) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric, logger log.Logger) error {
+	perfSchemaMemoryEventsRows, err := db.QueryContext(ctx, perfMemoryEventsQuery)
+	if err != nil {
+		return err
+	}
+	defer perfSchemaMemoryEventsRows.Close()
+
+	var (
+		eventName    string
+		bytesAlloc   uint64
+		bytesFree    uint64
+		currentBytes uint64
+	)
+
+	for perfSchemaMemoryEventsRows.Next() {
+		if err := perfSchemaMemoryEventsRows.Scan(
+			&eventName, &bytesAlloc, &bytesFree, &currentBytes,
+		); err != nil {
+			return err
+		}
+
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaMemoryBytesAllocDesc, prometheus.CounterValue, float64(bytesAlloc), eventName,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaMemoryBytesFreeDesc, prometheus.CounterValue, float64(bytesFree), eventName,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			perforanceSchemaMemoryUsedBytesDesc, prometheus.GaugeValue, float64(currentBytes), eventName,
+		)
+	}
+	return nil
+}
+
+// check interface
+var _ Scraper = ScrapePerfMemoryEvents{}

--- a/collector/perf_schema_memory_events.go
+++ b/collector/perf_schema_memory_events.go
@@ -1,3 +1,18 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Scrape `performance_schema.memory_summary_global_by_event_name`.
+
 package collector
 
 import (

--- a/collector/perf_schema_memory_events.go
+++ b/collector/perf_schema_memory_events.go
@@ -64,7 +64,7 @@ func (ScrapePerfMemoryEvents) Help() string {
 
 // Version of MySQL from which scraper is available.
 func (ScrapePerfMemoryEvents) Version() float64 {
-	return 5.6
+	return 5.7
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.

--- a/collector/perf_schema_memory_events_test.go
+++ b/collector/perf_schema_memory_events_test.go
@@ -1,3 +1,16 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package collector
 
 import (

--- a/collector/perf_schema_memory_events_test.go
+++ b/collector/perf_schema_memory_events_test.go
@@ -23,9 +23,15 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/smartystreets/goconvey/convey"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 func TestScrapePerfMemoryEvents(t *testing.T) {
+	_, err := kingpin.CommandLine.Parse([]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("error opening a stub database connection: %s", err)
@@ -54,15 +60,15 @@ func TestScrapePerfMemoryEvents(t *testing.T) {
 	}()
 
 	metricExpected := []MetricResult{
-		{labels: labelMap{"event_name": "memory/innodb/event1"}, value: 1001, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"event_name": "memory/innodb/event1"}, value: 500, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"event_name": "memory/innodb/event1"}, value: 501, metricType: dto.MetricType_GAUGE},
-		{labels: labelMap{"event_name": "memory/innodb/event2"}, value: 2002, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"event_name": "memory/innodb/event2"}, value: 1000, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"event_name": "memory/innodb/event2"}, value: 1002, metricType: dto.MetricType_GAUGE},
-		{labels: labelMap{"event_name": "memory/sql/event1"}, value: 30, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"event_name": "memory/sql/event1"}, value: 4, metricType: dto.MetricType_COUNTER},
-		{labels: labelMap{"event_name": "memory/sql/event1"}, value: 26, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"event_name": "innodb/event1"}, value: 1001, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"event_name": "innodb/event1"}, value: 500, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"event_name": "innodb/event1"}, value: 501, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"event_name": "innodb/event2"}, value: 2002, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"event_name": "innodb/event2"}, value: 1000, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"event_name": "innodb/event2"}, value: 1002, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"event_name": "sql/event1"}, value: 30, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"event_name": "sql/event1"}, value: 4, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"event_name": "sql/event1"}, value: 26, metricType: dto.MetricType_GAUGE},
 	}
 	convey.Convey("Metrics comparison", t, func() {
 		for _, expect := range metricExpected {

--- a/collector/perf_schema_memory_events_test.go
+++ b/collector/perf_schema_memory_events_test.go
@@ -1,0 +1,65 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/smartystreets/goconvey/convey"
+)
+
+func TestScrapePerfMemoryEvents(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("error opening a stub database connection: %s", err)
+	}
+	defer db.Close()
+
+	columns := []string{
+		"EVENT_NAME",
+		"SUM_NUMBER_OF_BYTES_ALLOC",
+		"SUM_NUMBER_OF_BYTES_FREE",
+		"CURRENT_NUMBER_OF_BYTES_USED",
+	}
+
+	rows := sqlmock.NewRows(columns).
+		AddRow("memory/innodb/event1", "1001", "500", "501").
+		AddRow("memory/innodb/event2", "2002", "1000", "1002").
+		AddRow("memory/sql/event1", "30", "4", "26")
+	mock.ExpectQuery(sanitizeQuery(perfMemoryEventsQuery)).WillReturnRows(rows)
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		if err = (ScrapePerfMemoryEvents{}).Scrape(context.Background(), db, ch, log.NewNopLogger()); err != nil {
+			panic(fmt.Sprintf("error calling function on test: %s", err))
+		}
+		close(ch)
+	}()
+
+	metricExpected := []MetricResult{
+		{labels: labelMap{"event_name": "memory/innodb/event1"}, value: 1001, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"event_name": "memory/innodb/event1"}, value: 500, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"event_name": "memory/innodb/event1"}, value: 501, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"event_name": "memory/innodb/event2"}, value: 2002, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"event_name": "memory/innodb/event2"}, value: 1000, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"event_name": "memory/innodb/event2"}, value: 1002, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"event_name": "memory/sql/event1"}, value: 30, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"event_name": "memory/sql/event1"}, value: 4, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"event_name": "memory/sql/event1"}, value: 26, metricType: dto.MetricType_GAUGE},
+	}
+	convey.Convey("Metrics comparison", t, func() {
+		for _, expect := range metricExpected {
+			got := readMetric(<-ch)
+			convey.So(got, convey.ShouldResemble, expect)
+		}
+	})
+
+	// Ensure all SQL queries were executed
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled exceptions: %s", err)
+	}
+}

--- a/go.sum
+++ b/go.sum
@@ -229,6 +229,7 @@ github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5Fsn
 github.com/prometheus/client_golang v1.3.0/go.mod h1:hJaj2vgQTGQmVCsAACORcieXFeDPbaTKGT+JTgUa3og=
 github.com/prometheus/client_golang v1.6.0 h1:YVPodQOcK15POxhgARIvnDRVpLcuK8mglnMrWfyrw6A=
 github.com/prometheus/client_golang v1.6.0/go.mod h1:ZLOG9ck3JLRdB5MgO8f+lLTe83AXG6ro35rLTxvnIl4=
+github.com/prometheus/client_golang v1.8.0 h1:zvJNkoCFAnYFNC24FV8nW4JdRJ3GIFcLbg65lL/JDcw=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 h1:idejC8f05m9MGOsuEi1ATq9shN03HrxNkD/luQvxCv8=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=

--- a/go.sum
+++ b/go.sum
@@ -229,7 +229,6 @@ github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5Fsn
 github.com/prometheus/client_golang v1.3.0/go.mod h1:hJaj2vgQTGQmVCsAACORcieXFeDPbaTKGT+JTgUa3og=
 github.com/prometheus/client_golang v1.6.0 h1:YVPodQOcK15POxhgARIvnDRVpLcuK8mglnMrWfyrw6A=
 github.com/prometheus/client_golang v1.6.0/go.mod h1:ZLOG9ck3JLRdB5MgO8f+lLTe83AXG6ro35rLTxvnIl4=
-github.com/prometheus/client_golang v1.8.0 h1:zvJNkoCFAnYFNC24FV8nW4JdRJ3GIFcLbg65lL/JDcw=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 h1:idejC8f05m9MGOsuEi1ATq9shN03HrxNkD/luQvxCv8=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -84,6 +84,7 @@ var scrapers = map[collector.Scraper]bool{
 	collector.ScrapePerfEventsWaits{}:                     false,
 	collector.ScrapePerfFileEvents{}:                      false,
 	collector.ScrapePerfFileInstances{}:                   false,
+	collector.ScrapePerfMemoryEvents{}:                    false,
 	collector.ScrapePerfReplicationGroupMembers{}:         false,
 	collector.ScrapePerfReplicationGroupMemberStats{}:     false,
 	collector.ScrapePerfReplicationApplierStatsByWorker{}: false,


### PR DESCRIPTION
This PR adds a collector for `performance_schema.memory_summary_global_by_event_name`, creating three metrics as described in #75 .

- The collector is disabled by default
- Include a flag to remove the `memory/` prefix from each event label for this metric.
- Tested locally against MySQL 5.6, 5.7 and 8.
- 5.6 doesn't have this table, so upon scrape, the exporter logs: 
```
level=error ts=2020-11-11T17:06:26.873Z caller=exporter.go:174 msg="Error from scraper" scraper=perf_schema.memory_events err="Error 1146: Table 'performance_schema.memory_summary_global_by_event_name' doesn't exist"
```
- Running against mysql:8 and mysql:5.7 with performance_schema=OFF, the exporter logs no errors and does not export any memory_events metrics, but does expose `mysql_exporter_collector_duration_seconds ` for the collector.

- Add new collector flags to the README. Also included missing flag for `file_instances.remove_prefix`.

