### PR TITLE
fix collect.info_schema.innodb_tablespaces for mariadb 10.3+ and mysq…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [FEATURE] Add collector for `replication_group_members` (PR #459) #362
 * [FEATURE] Add collector for `performance_schema.memory_summary_global_by_event_name` (PR #515) #75
 * [BUGFIX] Fixed output value of wsrep_cluster_status #473
+* [BUGFIX] Fix collect.info_schema.innodb_tablespaces for new table names #516
 
 ### BREAKING CHANGES:
 

--- a/collector/info_schema_innodb_sys_tablespaces_test.go
+++ b/collector/info_schema_innodb_sys_tablespaces_test.go
@@ -15,6 +15,7 @@ package collector
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -31,11 +32,18 @@ func TestScrapeInfoSchemaInnodbTablespaces(t *testing.T) {
 	}
 	defer db.Close()
 
-	columns := []string{"SPACE", "NAME", "FILE_FORMAT", "ROW_FORMAT", "SPACE_TYPE", "FILE_SIZE", "ALLOCATED_SIZE"}
+	columns := []string{"TABLE_NAME"}
 	rows := sqlmock.NewRows(columns).
+		AddRow("INNODB_SYS_TABLESPACES")
+	mock.ExpectQuery(sanitizeQuery(innodbTablespacesTablenameQuery)).WillReturnRows(rows)
+
+	tablespacesTablename := "INNODB_SYS_TABLESPACES"
+	columns = []string{"SPACE", "NAME", "FILE_FORMAT", "ROW_FORMAT", "SPACE_TYPE", "FILE_SIZE", "ALLOCATED_SIZE"}
+	rows = sqlmock.NewRows(columns).
 		AddRow(1, "sys/sys_config", "Barracuda", "Dynamic", "Single", 100, 100).
 		AddRow(2, "db/compressed", "Barracuda", "Compressed", "Single", 300, 200)
-	mock.ExpectQuery(sanitizeQuery(innodbTablespacesQuery)).WillReturnRows(rows)
+	query := fmt.Sprintf(innodbTablespacesQuery, tablespacesTablename, tablespacesTablename)
+	mock.ExpectQuery(sanitizeQuery(query)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
 	go func() {


### PR DESCRIPTION
made some changes so that collect.info_schema.innodb_tablespaces collection works for 10.3+ and mysql 8.0+
fixes #370 and #398 