### PR TITLE
bugfix: allow perf_schema.memory summary current_bytes to be negative

### DIFF
--- a/collector/perf_schema_memory_events.go
+++ b/collector/perf_schema_memory_events.go
@@ -90,7 +90,7 @@ func (ScrapePerfMemoryEvents) Scrape(ctx context.Context, db *sql.DB, ch chan<- 
 		eventName    string
 		bytesAlloc   uint64
 		bytesFree    uint64
-		currentBytes uint64
+		currentBytes int64
 	)
 
 	for perfSchemaMemoryEventsRows.Next() {

--- a/collector/perf_schema_memory_events_test.go
+++ b/collector/perf_schema_memory_events_test.go
@@ -47,6 +47,7 @@ func TestScrapePerfMemoryEvents(t *testing.T) {
 
 	rows := sqlmock.NewRows(columns).
 		AddRow("memory/innodb/event1", "1001", "500", "501").
+		AddRow("memory/performance_schema/event1", "6000", "7", "-83904").
 		AddRow("memory/innodb/event2", "2002", "1000", "1002").
 		AddRow("memory/sql/event1", "30", "4", "26")
 	mock.ExpectQuery(sanitizeQuery(perfMemoryEventsQuery)).WillReturnRows(rows)
@@ -63,6 +64,9 @@ func TestScrapePerfMemoryEvents(t *testing.T) {
 		{labels: labelMap{"event_name": "innodb/event1"}, value: 1001, metricType: dto.MetricType_COUNTER},
 		{labels: labelMap{"event_name": "innodb/event1"}, value: 500, metricType: dto.MetricType_COUNTER},
 		{labels: labelMap{"event_name": "innodb/event1"}, value: 501, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"event_name": "performance_schema/event1"}, value: 6000, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"event_name": "performance_schema/event1"}, value: 7, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{"event_name": "performance_schema/event1"}, value: -83904, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{"event_name": "innodb/event2"}, value: 2002, metricType: dto.MetricType_COUNTER},
 		{labels: labelMap{"event_name": "innodb/event2"}, value: 1000, metricType: dto.MetricType_COUNTER},
 		{labels: labelMap{"event_name": "innodb/event2"}, value: 1002, metricType: dto.MetricType_GAUGE},


### PR DESCRIPTION
Related to https://github.com/prometheus/mysqld_exporter/issues/75 and PR https://github.com/prometheus/mysqld_exporter/pull/515

It is possible to end up with a negative value for `CURRENT_NUMBER_OF_BYTES_USED` - this can happen if you enabled instrumentation for performance_schema memory at some point after startup time. 

Currently, if this is the case, the collector emits the following error when scraped, and stops scraping rows after the first row with a negative value for this column:

```
caller=exporter.go:174 msg="Error from scraper" scraper=perf_schema.memory_events err="sql: Scan error on column index 3, name \"CURRENT_NUMBER_OF_BYTES_USED\": converting driver.Value type []uint8 (\"-3214848\") to a uint64: invalid syntax"
```

This change makes the `currentBytes` variable signed, so it can accept negative values and should allow the collector to scrape all the rows of the query results.

the `memory_events_used_bytes ` is already a gauge, so it can be negative.