### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 ARG ARCH="amd64"
 ARG OS="linux"
-FROM   quay.io/prometheus/busybox:latest
-LABEL  maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
+FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
+LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
 ARG ARCH="amd64"
 ARG OS="linux"
 COPY .build/${OS}-${ARCH}/mysqld_exporter /bin/mysqld_exporter
 
-USER        nobody
 EXPOSE      9104
+USER        nobody
 ENTRYPOINT  [ "/bin/mysqld_exporter" ]


### PR DESCRIPTION
Use the correct busybox arch image so that docker-manifest picks up the
correct arch.

Signed-off-by: Ben Kochie <superq@gmail.com>