### PR TITLE
Improve parsing of boolean strings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ workflows:
           parameters:
             mysql_image:
             - mysql/mysql-server:5.6
-            - mysql/mysql-server:5.7
+            - mysql/mysql-server:5.7.33
             - mysql/mysql-server:8.0
             - mariadb:10.2
             - mariadb:10.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * [ENHANCEMENT]
 * [BUGFIX]
 
+* [ENHANCEMENT] Improve parsing of boolean strings
+
 ## 0.13.0-rc.0 / 2021-04-26
 
 BREAKING CHANGES:

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -43,21 +43,19 @@ func newDesc(subsystem, name, help string) *prometheus.Desc {
 }
 
 func parseStatus(data sql.RawBytes) (float64, bool) {
-	if bytes.Equal(data, []byte("Yes")) || bytes.Equal(data, []byte("ON")) {
+	dataString := strings.ToLower(string(data))
+	switch dataString {
+	case "yes", "on":
 		return 1, true
-	}
-	if bytes.Equal(data, []byte("No")) || bytes.Equal(data, []byte("OFF")) {
+	case "no", "off", "disabled":
 		return 0, true
-	}
 	// SHOW SLAVE STATUS Slave_IO_Running can return "Connecting" which is a non-running state.
-	if bytes.Equal(data, []byte("Connecting")) {
+	case "connecting":
 		return 0, true
-	}
 	// SHOW GLOBAL STATUS like 'wsrep_cluster_status' can return "Primary" or "non-Primary"/"Disconnected"
-	if bytes.Equal(data, []byte("Primary")) {
+	case "primary":
 		return 1, true
-	}
-	if strings.EqualFold(string(data), "non-Primary") || bytes.Equal(data, []byte("Disconnected")) {
+	case "non-primary", "disconnected":
 		return 0, true
 	}
 	if logNum := logRE.Find(data); logNum != nil {


### PR DESCRIPTION
* Always lowercase strings to improve matching.
* Add match for "disabled" as false.

Fixes: https://github.com/prometheus/mysqld_exporter/issues/547

Signed-off-by: Ben Kochie <superq@gmail.com>