### PR TITLE
 Exposing ssl cert expiry metrics from show global status command output

### DIFF
--- a/collector/global_status.go
+++ b/collector/global_status.go
@@ -78,16 +78,16 @@ var (
 		"Total number of MySQL instrumentations that could not be loaded or created due to memory constraints.",
 		[]string{"instrumentation"}, nil,
 	)
-        globalSSLCertExpiryBeforeDesc = prometheus.NewDesc(
-                prometheus.BuildFQName(namespace, globalStatus, "ssl_server_not_before"),
-                "Mysql server ssl certificate expiry start date.",
-                []string{}, nil,
-        )
-        globalSSLCertExpiryAfterDesc = prometheus.NewDesc(
-                prometheus.BuildFQName(namespace, globalStatus, "ssl_server_not_after"),
-                "Mysql server ssl certificate expiry end date.",
-                []string{}, nil,
-        )
+	globalSSLCertExpiryBeforeDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, globalStatus, "ssl_server_not_before"),
+		"Mysql server ssl certificate expiry start date.",
+		[]string{}, nil,
+	)
+	globalSSLCertExpiryAfterDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, globalStatus, "ssl_server_not_after"),
+		"Mysql server ssl certificate expiry end date.",
+		[]string{}, nil,
+	)
 )
 
 // ScrapeGlobalStatus collects from `SHOW GLOBAL STATUS`.
@@ -178,17 +178,17 @@ func (ScrapeGlobalStatus) Scrape(ctx context.Context, db *sql.DB, ch chan<- prom
 				ch <- prometheus.MustNewConstMetric(
 					globalPerformanceSchemaLostDesc, prometheus.CounterValue, floatVal, match[2],
 				)
-                        case "ssl_server":
-                                switch match[2] {
-                                case "not_before":
-                                        ch <- prometheus.MustNewConstMetric(
-                                                globalSSLCertExpiryBeforeDesc, prometheus.GaugeValue, floatVal,
-                                        )
-                                case "not_after":
-                                        ch <- prometheus.MustNewConstMetric(
-                                                globalSSLCertExpiryAfterDesc, prometheus.GaugeValue, floatVal,
-                                        )
-                                }
+			case "ssl_server":
+				switch match[2] {
+				case "not_before":
+					ch <- prometheus.MustNewConstMetric(
+						globalSSLCertExpiryBeforeDesc, prometheus.GaugeValue, floatVal,
+					)
+				case "not_after":
+					ch <- prometheus.MustNewConstMetric(
+						globalSSLCertExpiryAfterDesc, prometheus.GaugeValue, floatVal,
+					)
+				}
 			}
 		} else if _, ok := textItems[key]; ok {
 			textItems[key] = string(val)


### PR DESCRIPTION
mysql> show global status like 'ssl_server%';
+-----------------------+--------------------------+
| Variable_name         | Value                    |
+-----------------------+--------------------------+
| Ssl_server_not_after  | Dec 17 05:36:00 2021 GMT |
| Ssl_server_not_before | Dec 17 05:26:38 2020 GMT |
+-----------------------+--------------------------+
2 rows in set (0.00 sec)

Exposing this ssl metric to be used by prometheus to scrape and monitor ssl expiry for DB host