### PR TITLE
Data source template should be labelled 'Data Source'

### DIFF
--- a/mysqld-mixin/dashboards/mysql-overview.json
+++ b/mysqld-mixin/dashboards/mysql-overview.json
@@ -3712,7 +3712,7 @@
         "definition": "label_values(mysql_up, instance)",
         "hide": 0,
         "includeAll": true,
-        "label": null,
+        "label": "Data Source",
         "multi": true,
         "name": "instance",
         "options": [],


### PR DESCRIPTION
We're building a linter for Grafana dashboards and this came up; its super minor nit sorry.

Signed-off-by: Tom Wilkie <tom@grafana.com>