### PR TITLE
Add mysql_transaction_isolation metric

### DIFF
--- a/collector/global_variables.go
+++ b/collector/global_variables.go
@@ -153,6 +153,7 @@ func (ScrapeGlobalVariables) Scrape(ctx context.Context, db *sql.DB, ch chan<- p
 		"version_comment":        "",
 		"wsrep_cluster_name":     "",
 		"wsrep_provider_options": "",
+		"transaction_isolation":  "",
 	}
 
 	for globalVariablesRows.Next() {
@@ -201,6 +202,16 @@ func (ScrapeGlobalVariables) Scrape(ctx context.Context, db *sql.DB, ch chan<- p
 			newDesc("galera", "gcache_size_bytes", "PXC/Galera gcache size."),
 			prometheus.GaugeValue,
 			parseWsrepProviderOptions(textItems["wsrep_provider_options"]),
+		)
+	}
+
+	// mysql_transaction_isolation metric.
+	if textItems["transaction_isolation"] != "" {
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(prometheus.BuildFQName(namespace, "transaction", "isolation"), "MySQL transaction isolation.",
+				[]string{"level"}, nil),
+			prometheus.GaugeValue,
+			1, textItems["transaction_isolation"],
 		)
 	}
 

--- a/collector/global_variables.go
+++ b/collector/global_variables.go
@@ -153,6 +153,7 @@ func (ScrapeGlobalVariables) Scrape(ctx context.Context, db *sql.DB, ch chan<- p
 		"version_comment":        "",
 		"wsrep_cluster_name":     "",
 		"wsrep_provider_options": "",
+		"tx_isolation":           "",
 		"transaction_isolation":  "",
 	}
 
@@ -206,12 +207,16 @@ func (ScrapeGlobalVariables) Scrape(ctx context.Context, db *sql.DB, ch chan<- p
 	}
 
 	// mysql_transaction_isolation metric.
-	if textItems["transaction_isolation"] != "" {
+	if textItems["transaction_isolation"] != "" || textItems["tx_isolation"] != "" {
+		level := textItems["transaction_isolation"]
+		if level == "" {
+			level = textItems["tx_isolation"]
+		}
 		ch <- prometheus.MustNewConstMetric(
 			prometheus.NewDesc(prometheus.BuildFQName(namespace, "transaction", "isolation"), "MySQL transaction isolation.",
 				[]string{"level"}, nil),
 			prometheus.GaugeValue,
-			1, textItems["transaction_isolation"],
+			1, level,
 		)
 	}
 

--- a/collector/global_variables_test.go
+++ b/collector/global_variables_test.go
@@ -69,6 +69,7 @@ func TestScrapeGlobalVariables(t *testing.T) {
 		{labels: labelMap{"innodb_version": "5.6.30-76.3", "version": "5.6.30-76.3-56", "version_comment": "Percona XtraDB Cluster..."}, value: 1, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{"wsrep_cluster_name": "supercluster"}, value: 1, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{}, value: 134217728, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"level": "REPEATABLE-READ"}, value: 1, metricType: dto.MetricType_GAUGE},
 	}
 	convey.Convey("Metrics comparison", t, func() {
 		for _, expect := range counterExpected {


### PR DESCRIPTION
Hi,

This PR adds mysql_transaction_isolation metric.


```
# HELP mysql_transaction_isolation MySQL transaction isolation.
# TYPE mysql_transaction_isolation gauge
mysql_transaction_isolation{level="REPEATABLE-READ"} 1
````