### PR TITLE
remove SPACE_TYPE from innodb_tablespaces (Closes: #528)

### DIFF
--- a/collector/info_schema_innodb_sys_tablespaces.go
+++ b/collector/info_schema_innodb_sys_tablespaces.go
@@ -42,7 +42,6 @@ const innodbTablespacesQuery = `
 			  AND TABLE_NAME = ` + "'%s'" + `
 			  AND COLUMN_NAME = 'FILE_FORMAT' LIMIT 1), 'NONE') as FILE_FORMAT,
 	    ifnull(ROW_FORMAT, 'NONE') as ROW_FORMAT,
-	    ifnull(SPACE_TYPE, 'NONE') as SPACE_TYPE,
 	    FILE_SIZE,
 	    ALLOCATED_SIZE
 	  FROM information_schema.` + "`%s`"
@@ -52,7 +51,7 @@ var (
 	infoSchemaInnodbTablesspaceInfoDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, informationSchema, "innodb_tablespace_space_info"),
 		"The Tablespace information and Space ID.",
-		[]string{"tablespace_name", "file_format", "row_format", "space_type"}, nil,
+		[]string{"tablespace_name", "file_format", "row_format"}, nil,
 	)
 	infoSchemaInnodbTablesspaceFileSizeDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, informationSchema, "innodb_tablespace_file_size_bytes"),
@@ -111,7 +110,6 @@ func (ScrapeInfoSchemaInnodbTablespaces) Scrape(ctx context.Context, db *sql.DB,
 		tableName     string
 		fileFormat    string
 		rowFormat     string
-		spaceType     string
 		fileSize      uint64
 		allocatedSize uint64
 	)
@@ -122,7 +120,6 @@ func (ScrapeInfoSchemaInnodbTablespaces) Scrape(ctx context.Context, db *sql.DB,
 			&tableName,
 			&fileFormat,
 			&rowFormat,
-			&spaceType,
 			&fileSize,
 			&allocatedSize,
 		)
@@ -131,7 +128,7 @@ func (ScrapeInfoSchemaInnodbTablespaces) Scrape(ctx context.Context, db *sql.DB,
 		}
 		ch <- prometheus.MustNewConstMetric(
 			infoSchemaInnodbTablesspaceInfoDesc, prometheus.GaugeValue, float64(tableSpace),
-			tableName, fileFormat, rowFormat, spaceType,
+			tableName, fileFormat, rowFormat,
 		)
 		ch <- prometheus.MustNewConstMetric(
 			infoSchemaInnodbTablesspaceFileSizeDesc, prometheus.GaugeValue, float64(fileSize),

--- a/collector/info_schema_innodb_sys_tablespaces_test.go
+++ b/collector/info_schema_innodb_sys_tablespaces_test.go
@@ -38,10 +38,10 @@ func TestScrapeInfoSchemaInnodbTablespaces(t *testing.T) {
 	mock.ExpectQuery(sanitizeQuery(innodbTablespacesTablenameQuery)).WillReturnRows(rows)
 
 	tablespacesTablename := "INNODB_SYS_TABLESPACES"
-	columns = []string{"SPACE", "NAME", "FILE_FORMAT", "ROW_FORMAT", "SPACE_TYPE", "FILE_SIZE", "ALLOCATED_SIZE"}
+	columns = []string{"SPACE", "NAME", "FILE_FORMAT", "ROW_FORMAT", "FILE_SIZE", "ALLOCATED_SIZE"}
 	rows = sqlmock.NewRows(columns).
-		AddRow(1, "sys/sys_config", "Barracuda", "Dynamic", "Single", 100, 100).
-		AddRow(2, "db/compressed", "Barracuda", "Compressed", "Single", 300, 200)
+		AddRow(1, "sys/sys_config", "Barracuda", "Dynamic", 100, 100).
+		AddRow(2, "db/compressed", "Barracuda", "Compressed", 300, 200)
 	query := fmt.Sprintf(innodbTablespacesQuery, tablespacesTablename, tablespacesTablename)
 	mock.ExpectQuery(sanitizeQuery(query)).WillReturnRows(rows)
 
@@ -54,10 +54,10 @@ func TestScrapeInfoSchemaInnodbTablespaces(t *testing.T) {
 	}()
 
 	expected := []MetricResult{
-		{labels: labelMap{"tablespace_name": "sys/sys_config", "file_format": "Barracuda", "row_format": "Dynamic", "space_type": "Single"}, value: 1, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"tablespace_name": "sys/sys_config", "file_format": "Barracuda", "row_format": "Dynamic"}, value: 1, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{"tablespace_name": "sys/sys_config"}, value: 100, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{"tablespace_name": "sys/sys_config"}, value: 100, metricType: dto.MetricType_GAUGE},
-		{labels: labelMap{"tablespace_name": "db/compressed", "file_format": "Barracuda", "row_format": "Compressed", "space_type": "Single"}, value: 2, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"tablespace_name": "db/compressed", "file_format": "Barracuda", "row_format": "Compressed"}, value: 2, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{"tablespace_name": "db/compressed"}, value: 300, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{"tablespace_name": "db/compressed"}, value: 200, metricType: dto.MetricType_GAUGE},
 	}


### PR DESCRIPTION
The SPACE_TYPE column was introduced in MariaDB 10.2.1 and removed in MariaDB 10.5.0.

