### PR TITLE
enableMgrAlert:Return different values according to different states …

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ config.my-cnf                              | Path to .my.cnf file to read MySQL 
 log.level                                  | Logging verbosity (default: info)
 exporter.lock_wait_timeout                 | Set a lock_wait_timeout (in seconds) on the connection to avoid long metadata locking. (default: 2)
 exporter.log_slow_filter                   | Add a log_slow_filter to avoid slow query logging of scrapes.  NOTE: Not supported by Oracle MySQL.
+tls.insecure-skip-verify                   | Ignore tls verification errors.
 web.config.file                            | Path to a [web configuration file](#tls-and-basic-authentication)
 web.listen-address                         | Address to listen on for web interface and telemetry.
 web.telemetry-path                         | Path under which to expose metrics.


### PR DESCRIPTION
…of performance_schema.replication_group_members column member_state state, and then alarm for MGR. Performance_schema. replication_group_members MEMBER_STATE: returns 0 when not ONLINE. Configure rules in Prometheus for sending MGR non-online alarm.

Signed-off-by: jianshenghan <jianshenghan@163.com>