### PR TITLE
Allow tlsCfg.InsecureSkipVerify outside of mTLS

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -171,8 +171,8 @@ func customizeTLS(sslCA string, sslCert string, sslKey string) error {
 		}
 		certPairs = append(certPairs, keypair)
 		tlsCfg.Certificates = certPairs
-		tlsCfg.InsecureSkipVerify = *tlsInsecureSkipVerify
 	}
+	tlsCfg.InsecureSkipVerify = *tlsInsecureSkipVerify
 	mysql.RegisterTLSConfig("custom", &tlsCfg)
 	return nil
 }


### PR DESCRIPTION
@SuperQ 

Fix a bug where the `tlsCfg.InsecureSkipVerify` flag was only consumed when using mTLS.