### PR TITLE
Don't use HOME env in the my-cnf config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 BREAKING CHANGES:
 
+Don't prepend the `.my.cnf` file with the `HOME` environment.
+
 Changes:
+
+* [CHANGE] Don't use HOME env in the my-cnf config path.
 
 * [CHANGE]
 * [FEATURE]

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -59,7 +59,7 @@ var (
 	configMycnf = kingpin.Flag(
 		"config.my-cnf",
 		"Path to .my.cnf file to read MySQL credentials from.",
-	).Default(path.Join(os.Getenv("HOME"), ".my.cnf")).String()
+	).Default(".my.cnf").String()
 	tlsInsecureSkipVerify = kingpin.Flag(
 		"tls.insecure-skip-verify",
 		"Ignore certificate and server verification when using a tls connection.",


### PR DESCRIPTION
Use a relative file as the default for the .my.cnf style configuration.

Fixes: https://github.com/prometheus/mysqld_exporter/issues/633

Signed-off-by: SuperQ <superq@gmail.com>