### PR TITLE
Add support for single mysqld_exporter collect multiple MySQL instances

### DIFF
--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -27,6 +28,7 @@ import (
 	"github.com/go-kit/log/level"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -81,6 +83,19 @@ type Exporter struct {
 	dsn      string
 	scrapers []Scraper
 	metrics  Metrics
+}
+
+func ProbeHandler(w http.ResponseWriter, r *http.Request, metrics Metrics, scrapers []Scraper, logger log.Logger) {
+	dsn := r.URL.Query().Get("dsn")
+	if dsn == "" {
+		http.Error(w, fmt.Sprintf("dsn empty %q", dsn), http.StatusBadRequest)
+		return
+	}
+	mysqlExp := New(r.Context(), dsn, metrics, scrapers, logger)
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(mysqlExp)
+	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
+	h.ServeHTTP(w, r)
 }
 
 // New returns a new MySQL exporter for the provided DSN.

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -277,14 +277,14 @@ func main() {
 	level.Info(logger).Log("msg", "Starting mysqld_exporter", "version", version.Info())
 	level.Info(logger).Log("msg", "Build context", version.BuildContext())
 
-	dsn = os.Getenv("DATA_SOURCE_NAME")
-	if len(dsn) == 0 {
-		var err error
-		if dsn, err = parseMycnf(*configMycnf); err != nil {
-			level.Info(logger).Log("msg", "Error parsing my.cnf", "file", *configMycnf, "err", err)
-			os.Exit(1)
-		}
-	}
+	// dsn = os.Getenv("DATA_SOURCE_NAME")
+	// if len(dsn) == 0 {
+	// 	var err error
+	// 	if dsn, err = parseMycnf(*configMycnf); err != nil {
+	// 		level.Info(logger).Log("msg", "Error parsing my.cnf", "file", *configMycnf, "err", err)
+	// 		os.Exit(1)
+	// 	}
+	// }
 
 	// Register only scrapers enabled by flag.
 	enabledScrapers := []collector.Scraper{}
@@ -294,10 +294,13 @@ func main() {
 			enabledScrapers = append(enabledScrapers, scraper)
 		}
 	}
-	handlerFunc := newHandler(collector.NewMetrics(), enabledScrapers, logger)
-	http.Handle(*metricPath, promhttp.InstrumentMetricHandler(prometheus.DefaultRegisterer, handlerFunc))
+	// handlerFunc := newHandler(collector.NewMetrics(), enabledScrapers, logger)
+	// http.Handle(*metricPath, promhttp.InstrumentMetricHandler(prometheus.DefaultRegisterer, handlerFunc))
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write(landingPage)
+	})
+	http.HandleFunc("/probe", func(w http.ResponseWriter, r *http.Request) {
+		collector.ProbeHandler(w, r, collector.NewMetrics(), enabledScrapers, logger)
 	})
 
 	level.Info(logger).Log("msg", "Listening on address", "address", *listenAddress)


### PR DESCRIPTION
### Add support for single mysqld_exporter collect multiple MySQL instances

- Example：
```
curl 'http://localhost:9104/probe?dsn=mysql_user1:password1@tcp(196.168.1.1:3306)/'
curl 'http://localhost:9104/probe?dsn=mysql_user2:password2@tcp(196.168.2.2:3306)/'
```