### PR TITLE
Remove ioutil

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -18,7 +18,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -153,7 +152,7 @@ func parseMycnf(config interface{}) (string, error) {
 func customizeTLS(sslCA string, sslCert string, sslKey string) error {
 	var tlsCfg tls.Config
 	caBundle := x509.NewCertPool()
-	pemCA, err := ioutil.ReadFile(sslCA)
+	pemCA, err := os.ReadFile(sslCA)
 	if err != nil {
 		return err
 	}

--- a/mysqld_exporter_test.go
+++ b/mysqld_exporter_test.go
@@ -16,7 +16,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -157,7 +157,7 @@ func TestBin(t *testing.T) {
 	var err error
 	binName := "mysqld_exporter"
 
-	binDir, err := ioutil.TempDir("/tmp", binName+"-test-bindir-")
+	binDir, err := os.MkdirTemp("/tmp", binName+"-test-bindir-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +294,7 @@ func getBody(urlToGet string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`ioutil` is deprecated from go1.16 (ref: https://go.dev/doc/go1.16#ioutil).
So removed them.

Signed-off-by: inosato <si17_21@yahoo.co.jp>