### PR TITLE
replication_applier_status_by_worker requires mysql 8.0

### DIFF
--- a/collector/perf_schema_replication_applier_status_by_worker.go
+++ b/collector/perf_schema_replication_applier_status_by_worker.go
@@ -97,7 +97,7 @@ func (ScrapePerfReplicationApplierStatsByWorker) Help() string {
 
 // Version of MySQL from which scraper is available.
 func (ScrapePerfReplicationApplierStatsByWorker) Version() float64 {
-	return 5.7
+	return 8.0
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.


### PR DESCRIPTION
The query in the replication_applier_status_by_worker check assumes the replication_applier_status_by_worker table layout in mysql 8.0.

Without this if you enable replication_applier_status_by_worker you'll receive the following error:

```
caller=exporter.go:174 level=error msg="Error from scraper" scraper=perf_schema.replication_applier_status_by_worker err="Error 1054: Unknown column 'LAST_APPLIED_TRANSACTION_ORIGINAL_COMMIT_TIMESTAMP' in 'field list'
```