### PR TITLE
Change processlist query to support ONLY_FULL_GROUP_BY sql_mode

### DIFF
--- a/collector/info_schema_processlist.go
+++ b/collector/info_schema_processlist.go
@@ -39,7 +39,7 @@ const infoSchemaProcesslistQuery = `
 		  FROM information_schema.processlist
 		  WHERE ID != connection_id()
 		    AND TIME >= %d
-		  GROUP BY user, SUBSTRING_INDEX(host, ':', 1), command, state
+		  GROUP BY user, host, command, state
 	`
 
 // Tunable flags.


### PR DESCRIPTION
Otherwise `Error 1055: 'information_schema.processlist.HOST' isn't in GROUP BY` is raised.

fixes #610 (for details see [#issuecomment-1320577266](https://github.com/prometheus/mysqld_exporter/issues/610#issuecomment-1320577266))

@SuperQ 
CC @peterloeffler