### PR TITLE
Fix infoSchemaInnodbMetricsEnabledColumnQuery

### DIFF
--- a/collector/info_schema_innodb_metrics.go
+++ b/collector/info_schema_innodb_metrics.go
@@ -31,8 +31,10 @@ const infoSchemaInnodbMetricsEnabledColumnQuery = `
 	SELECT
 	    column_name
 	  FROM information_schema.columns
-	  WHERE table_name = 'INNODB_METRICS'
+	  WHERE table_schema = 'information_schema'
+	    AND table_name = 'INNODB_METRICS'
 	    AND column_name IN ('status', 'enabled')
+	  LIMIT 1
 	`
 
 const infoSchemaInnodbMetricsQuery = `


### PR DESCRIPTION
The query introduced with #523 performs poorly when there are sufficient numbers of rows in `information_schema.columns`.

* Added using the `table_schema` as a filter
* Added limit to the query