### PR TITLE
Fix unclosed code block in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ docker run -d \
   --network my-mysql-network  \
   prom/mysqld-exporter
   --config.my-cnf=<path_to_cnf>
+```
 
 ## heartbeat
 


### PR DESCRIPTION
This fixes a code block that not properly closed, causing the next two sections rendered as code.