### PR TITLE
Fix prometheus scrape example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ On the prometheus side you can set a scrape config as follows
         - job_name: mysql # To get metrics about the mysql exporter’s targets
           params:
             # Not required. Will match value to child in config file. Default value is `client`.
-            auth_module: client.servers
+            auth_module: [client.servers]
           static_configs:
             - targets:
               # All mysql hostnames to monitor.


### PR DESCRIPTION
Fix the type of params in Prometheus scrape_config

The old one is:
```
    params:
      # Not required. Will match value to child in config file. Default value is `client`.
      auth_module: client.servers
```

It will introduce an issue that the Prometheus service fails to start, due to the config file error.

As in the official documents of Prometheus: [scrape_config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config), `params` should be:
```
# Optional HTTP URL parameters.
params:
  [ <string>: [<string>, ...] ]
```
So, I updated the example to
```
params:
    auth_module: [client.servers]
```
And the Prometheus service instance can start normally.