### PR TITLE
Add UNIX domain socket support for multi-target scraping

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/go-kit/log"
@@ -193,6 +194,9 @@ func (m MySqlConfig) FormDSN(target string) (string, error) {
 			config.Net = "unix"
 			config.Addr = m.Socket
 		}
+	} else if prefix := "unix://"; strings.HasPrefix(target, prefix) {
+		config.Net = "unix"
+		config.Addr = target[len(prefix):]
 	} else {
 		if _, _, err = net.SplitHostPort(target); err != nil {
 			return "", fmt.Errorf("failed to parse target: %s", err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -168,6 +168,14 @@ func TestFormDSN(t *testing.T) {
 			}
 			convey.So(dsn, convey.ShouldEqual, "test:foo@tcp(server1:5000)/")
 		})
+		convey.Convey("UNIX domain socket", func() {
+			cfg := c.GetConfig()
+			section := cfg.Sections["client.server1"]
+			if dsn, err = section.FormDSN("unix:///run/mysqld/mysqld.sock"); err != nil {
+				t.Error(err)
+			}
+			convey.So(dsn, convey.ShouldEqual, "test:foo@unix(/run/mysqld/mysqld.sock)/")
+		})
 	})
 }
 


### PR DESCRIPTION
This pull request expands the multi-target scraping ability introduced by #504 and #651 to UNIX domain sockets.

If the `target` query starts with `unix://`, connect to the server using UNIX domain socket. Otherwise, use TCP.

~This PR adds a new query parameter `network` to specify the network type either "tcp" or "unix". If no value is set, it defaults to "tcp".~


Support for multiple UNIX domain sockets is useful if, for example, mysqld_exporter runs on Cloud Run configured with multiple Cloud SQL connections. Cloud Run mounts multiple UNIX domain sockets on the `/cloudsql` directory. https://cloud.google.com/sql/docs/mysql/connect-run?hl=en#connect_to

(Fixed in #714) ~By the way, I found that the `/probe` endpoint emits error messages to the client along with metrics in some error conditions. I don't know if Prometheus can handle it correctly, but at least prom2json couldn't handle it.~

https://github.com/prometheus/mysqld_exporter/blob/593b0095a5bd0bd852029dd2dfa5f204a15de946/probe.go#L45-L54

~In the same condition, the `/metrics` endpoint doesn't emit error messages.~

https://github.com/prometheus/mysqld_exporter/blob/593b0095a5bd0bd852029dd2dfa5f204a15de946/mysqld_exporter.go#L140-L147

~Is that OK or should be patched to emit only either error messages or metrics? I'd like to send a PR as needed.~

