### PR TITLE
fix duplicated collector when collectParams was passed in probe mode

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -106,7 +106,7 @@ var scrapers = map[collector.Scraper]bool{
 }
 
 func filterScrapers(scrapers []collector.Scraper, collectParams []string) []collector.Scraper {
-	filteredScrapers := scrapers
+	var filteredScrapers []collector.Scraper
 
 	// Check if we have some "collect[]" query parameters.
 	if len(collectParams) > 0 {
@@ -120,6 +120,9 @@ func filterScrapers(scrapers []collector.Scraper, collectParams []string) []coll
 				filteredScrapers = append(filteredScrapers, scraper)
 			}
 		}
+	}
+	if len(filteredScrapers) == 0 {
+		return scrapers
 	}
 	return filteredScrapers
 }

--- a/mysqld_exporter_test.go
+++ b/mysqld_exporter_test.go
@@ -243,9 +243,7 @@ func Test_filterScrapers(t *testing.T) {
 				[]collector.Scraper{collector.ScrapeGlobalStatus{}},
 				[]string{collector.ScrapeGlobalVariables{}.Name()},
 			},
-			[]collector.Scraper{
-				collector.ScrapeGlobalStatus{},
-			}},
+			[]collector.Scraper{collector.ScrapeGlobalStatus{}}},
 		{"respect_params",
 			args{
 				[]collector.Scraper{


### PR DESCRIPTION
when using [filters](https://github.com/prometheus/mysqld_exporter#filtering-enabled-collectors), there would be a error

```
collected metric "mysql_exporter_collector_duration_seconds" { label:<name:"collector" value:"collect.perf_schema.replication_group_member_stats" > gauge:<value:0.001734619 > } was collected before with the same name and label values
```

the reason is that the collector is registed twice, I'll fix this error in the comming commits, this commit is about tests that can reproduce the error