### PR TITLE
Fix shared metrics between requests

### DIFF
--- a/collector/exporter_test.go
+++ b/collector/exporter_test.go
@@ -36,7 +36,6 @@ func TestExporter(t *testing.T) {
 	exporter := New(
 		context.Background(),
 		dsn,
-		NewMetrics(),
 		[]Scraper{
 			ScrapeGlobalStatus{},
 		},

--- a/probe.go
+++ b/probe.go
@@ -24,7 +24,7 @@ import (
 	"github.com/prometheus/mysqld_exporter/collector"
 )
 
-func handleProbe(metrics collector.Metrics, scrapers []collector.Scraper, logger log.Logger) http.HandlerFunc {
+func handleProbe(scrapers []collector.Scraper, logger log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		params := r.URL.Query()
@@ -57,7 +57,7 @@ func handleProbe(metrics collector.Metrics, scrapers []collector.Scraper, logger
 		filteredScrapers := filterScrapers(scrapers, collectParams)
 
 		registry := prometheus.NewRegistry()
-		registry.MustRegister(collector.New(ctx, dsn, metrics, filteredScrapers, logger))
+		registry.MustRegister(collector.New(ctx, dsn, filteredScrapers, logger))
 
 		h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 		h.ServeHTTP(w, r)


### PR DESCRIPTION
## Breaking changes

### dropped metrics
* mysql_exporter_scrapes_total 
* mysql_exporter_scrape_errors_total
* mysql_last_scrape_failed 

### new metrics
* mysql_exporter_collector_success (replace mysql_exporter_scrape_errors_total)

### metrics isolated between requests
* mysql_up
* mysql_exporter_collector_success
* mysql_exporter_collector_duration_seconds

## Why is this neccessary
We are using mysqld_exporter in `multi-target` method, which means one exporter for multiple mysql instance, the crucial metric `mysql_up` must be isolated between requests, or there will be misunderstandings, some mysql instance would shown as down while in fact it is not.

all shared metrics are dropped especially `mysql_exporter_scrapes_total`  and `mysql_exporter_scrape_errors_total` , the metrics are useless since prometheus can record almost everything, including scrape fail for each collector.

`mysql_last_scrape_failed`  is covered by `mysql_exporter_collector_success` so it is also dropped.

fix #713 