### PR TITLE
use the target for dsn building in colector

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -136,17 +136,22 @@ func newHandler(scrapers []collector.Scraper, logger log.Logger) http.HandlerFun
 	return func(w http.ResponseWriter, r *http.Request) {
 		var dsn string
 		var err error
+		target := ""
+		q := r.URL.Query()
+		if q.Has("target") {
+			target = q.Get("target")
+		}
 
 		cfg := c.GetConfig()
 		cfgsection, ok := cfg.Sections["client"]
 		if !ok {
 			level.Error(logger).Log("msg", "Failed to parse section [client] from config file", "err", err)
 		}
-		if dsn, err = cfgsection.FormDSN(""); err != nil {
+		if dsn, err = cfgsection.FormDSN(target); err != nil {
 			level.Error(logger).Log("msg", "Failed to form dsn from section [client]", "err", err)
 		}
 
-		collect := r.URL.Query()["collect[]"]
+		collect := q["collect[]"]
 
 		// Use request context for cancellation when connection gets closed.
 		ctx := r.Context()


### PR DESCRIPTION
It looks like that in the latest release; there is a provision for multiple targets.

> To use the multi-target functionality, send an http request to the endpoint /probe?target=foo:3306 where target is set to the DSN of the MySQL instance to scrape metrics from.

I used this mechanism but the scraper only tried to scrape itself (127.0.0.1). When you set the mysqld.address flag - then it scrapes that host - for all targets.

This fixes that by using the target in the query string as part of the DSN building.