### PR TITLE
Use target in DSN builder.

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -136,17 +136,22 @@ func newHandler(scrapers []collector.Scraper, logger log.Logger) http.HandlerFun
 	return func(w http.ResponseWriter, r *http.Request) {
 		var dsn string
 		var err error
+		target := ""
+		q := r.URL.Query()
+		if q.Has("target") {
+			target = q.Get("target")
+		}
 
 		cfg := c.GetConfig()
 		cfgsection, ok := cfg.Sections["client"]
 		if !ok {
 			level.Error(logger).Log("msg", "Failed to parse section [client] from config file", "err", err)
 		}
-		if dsn, err = cfgsection.FormDSN(""); err != nil {
+		if dsn, err = cfgsection.FormDSN(target); err != nil {
 			level.Error(logger).Log("msg", "Failed to form dsn from section [client]", "err", err)
 		}
 
-		collect := r.URL.Query()["collect[]"]
+		collect := q["collect[]"]
 
 		// Use request context for cancellation when connection gets closed.
 		ctx := r.Context()


### PR DESCRIPTION
When I configured mysqld_exporter for multi targets as per the main README:

> To use the multi-target functionality, send an http request to the endpoint /probe?target=foo:3306 where target is set to the DSN of the MySQL instance to scrape metrics from.

If you use this - regardless of the target it uses 127.0.0.1 as the MySQL host. If you use the mysqld.addressflag - then for all targets it uses the mysqld.address host. 

Signed-off-by: Nick Knight <nick@babblevoice.com>