### PR TITLE
BUGFIX for 0.15.0-rc.0  sys.X$user_summary latencies doesn't fit to uint64 

### DIFF
--- a/collector/sys_user_summary.go
+++ b/collector/sys_user_summary.go
@@ -16,6 +16,7 @@ package collector
 import (
 	"context"
 	"database/sql"
+
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -109,10 +110,10 @@ func (ScrapeSysUserSummary) Scrape(ctx context.Context, db *sql.DB, ch chan<- pr
 	var (
 		user                   string
 		statements             uint64
-		statement_latency      uint64
+		statement_latency      float64
 		table_scans            uint64
 		file_ios               uint64
-		file_io_latency        uint64
+		file_io_latency        float64
 		current_connections    uint64
 		total_connections      uint64
 		unique_hosts           uint64


### PR DESCRIPTION
I just needed these new metrics, so now I'm using using 0.15.0-rc.0  with our db servers.
However our latencies in production db didn't fit to the uint64, so I changed them to float64.
Other fields can still can contain values that are too large, but I didn't change them because we're not going to hit them.
Thanks for your work. and use pull request in any way you see suitable.
```
user                statements     statement_latency  table_scans     file_ios      file_io_latency  current_connections  total_connections  unique_hosts  current_memory  total_memory_allocated
----------------  ------------  --------------------  -----------  -----------  -------------------  -------------------  -----------------  ------------  --------------  ----------------------
importer          179044695398  64257202333135470768   3305598022  30195112360  2544309359781509650                    0         1728175366             2               0                       0
```