### PR TITLE
Don't use HOME env in the my-cnf config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 BREAKING CHANGES:
 
+Don't prepend the `.my.cnf` file with the `HOME` environment.
+
 Changes:
+
+* [CHANGE] Don't use HOME env in the my-cnf config path. #745
 
 * [CHANGE]
 * [FEATURE]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BREAKING CHANGES:
 
-Don't prepend the `.my.cnf` file with the `HOME` environment.
+The default client configuration file is now `.my.cnf` in the process working directory. Use `--config.my-cnf="$HOME/.my.cnf"` to retain the previous default.
 
 Changes:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ NOTE: It is recommended to set a max connection limit for the user to avoid over
 
 #####  Single exporter mode
 
-Running using ~/.my.cnf:
+Running using `.my.cnf` from the current directory:
 
     ./mysqld_exporter <flags>
 

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"net/http"
 	"os"
-	"path"
 	"strconv"
 	"time"
 
@@ -48,7 +47,7 @@ var (
 	configMycnf = kingpin.Flag(
 		"config.my-cnf",
 		"Path to .my.cnf file to read MySQL credentials from.",
-	).Default(path.Join(os.Getenv("HOME"), ".my.cnf")).String()
+	).Default(".my.cnf").String()
 	mysqldAddress = kingpin.Flag(
 		"mysqld.address",
 		"Address to use for connecting to MySQL",


### PR DESCRIPTION
Use a relative file as the default for the .my.cnf style configuration.

Fixes: https://github.com/prometheus/mysqld_exporter/issues/633