### PR TITLE
Allow comment characters within configuration values when using my.cnf

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -52,6 +52,8 @@ var (
 		Loose: true,
 		// MySQL ini file can have boolean keys.
 		AllowBooleanKeys: true,
+		// Allow comment characters inside values.
+		SpaceBeforeInlineComment: true,
 	}
 
 	err error

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -139,6 +139,28 @@ func TestValidateConfig(t *testing.T) {
 		convey.So(section.User, convey.ShouldEqual, "abc")
 		convey.So(section.Password, convey.ShouldEqual, "")
 	})
+
+	convey.Convey("Comment characters in password", t, func() {
+		c := MySqlConfigHandler{
+			Config: &Config{},
+		}
+		if err := c.ReloadConfig("testdata/comment_char_in_password.cnf", "localhost:3306", "", true, log.NewNopLogger()); err != nil {
+			t.Error(err)
+		}
+		cfg := c.GetConfig()
+		convey.Convey("hash", func() {
+			section := cfg.Sections["client.hash"]
+			convey.So(section.Password, convey.ShouldEqual, "abc#xyz")
+		})
+		convey.Convey("semicolon", func() {
+			section := cfg.Sections["client.semicolon"]
+			convey.So(section.Password, convey.ShouldEqual, "abc;xyz")
+		})
+		convey.Convey("hash and semicolon", func() {
+			section := cfg.Sections["client.both"]
+			convey.So(section.Password, convey.ShouldEqual, "abc#xyz;pqr")
+		})
+	})
 }
 
 func TestFormDSN(t *testing.T) {

--- a/config/testdata/comment_char_in_password.cnf
+++ b/config/testdata/comment_char_in_password.cnf
@@ -1,0 +1,9 @@
+[client.hash]
+user = test
+password = abc#xyz
+[client.semicolon]
+user = test
+password = abc;xyz
+[client.both]
+user = test
+password = abc#xyz;pqr


### PR DESCRIPTION
This PR will fix https://github.com/prometheus/mysqld_exporter/issues/376

I've configured `SpaceBeforeInlineComment` option to allow comment characters within values.
see https://github.com/go-ini/ini/blob/b2f570e5b5b844226bbefe6fb521d891f529a951/ini.go#L97-L101