### PR TITLE
Refactor collectors to not depend of kingpin to be configured

### DIFF
--- a/collector/exporter_test.go
+++ b/collector/exporter_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
@@ -30,6 +31,14 @@ func TestExporter(t *testing.T) {
 		t.Skip("-short is passed, skipping test")
 	}
 
+	var exporterConfig Config
+	kingpinApp := kingpin.New("TestExporter", "")
+	exporterConfig.RegisterFlags(kingpinApp)
+	_, err := kingpinApp.Parse([]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	exporter := New(
 		context.Background(),
 		dsn,
@@ -37,6 +46,7 @@ func TestExporter(t *testing.T) {
 			ScrapeGlobalStatus{},
 		},
 		promslog.NewNopLogger(),
+		exporterConfig,
 	)
 
 	convey.Convey("Metrics describing", t, func() {

--- a/collector/heartbeat_test.go
+++ b/collector/heartbeat_test.go
@@ -55,7 +55,12 @@ var ScrapeHeartbeatTestCases = []ScrapeHeartbeatTestCase{
 func TestScrapeHeartbeat(t *testing.T) {
 	for _, tt := range ScrapeHeartbeatTestCases {
 		t.Run(fmt.Sprint(tt.Args), func(t *testing.T) {
-			_, err := kingpin.CommandLine.Parse(tt.Args)
+			scraper := ScrapeHeartbeat{}
+
+			app := kingpin.New("TestScrapeHeartbeat", "")
+			scraper.RegisterFlags(app)
+
+			_, err := app.Parse(tt.Args)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -73,7 +78,7 @@ func TestScrapeHeartbeat(t *testing.T) {
 
 			ch := make(chan prometheus.Metric)
 			go func() {
-				if err = (ScrapeHeartbeat{}).Scrape(context.Background(), inst, ch, promslog.NewNopLogger()); err != nil {
+				if err = scraper.Scrape(context.Background(), inst, ch, promslog.NewNopLogger()); err != nil {
 					t.Errorf("error calling function on test: %s", err)
 				}
 				close(ch)

--- a/collector/info_schema_processlist_test.go
+++ b/collector/info_schema_processlist_test.go
@@ -27,7 +27,11 @@ import (
 )
 
 func TestScrapeProcesslist(t *testing.T) {
-	_, err := kingpin.CommandLine.Parse([]string{
+	scraper := ScrapeProcesslist{}
+	app := kingpin.New("TestScrapeProcesslist", "")
+	scraper.RegisterFlags(app)
+
+	_, err := app.Parse([]string{
 		"--collect.info_schema.processlist.processes_by_user",
 		"--collect.info_schema.processlist.processes_by_host",
 	})
@@ -57,7 +61,7 @@ func TestScrapeProcesslist(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeProcesslist{}).Scrape(context.Background(), inst, ch, promslog.NewNopLogger()); err != nil {
+		if err = scraper.Scrape(context.Background(), inst, ch, promslog.NewNopLogger()); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/perf_schema_events_statements_test.go
+++ b/collector/perf_schema_events_statements_test.go
@@ -54,7 +54,12 @@ func TestScrapePerfEventsStatements(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapePerfEventsStatements{}).Scrape(context.Background(), &instance{db: db}, ch, promslog.NewNopLogger()); err != nil {
+		scraper := ScrapePerfEventsStatements{
+			Limit:           250,
+			TimeLimit:       86400,
+			DigestTextLimit: 120,
+		}
+		if err = scraper.Scrape(context.Background(), &instance{db: db}, ch, promslog.NewNopLogger()); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)
@@ -130,7 +135,12 @@ func TestScrapePerfEventsStatementsMySQL8028(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapePerfEventsStatements{}).Scrape(context.Background(), inst, ch, promslog.NewNopLogger()); err != nil {
+		scraper := ScrapePerfEventsStatements{
+			Limit:           250,
+			TimeLimit:       86400,
+			DigestTextLimit: 120,
+		}
+		if err = scraper.Scrape(context.Background(), inst, ch, promslog.NewNopLogger()); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/perf_schema_file_instances_test.go
+++ b/collector/perf_schema_file_instances_test.go
@@ -27,7 +27,11 @@ import (
 )
 
 func TestScrapePerfFileInstances(t *testing.T) {
-	_, err := kingpin.CommandLine.Parse([]string{"--collect.perf_schema.file_instances.filter", ""})
+	scraper := ScrapePerfFileInstances{}
+
+	app := kingpin.New("TestScrapePerfFileInstances", "")
+	scraper.RegisterFlags(app)
+	_, err := app.Parse([]string{"--collect.perf_schema.file_instances.filter", ""})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +53,7 @@ func TestScrapePerfFileInstances(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapePerfFileInstances{}).Scrape(context.Background(), inst, ch, promslog.NewNopLogger()); err != nil {
+		if err = scraper.Scrape(context.Background(), inst, ch, promslog.NewNopLogger()); err != nil {
 			panic(fmt.Sprintf("error calling function on test: %s", err))
 		}
 		close(ch)

--- a/collector/perf_schema_memory_events_test.go
+++ b/collector/perf_schema_memory_events_test.go
@@ -27,7 +27,11 @@ import (
 )
 
 func TestScrapePerfMemoryEvents(t *testing.T) {
-	_, err := kingpin.CommandLine.Parse([]string{})
+	scraper := ScrapePerfMemoryEvents{}
+
+	app := kingpin.New("TestScrapePerfMemoryEvents", "")
+	scraper.RegisterFlags(app)
+	_, err := app.Parse([]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +59,7 @@ func TestScrapePerfMemoryEvents(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapePerfMemoryEvents{}).Scrape(context.Background(), inst, ch, promslog.NewNopLogger()); err != nil {
+		if err = scraper.Scrape(context.Background(), inst, ch, promslog.NewNopLogger()); err != nil {
 			panic(fmt.Sprintf("error calling function on test: %s", err))
 		}
 		close(ch)

--- a/collector/scraper.go
+++ b/collector/scraper.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/alecthomas/kingpin/v2"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -35,4 +36,12 @@ type Scraper interface {
 
 	// Scrape collects data from database connection and sends it over channel as prometheus metric.
 	Scrape(ctx context.Context, instance *instance, ch chan<- prometheus.Metric, logger *slog.Logger) error
+}
+
+// ConfigurableScraper extends the Scraper interface by allowing it to be configured with flags.
+type ConfigurableScraper interface {
+	Scraper
+
+	// Register flags to configure a scraper against a given kingpin Application.
+	RegisterFlags(application *kingpin.Application)
 }

--- a/probe.go
+++ b/probe.go
@@ -25,7 +25,7 @@ import (
 	"github.com/prometheus/mysqld_exporter/collector"
 )
 
-func handleProbe(scrapers []collector.Scraper, logger *slog.Logger) http.HandlerFunc {
+func handleProbe(scrapers []collector.Scraper, logger *slog.Logger, config collector.Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		params := r.URL.Query()
@@ -72,7 +72,7 @@ func handleProbe(scrapers []collector.Scraper, logger *slog.Logger) http.Handler
 		filteredScrapers := filterScrapers(scrapers, collectParams)
 
 		registry := prometheus.NewRegistry()
-		registry.MustRegister(collector.New(ctx, dsn, filteredScrapers, logger))
+		registry.MustRegister(collector.New(ctx, dsn, filteredScrapers, logger, config))
 
 		h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 		h.ServeHTTP(w, r)


### PR DESCRIPTION
This PR removes references to `kingpin.CommandLine`, allowing for the
collector package to be used and configured with a custom kingpin (or no
kingpin at all).

The configuration for collectors has been moved to struct fields, which
the kingpin flags populate at flag parse time. This allows the exporter to be 
embeddable in other programs.