### PR TITLE
display "target" to log msg

### DIFF
--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -136,7 +136,7 @@ func (e *Exporter) scrape(ctx context.Context, ch chan<- prometheus.Metric) floa
 	e.instance = instance
 
 	if err := instance.Ping(); err != nil {
-		level.Error(e.logger).Log("msg", "Error pinging mysqld", "err", err)
+		level.Error(e.logger).Log("msg", "Error pinging mysqld", "target", e.getTargetFromDsn(), "err", err)
 		return 0.0
 	}
 


### PR DESCRIPTION
Hello, I'd like to display the 'target' field in the logs for easier debugging.

**OLD**
`ts=2023-12-19T02:53:31.516Z caller=exporter.go:152 level=error msg="Error pinging mysqld" err="Error 1045 (28000): Access denied for user 'testuser'@'127.0.0.1' (using password: YES)"
ts=2023-12-19T02:53:35.076Z caller=exporter.go:152 level=error msg="Error pinging mysqld" err="Error 1045 (28000): Access denied for user 'testuser'@'127.0.0.1' (using password: YES)"
`

**NEW**
`ts=2023-12-19T02:53:31.516Z caller=exporter.go:152 level=error msg="Error pinging mysqld" target=1.2.3.4:3306 err="Error 1045 (28000): Access denied for user 'testuser'@'127.0.0.1' (using password: YES)"
ts=2023-12-19T02:53:35.076Z caller=exporter.go:152 level=error msg="Error pinging mysqld" target=1.2.3.5:3306 err="Error 1045 (28000): Access denied for user 'testuser'@'127.0.0.1' (using password: YES)"
`