### PR TITLE
Add graceful shutdown

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -15,12 +15,15 @@ package main
 
 import (
 	"context"
+	"errors"
+	"github.com/alecthomas/kingpin/v2"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
 	"time"
 
-	"github.com/alecthomas/kingpin/v2"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
@@ -264,8 +267,26 @@ func main() {
 		_, _ = w.Write([]byte(`ok`))
 	})
 	srv := &http.Server{}
-	if err := web.ListenAndServe(srv, toolkitFlags, logger); err != nil {
-		level.Error(logger).Log("msg", "Error starting HTTP server", "err", err)
+	go func() {
+		if err := web.ListenAndServe(srv, toolkitFlags, logger); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			level.Error(logger).Log("msg", "Error starting HTTP server", "err", err)
+			os.Exit(1)
+		}
+	}()
+	// graceful shutdown
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	_quit := <-quit
+	level.Info(logger).Log("msg", "Received signal, exiting", "signal", _quit.String())
+	// Create a context with a timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Shutdown the HTTP server gracefully
+	if err := srv.Shutdown(ctx); err != nil {
+		level.Error(logger).Log("msg", "Error shutting down HTTP server", "err", err)
 		os.Exit(1)
 	}
+	level.Info(logger).Log("msg", "Server shutdown gracefully")
+
 }


### PR DESCRIPTION
When I send kill signal to mysqld_exporter, I meet "Exit Code: 2, Exit Message: "Docker container exited with non-zero exit code: 2". It make my job-watchdog can't know the mysqld_exporter is it a normal exit.