### PR TITLE
fix(docs): Update docker registry link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ ssl-cert=/path/to/ssl/client/cert
 
 ## Using Docker
 
-You can deploy this exporter using the [prom/mysqld-exporter](https://registry.hub.docker.com/r/prom/mysqld-exporter/) Docker image.
+You can deploy this exporter using the [prom/mysqld-exporter](https://hub.docker.com/r/prom/mysqld-exporter/) Docker image.
 
 For example:
 


### PR DESCRIPTION
It looks like the old link is dead/nonfunctional. This fixes it.