### PR TITLE
Support for prometheus scrape timeout in probe endpoint

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"strconv"
@@ -127,6 +128,32 @@ func filterScrapers(scrapers []collector.Scraper, collectParams []string) []coll
 	return filteredScrapers
 }
 
+func getScrapeTimeoutSeconds(r *http.Request, offset float64) (float64, error) {
+	var timeoutSeconds float64
+	if v := r.Header.Get("X-Prometheus-Scrape-Timeout-Seconds"); v != "" {
+		var err error
+		timeoutSeconds, err = strconv.ParseFloat(v, 64)
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse timeout from Prometheus header: %v", err)
+		}
+	}
+	if timeoutSeconds == 0 {
+		return 0, nil
+	}
+	if timeoutSeconds < 0 {
+		return 0, fmt.Errorf("timeout value from Prometheus header is invalid: %f", timeoutSeconds)
+	}
+
+	if offset >= timeoutSeconds {
+		// Ignore timeout offset if it doesn't leave time to scrape.
+		return 0, fmt.Errorf("timeout offset (%f) should be lower than prometheus scrape timeout (%f)", offset, timeoutSeconds)
+	} else {
+		// Subtract timeout offset from timeout.
+		timeoutSeconds -= offset
+	}
+	return timeoutSeconds, nil
+}
+
 func init() {
 	prometheus.MustRegister(version.NewCollector("mysqld_exporter"))
 }
@@ -155,25 +182,17 @@ func newHandler(scrapers []collector.Scraper, logger log.Logger) http.HandlerFun
 		// Use request context for cancellation when connection gets closed.
 		ctx := r.Context()
 		// If a timeout is configured via the Prometheus header, add it to the context.
-		if v := r.Header.Get("X-Prometheus-Scrape-Timeout-Seconds"); v != "" {
-			timeoutSeconds, err := strconv.ParseFloat(v, 64)
-			if err != nil {
-				level.Error(logger).Log("msg", "Failed to parse timeout from Prometheus header", "err", err)
-			} else {
-				if *timeoutOffset >= timeoutSeconds {
-					// Ignore timeout offset if it doesn't leave time to scrape.
-					level.Error(logger).Log("msg", "Timeout offset should be lower than prometheus scrape timeout", "offset", *timeoutOffset, "prometheus_scrape_timeout", timeoutSeconds)
-				} else {
-					// Subtract timeout offset from timeout.
-					timeoutSeconds -= *timeoutOffset
-				}
-				// Create new timeout context with request context as parent.
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithTimeout(ctx, time.Duration(timeoutSeconds*float64(time.Second)))
-				defer cancel()
-				// Overwrite request with timeout context.
-				r = r.WithContext(ctx)
-			}
+		timeoutSeconds, err := getScrapeTimeoutSeconds(r, *timeoutOffset)
+		if err != nil {
+			level.Error(logger).Log("msg", "Error getting timeout from Prometheus header", "err", err)
+		}
+		if timeoutSeconds > 0 {
+			// Create new timeout context with request context as parent.
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, time.Duration(timeoutSeconds*float64(time.Second)))
+			defer cancel()
+			// Overwrite request with timeout context.
+			r = r.WithContext(ctx)
 		}
 
 		filteredScrapers := filterScrapers(scrapers, collect)

--- a/mysqld_exporter_test.go
+++ b/mysqld_exporter_test.go
@@ -304,3 +304,80 @@ func Test_filterScrapers(t *testing.T) {
 		})
 	}
 }
+
+func Test_getScrapeTimeoutSeconds(t *testing.T) {
+	type args struct {
+		timeoutHeader string
+		offset        float64
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantTimeout float64
+		wantErr     bool
+	}{
+		{"no_timeout_header",
+			args{},
+			0, false,
+		},
+		{"zero_timeout_header",
+			args{
+				timeoutHeader: "0",
+			},
+			0, false,
+		},
+		{"negative_timeout_header",
+			args{
+				timeoutHeader: "-5",
+			},
+			0, true,
+		},
+		{"offset_greater_than_timeout",
+			args{
+				timeoutHeader: "5",
+				offset:        6,
+			},
+			0, true,
+		},
+		{"offset_equal_timeout",
+			args{
+				timeoutHeader: "5",
+				offset:        5,
+			},
+			0, true,
+		},
+		{"offset_less_than_timeout",
+			args{
+				timeoutHeader: "5",
+				offset:        1,
+			},
+			4, false,
+		},
+		{"no_offset",
+			args{
+				timeoutHeader: "5",
+			},
+			5, false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request, err := http.NewRequest(http.MethodGet, "", nil)
+			if err != nil {
+				t.Fatalf("unexpected error creating http request: %v", err)
+			}
+			request.Header.Set("X-Prometheus-Scrape-Timeout-Seconds", tt.args.timeoutHeader)
+
+			timeout, err := getScrapeTimeoutSeconds(request, tt.args.offset)
+			if err != nil && !tt.wantErr {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err == nil && tt.wantErr {
+				t.Fatal("expecting an error, got nil")
+			}
+			if timeout != tt.wantTimeout {
+				t.Fatalf("unexpected timeout, got '%f' but expected '%f'", timeout, tt.wantTimeout)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hey @SuperQ ! First of all, I wanted to say thank you for the great work done in this exporter and for the effort maintaining it 🙏🏻 

In [mariadb-operator](https://github.com/mariadb-operator/mariadb-operator), we are currently provisioning `mysqld_exporter` as a source of metrics for our `MariaDB` resources. The recent introduction of the [multi-target support](https://github.com/prometheus/mysqld_exporter?tab=readme-ov-file#multi-target-support) was a massive improvement for us, as we are able to provision a single `mysqld_exporter`  `Deployment` that exposes the metrics of all the `MariaDB` replicas. This implies that we no longer need  `mysqld_exporter`  sidecars in our `MariaDB` `StatefulSet`, and more importantly, we can upgrade the exporters without affecting the `MariaDB` availability.

Driven by the curiosity of how the `/probe` endpoint was implemented, I've realized that it doesn't support configuring the Prometheus scrape timeout as the `/metrics` endpoint currently does. This PR separates this functionality into a reusable function, applicable to both `/metrics` and `/probe` endpoints. It is my very first PR here, so let me know if I'm missing something!

Exposing metrics in [mariadb-operator](https://github.com/mariadb-operator/mariadb-operator) without `mysqld_exporter`  would have been way more difficult, so again I wanted to express my gratitude, let me know if there is any way I can keep collaborating with this project!

