### PR TITLE
 Fix auto_increment metric collection errors caused by using collation in INFORMATION_SCHEMA searches

### DIFF
--- a/collector/info_schema_auto_increment.go
+++ b/collector/info_schema_auto_increment.go
@@ -24,7 +24,7 @@ import (
 )
 
 const infoSchemaAutoIncrementQuery = `
-		SELECT table_schema, table_name, column_name, auto_increment,
+		SELECT c.table_schema, c.table_name, column_name, auto_increment,
 		  pow(2, case data_type
 		    when 'tinyint'   then 7
 		    when 'smallint'  then 15
@@ -33,7 +33,7 @@ const infoSchemaAutoIncrementQuery = `
 		    when 'bigint'    then 63
 		    end+(column_type like '% unsigned'))-1 as max_int
 		  FROM information_schema.columns c
-		  STRAIGHT_JOIN information_schema.tables t USING (table_schema,table_name)
+		  STRAIGHT_JOIN information_schema.tables t ON (BINARY c.table_schema=t.table_schema AND BINARY c.table_name=t.table_name)
 		  WHERE c.extra = 'auto_increment' AND t.auto_increment IS NOT NULL
 		`
 


### PR DESCRIPTION
Hello, we have encountered the following issues in our actual production:

There are two tables in the database, test.x and test.X, which caused data collection failure.

Original error message:

```
An error has occurred while serving metrics:

4 error(s) occurred:
* collected metric "mysql_info_schema_auto_increment_column" { label:<name:"column" value:"id" > label:<name:"schema" value:"test" > label:<name:"table" value:"x" > gauge:<value:1 > } was collected before with the same name and label values
* collected metric "mysql_info_schema_auto_increment_column_max" { label:<name:"column" value:"id" > label:<name:"schema" value:"test" > label:<name:"table" value:"x" > gauge:<value:4.294967295e+09 > } was collected before with the same name and label values
* collected metric "mysql_info_schema_auto_increment_column" { label:<name:"column" value:"id" > label:<name:"schema" value:"test" > label:<name:"table" value:"X" > gauge:<value:1 > } was collected before with the same name and label values
* collected metric "mysql_info_schema_auto_increment_column_max" { label:<name:"column" value:"id" > label:<name:"schema" value:"test" > label:<name:"table" value:"X" > gauge:<value:4.294967295e+09 > } was collected before with the same name and label values
```

The result set obtained from the original SQL query on the database is as follows:

![img_v3_02a1_b82584ff-f320-41b2-b02a-d97cb6b06c9g](https://github.com/prometheus/mysqld_exporter/assets/51746100/c04493bd-a966-431e-b642-3abed3535238)


MySQL instance parameters:

```
lower_case_file_system=off
lower_case_file_system=0
```

The data of the two tables with different cases, x and X, will appear twice separately. This caused the data collection to fail, and the relevant metrics for that node could not be collected. The table_schema and table_name need to be treated as case-sensitive unique keys for association.

References:

https://bugs.mysql.com/bug.php?id=34921

https://dev.mysql.com/doc/refman/5.7/en/charset-collation-information-schema.html