### PR TITLE
Support MySQL 8.4 replicas syntax

### DIFF
--- a/collector/slave_status.go
+++ b/collector/slave_status.go
@@ -30,7 +30,7 @@ const (
 	slaveStatus = "slave_status"
 )
 
-var slaveStatusQueries = [2]string{"SHOW ALL SLAVES STATUS", "SHOW SLAVE STATUS"}
+var slaveStatusQueries = [3]string{"SHOW ALL SLAVES STATUS", "SHOW SLAVE STATUS", "SHOW REPLICA STATUS"}
 var slaveStatusQuerySuffixes = [3]string{" NONBLOCKING", " NOLOCK", ""}
 
 func columnIndex(slaveCols []string, colName string) int {
@@ -113,7 +113,13 @@ func (ScrapeSlaveStatus) Scrape(ctx context.Context, db *sql.DB, ch chan<- prome
 		}
 
 		masterUUID := columnValue(scanArgs, slaveCols, "Master_UUID")
+		if masterUUID == "" {
+			masterUUID = columnValue(scanArgs, slaveCols, "Source_UUID")
+		}
 		masterHost := columnValue(scanArgs, slaveCols, "Master_Host")
+		if masterHost == "" {
+			masterHost = columnValue(scanArgs, slaveCols, "Source_Host")
+		}
 		channelName := columnValue(scanArgs, slaveCols, "Channel_Name")       // MySQL & Percona
 		connectionName := columnValue(scanArgs, slaveCols, "Connection_name") // MariaDB
 


### PR DESCRIPTION
#### Summary

In MySQL 8.4, several "Replication SQL syntax" commands have been deprecated, requiring the use of new syntax. During testing, it was confirmed that errors occur with the old syntax. This PR updates the code to be compatible with the new syntax. Could you please review this PR?

#### Details

The changes address the syntax errors that arise due to the deprecated commands. Below are the specific errors encountered:

```
mysqld-exporter  | ts=2024-05-15T02:39:40.760Z caller=exporter.go:173 level=error msg="Error from scraper" scraper=slave_status target=mysql_replica:3306 err="Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'SLAVE STATUS' at line 1"
mysqld-exporter  | ts=2024-05-15T02:43:26.471Z caller=exporter.go:173 level=error msg="Error from scraper" scraper=slave_hosts target=mysql_replica:3306 err="Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'SLAVE HOSTS' at line 1"
```

For reference, you can find the MySQL 8.4 release notes here: [MySQL 8.4 Release Notes](https://dev.mysql.com/doc/refman/8.4/en/mysql-nutshell.html#mysql-nutshell-removals).

Thank you for reviewing this PR!