### PR TITLE
Fixed parsing of timestamps with non-zero padded days

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -59,7 +59,7 @@ func parseStatus(data sql.RawBytes) (float64, bool) {
 	case "non-primary", "disconnected":
 		return 0, true
 	}
-	if ts, err := time.Parse("Jan 02 15:04:05 2006 MST", string(data)); err == nil {
+	if ts, err := time.Parse("Jan _2 15:04:05 2006 MST", string(data)); err == nil {
 		return float64(ts.Unix()), true
 	}
 	if ts, err := time.Parse("2006-01-02 15:04:05", string(data)); err == nil {


### PR DESCRIPTION
👋 @SuperQ

After rotating some certificates last week, `mysql_global_status_ssl_server_not_after` metric stopped working. It turned out that the new certificates had expiration dates like `Jun  3 14:02:39 2024 GMT` (single digit day, non-zero padded) and parsing it returned ~negative results.~ (sorry, it was the end of a long day and while trying to be concise I mixed up some early testing results with the real behavior) an error:

```
parsing time "Jun  3 14:02:39 2024 GMT" as "Jan 02 15:04:05 2006 MST": cannot parse "3 14:02:39 2024 GMT" as "02"
```