### PR TITLE
Fix Docker run command and update documentation for cnf file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,9 @@ docker pull prom/mysqld-exporter
 
 docker run -d \
   -p 9104:9104 \
+  -v /home/user/user_my.cnf:/.my.cnf \
   --network my-mysql-network  \
   prom/mysqld-exporter
-  --config.my-cnf=<path_to_cnf>
 ```
 
 ## heartbeat


### PR DESCRIPTION
@SuperQ 

When running docker run as currently specified in the README, it returns -bash: --config.my-cnf=./my.cnf: No such file or directory. If you try using .my.cnf as suggested by someone else in the issue #790 , it returns -bash: --config.my-cnf=.my.cnf: command not found.

It would be better to revise the documentation to have users create the cnf file themselves and use volume mounting instead of using an option.

The updated command is as follows:
```bash
docker run -d \
  -p 9104:9104 \
  -v /home/user/user_my.cnf:/.my.cnf \
  --network my-mysql-network \
  prom/mysqld-exporter
```
