### PR TITLE
feat(INFRA-1459): Stale GH actions workflow and README update

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,18 @@
+name: build-and-test
+
+on:
+  push:
+    branches-ignore:
+      - master
+    tags-ignore:
+      - "*"
+
+jobs:
+  build-and-test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and test
+        run: make

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+name: release
+
+on:
+  push:
+    tags: ["*"]
+
+jobs:
+  create-release:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v1
+        with:
+          version: latest
+          args: release --rm-dist --config .goreleaser.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,15 @@
+---
+name: 'Close stale PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: [self-hosted, runner, mgmt, base]
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label, comment on PR or this will be closed in 10 days.'
+          days-before-stale: 30
+          days-before-close: 10

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,7 +32,7 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
-    name_template: "{{ .Binary }}-{{ .Tag }}.{{ .Os }}-{{ .Arch }}"
+    name_template: "{{ .Binary }}-{{ .Version }}.{{ .Os }}-{{ .Arch }}"
     files:
       - licence*
       - LICENCE*

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,7 +32,7 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
-    name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .Binary }}-{{ .Tag }}.{{ .Os }}-{{ .Arch }}"
     files:
       - licence*
       - LICENCE*

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,44 @@
+project_name: mysqld_exporter
+release:
+  github:
+    owner: CloudTalk-io
+    name: mysqld_exporter
+builds:
+  - id: mysqld_exporter
+    goos:
+    - linux
+    - windows
+    - darwin
+    goarch:
+    - amd64
+    - "386"
+    env:
+      - CGO_ENABLED=0
+      - GO111MODULE=on
+    main: mysqld_exporter.go
+    ldflags: -s -w
+      -X github.com/CloudTalk-io/mysqld_exporter/version.version={{.Version}}
+      -X github.com/CloudTalk-io/mysqld_exporter/version.gitSHA={{.Commit}}
+      -X github.com/CloudTalk-io/mysqld_exporter/version.buildTime={{.Date}}
+      -extldflags "-static"
+    flags: -tags netgo -installsuffix netgo
+    binary: mysqld_exporter
+    hooks: {}
+archives:
+  - id: mysqld_exporter
+    builds:
+      - mysqld_exporter
+    format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+    name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - licence*
+      - LICENCE*
+      - license*
+      - LICENSE*
+      - readme*
+      - README*
+      - changelog*
+      - CHANGELOG*

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,6 +33,7 @@ archives:
       - goos: windows
         format: zip
     name_template: "{{ .Binary }}-{{ .Version }}.{{ .Os }}-{{ .Arch }}"
+    wrap_in_directory: true
     files:
       - licence*
       - LICENCE*

--- a/README.md
+++ b/README.md
@@ -184,3 +184,10 @@ There is a set of sample rules, alerts and dashboards available in the [mysqld-m
 [travis]: https://travis-ci.org/prometheus/mysqld_exporter
 [quay]: https://quay.io/repository/prometheus/mysqld-exporter
 [parsetime]: https://github.com/go-sql-driver/mysql#parsetime
+\n## Stale PRs
+
+Stale pull requests (PRs) are those that have not had any activity for a certain period of time. It's important to manage stale PRs to keep the project's pull requests manageable and to ensure that contributions are either moving forward or being closed if they are no longer relevant.
+
+Stale PRs are managed by using the [Stale](https://github.com/actions/stale):
+- PRs with no activity for 30 days are marked as stale
+- stale PRs for 10 days are closed


### PR DESCRIPTION
## Jira Task link

Link to [INFRA-1459](https://cloudtalk.atlassian.net/browse/INFRA-1459)

## Why is this change required

Configure [Stale](https://github.com/actions/stale) to firstly mark PRs as stale after 30 days of inactivity and then close them after 10 days of being stale.

## What changed

- Added a new workflow file `stale.yaml` to `.github/workflows` directory.
- updated docs