### PR TITLE
File-controlled scrapers that can run arbitrary queries

### DIFF
--- a/collector/extras.go
+++ b/collector/extras.go
@@ -1,0 +1,203 @@
+// Copyright 2024 PlanetScale, Inc. to appease `make check_license`
+package collector
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/yaml.v3"
+)
+
+type ExtraScraper struct {
+	Metric string // suffix after "mysql_extras_" in the fully-qualified metric name
+	Query  string // SQL query with named outputs
+}
+
+func (es *ExtraScraper) Name() string {
+	return fmt.Sprintf("extra_%s", es.Metric)
+}
+
+func (es *ExtraScraper) Help() string {
+	return fmt.Sprintf("Extra metrics from %s", es.Query)
+}
+
+func (*ExtraScraper) Version() float64 {
+	return 5.1
+}
+
+func (es *ExtraScraper) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric, logger log.Logger) error {
+	rows, err := db.QueryContext(ctx, es.Query)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	columns, err := rows.Columns()
+	if err != nil {
+		return err
+	}
+	floats, pointers := make([]float64, len(columns)), make([]any, len(columns))
+	for i := range columns {
+		pointers[i] = &floats[i]
+	}
+
+	for rows.Next() {
+		if err := rows.Scan(pointers...); err != nil {
+			return err
+		}
+
+		for i := range columns {
+			ch <- prometheus.MustNewConstMetric(
+				prometheus.NewDesc(
+					prometheus.BuildFQName(namespace, "extra", es.Metric),
+					es.Help(),
+					nil,
+					prometheus.Labels{"column": columns[i]},
+				),
+				prometheus.GaugeValue,
+				floats[i],
+			)
+		}
+	}
+
+	return nil
+}
+
+var _ Scraper = &ExtraScraper{}
+
+type Extras struct {
+	filename string
+	interval time.Duration
+	logger   log.Logger
+	rw       sync.RWMutex // control asynchronous swaps to scrapers
+	scrapers []*ExtraScraper
+}
+
+func NewExtras(logger log.Logger) (e *Extras, err error) {
+	return newExtras(*extrasFilename, *extrasInterval, logger)
+}
+
+func newExtras(filename, interval string, logger log.Logger) (e *Extras, err error) {
+	e = &Extras{
+		filename: filename,
+		logger:   logger,
+	}
+	if interval != "" {
+		if e.interval, err = time.ParseDuration(interval); err != nil {
+			return
+		}
+		go e.refresh()
+	}
+	if err = e.Refresh(); err != nil {
+		return
+	}
+	return
+}
+
+func (*Extras) Name() string {
+	return "extras"
+}
+
+func (*Extras) Help() string {
+	return "Extra metrics from arbitrary SQL queries"
+}
+
+func (*Extras) Version() float64 {
+	return 5.1
+}
+
+func (e *Extras) Scrape(ctx context.Context, db *sql.DB, ch chan<- prometheus.Metric, logger log.Logger) error {
+	for _, s := range e.Scrapers() {
+		if err := s.Scrape(ctx, db, ch, logger); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var _ Scraper = &Extras{}
+
+func (e *Extras) Filename() string {
+	return e.filename // no need to lock since it's not exported and we don't mutate it
+}
+
+func (e *Extras) Interval() time.Duration {
+	return e.interval // no need to lock since it's not exported and we don't mutate it
+}
+
+func (e *Extras) Refresh() error {
+	if e.filename == "" {
+		return nil
+	}
+
+	f, err := os.Open(e.filename)
+	if errors.Is(err, os.ErrNotExist) || errors.Is(err, io.EOF) {
+		level.Info(e.logger).Log("msg", "Ignoring error refreshing extras", "err", err)
+		return nil // ignore ENOENT and EOF; possibly the next refresh will go better
+	} else if err != nil {
+		return err
+	}
+	defer f.Close()
+	dec := yaml.NewDecoder(f)
+	var scrapers []*ExtraScraper
+	if err := dec.Decode(&scrapers); errors.Is(err, io.EOF) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	e.rw.Lock()
+	defer e.rw.Unlock()
+	e.scrapers = scrapers
+	return nil
+}
+
+func (e *Extras) Scrapers() []*ExtraScraper {
+	e.rw.RLock()
+	defer e.rw.RUnlock()
+	scrapers := make([]*ExtraScraper, len(e.scrapers))
+	copy(scrapers, e.scrapers)
+	return scrapers
+}
+
+func (e *Extras) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Content-Type", "application/json; charset=utf-8")
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "\t") // tab makes this easier to test in a Go source file
+	enc.Encode(struct {
+		Filename, Interval string
+		Scrapers           []*ExtraScraper
+	}{e.Filename(), e.Interval().String(), e.Scrapers()})
+}
+
+func (e *Extras) refresh() {
+	for range time.Tick(e.interval) {
+		if err := e.Refresh(); err != nil {
+			level.Info(e.logger).Log("msg", "Error refreshing extras", "err", err)
+		}
+	}
+}
+
+var (
+	extrasFilename = kingpin.Flag(
+		"extras.file",
+		"path to a file containing extra scraper configurations",
+	).String()
+	extrasInterval = kingpin.Flag(
+		"extras.refresh-interval",
+		"interval (in a format acceptable to Go's time.ParseDuration) for refreshing extra scraper configurations",
+	).String()
+)

--- a/collector/extras_test.go
+++ b/collector/extras_test.go
@@ -1,0 +1,127 @@
+// Copyright 2024 PlanetScale, Inc. to appease `make check_license`
+package collector
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/smartystreets/goconvey/convey"
+)
+
+const (
+	testFooBar       = "foobar"
+	testFooBarQuery  = "SELECT 47 AS foo, 48879 AS bar;"
+	testBazQuux      = "bazquux"
+	testBazQuuxQuery = "SELECT 3.14159 AS baz, 2.71828 AS quux;"
+)
+
+func TestExtrasInit(t *testing.T) {
+	f := createTemp(t)
+	defer removeTemp(t, f)
+	writeExtrasYAML(t, f)                  // write first
+	e, err := newExtras(f.Name(), "", nil) // then read during initialization
+	if err != nil {
+		t.Fatal(err)
+	}
+	testExtraScrapers(t, e)
+}
+
+func TestExtrasRefresh(t *testing.T) {
+	f := createTemp(t)
+	defer removeTemp(t, f)
+	e, err := newExtras(f.Name(), "500ms", nil) // initialize empty
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scrapers := e.Scrapers(); len(scrapers) != 0 { // test that the list is empty
+		t.Fatal(scrapers)
+	}
+	writeExtrasYAML(t, f)   // then write
+	time.Sleep(time.Second) // could e.Refresh() but this exercises the goroutine, too
+	testExtraScrapers(t, e)
+}
+
+func createTemp(t *testing.T) *os.File {
+	f, err := os.CreateTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func removeTemp(t *testing.T, f *os.File) {
+	if err := os.Remove(f.Name()); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testExtraScrapers(t *testing.T, e *Extras) {
+	scrapers := e.Scrapers()
+	if len(scrapers) != 2 {
+		t.Fatal(scrapers)
+	}
+	if scrapers[0].Metric != testFooBar || scrapers[0].Query != testFooBarQuery {
+		t.Fatal(scrapers)
+	}
+	if scrapers[1].Metric != testBazQuux || scrapers[1].Query != testBazQuuxQuery {
+		t.Fatal(scrapers)
+	}
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	mock.ExpectQuery(testFooBarQuery).WillReturnRows(sqlmock.NewRows([]string{"foo", "bar"}).AddRow(47, 48879))
+	mock.ExpectQuery(testBazQuuxQuery).WillReturnRows(sqlmock.NewRows([]string{"baz", "quux"}).AddRow(3.14159, 2.71828))
+	ch := make(chan prometheus.Metric)
+	go func() {
+		if err = e.Scrape(context.Background(), db, ch, log.NewNopLogger()); err != nil {
+			t.Error(err)
+		}
+		close(ch)
+	}()
+	expected := []MetricResult{
+		{labels: labelMap{"column": "foo"}, value: 47, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"column": "bar"}, value: 48879, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"column": "baz"}, value: 3.14159, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"column": "quux"}, value: 2.71828, metricType: dto.MetricType_GAUGE},
+	}
+	convey.Convey("Metrics comparison", t, func() {
+		for _, expect := range expected {
+			got := readMetric(<-ch)
+			convey.So(expect, convey.ShouldResemble, got)
+		}
+	})
+	if m := <-ch; m != nil {
+		t.Fatalf("unexpected %+v", readMetric(m))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeExtrasYAML(t *testing.T, f *os.File) {
+	if _, err := f.Write([]byte(fmt.Sprintf(`---
+- metric: %s
+  query: %s
+- metric: %s
+  query: %s
+...
+`, testFooBar, testFooBarQuery, testBazQuux, testBazQuuxQuery))); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Sync(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/prometheus/exporter-toolkit v0.11.0
 	github.com/smartystreets/goconvey v1.8.1
 	gopkg.in/ini.v1 v1.67.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (


### PR DESCRIPTION
This patch adds `--extras.file` and `--extras.refresh-interval` to `mysqld_exporter` in order to allow easy addition of arbitrary metric-gathering queries without restarting `mysqld` or worse.

Usage:

    cat >extras.yaml <<EOF
    ---
    - metric: foobar
      query: SELECT 47 AS foo, 48879 AS bar;
    - metric: bazquux
      query: SELECT 3.14159 AS baz, 2.71828 AS quux;
    ...
    EOF
    mysqld_exporter \
        --extras.file /path/to/mounted/config/map/extras.yaml \
        --extras.refresh-interval 1m

When scraped, these metrics will be among the output:

    # HELP mysql_extra_bazquux Extra metrics from SELECT 3.14159 AS baz, 2.71828 AS quux;
    # TYPE mysql_extra_bazquux gauge
    mysql_extra_bazquux{column="baz"} 3.14159
    mysql_extra_bazquux{column="quux"} 2.71828
    # HELP mysql_extra_foobar Extra metrics from SELECT 47 AS foo, 48879 AS bar;
    # TYPE mysql_extra_foobar gauge
    mysql_extra_foobar{column="bar"} 48879
    mysql_extra_foobar{column="foo"} 47

The YAML file is not intended to be stuffed in the filesystem and forgotten about. Instead, it should be served via a Kubernetes config map. To update the metrics and queries that it scrapes, update the config map and wait longer than about the `--extras.refresh-interval` plus one minute (empirically how long config map updates take to become visible).

ENOENT and EOF on the `--extras.file` are not considered errors. It might exist next time! This also means that deleting or emptying the file is a valid way to _stop_ collecting these metrics.

Post merge, here's what comes next:

1. Figure out how to build this container image.
2. Test this patch on my pet turtle.
3. Make a release plan and do it.