### PR TITLE
Skip SPACE_TYPE column for MariaDB >=10.5

### DIFF
--- a/collector/info_schema_innodb_sys_tablespaces_test.go
+++ b/collector/info_schema_innodb_sys_tablespaces_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/blang/semver/v4"
 	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -31,7 +32,10 @@ func TestScrapeInfoSchemaInnodbTablespaces(t *testing.T) {
 		t.Fatalf("error opening a stub database connection: %s", err)
 	}
 	defer db.Close()
-	inst := &instance{db: db}
+	inst := &instance{
+		db:     db,
+		flavor: FlavorMySQL,
+	}
 
 	columns := []string{"TABLE_NAME"}
 	rows := sqlmock.NewRows(columns).
@@ -43,7 +47,7 @@ func TestScrapeInfoSchemaInnodbTablespaces(t *testing.T) {
 	rows = sqlmock.NewRows(columns).
 		AddRow(1, "sys/sys_config", "Barracuda", "Dynamic", "Single", 100, 100).
 		AddRow(2, "db/compressed", "Barracuda", "Compressed", "Single", 300, 200)
-	query := fmt.Sprintf(innodbTablespacesQuery, tablespacesTablename, tablespacesTablename)
+	query := fmt.Sprintf(innodbTablespacesQueryMySQL, tablespacesTablename, tablespacesTablename)
 	mock.ExpectQuery(sanitizeQuery(query)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
@@ -59,6 +63,55 @@ func TestScrapeInfoSchemaInnodbTablespaces(t *testing.T) {
 		{labels: labelMap{"tablespace_name": "sys/sys_config"}, value: 100, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{"tablespace_name": "sys/sys_config"}, value: 100, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{"tablespace_name": "db/compressed", "file_format": "Barracuda", "row_format": "Compressed", "space_type": "Single"}, value: 2, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"tablespace_name": "db/compressed"}, value: 300, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"tablespace_name": "db/compressed"}, value: 200, metricType: dto.MetricType_GAUGE},
+	}
+	convey.Convey("Metrics comparison", t, func() {
+		for _, expect := range expected {
+			got := readMetric(<-ch)
+			convey.So(expect, convey.ShouldResemble, got)
+		}
+	})
+}
+
+func TestScrapeInfoSchemaInnodbTablespacesWithoutSpaceType(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("error opening a stub database connection: %s", err)
+	}
+	defer db.Close()
+	inst := &instance{
+		db:      db,
+		flavor:  FlavorMariaDB,
+		version: semver.MustParse("10.5.0"),
+	}
+
+	columns := []string{"TABLE_NAME"}
+	rows := sqlmock.NewRows(columns).
+		AddRow("INNODB_SYS_TABLESPACES")
+	mock.ExpectQuery(sanitizeQuery(innodbTablespacesTablenameQuery)).WillReturnRows(rows)
+
+	tablespacesTablename := "INNODB_SYS_TABLESPACES"
+	columns = []string{"SPACE", "NAME", "FILE_FORMAT", "ROW_FORMAT", "FILE_SIZE", "ALLOCATED_SIZE"}
+	rows = sqlmock.NewRows(columns).
+		AddRow(1, "sys/sys_config", "Barracuda", "Dynamic", 100, 100).
+		AddRow(2, "db/compressed", "Barracuda", "Compressed", 300, 200)
+	query := fmt.Sprintf(innodbTablespacesQueryMariaDB, tablespacesTablename, tablespacesTablename)
+	mock.ExpectQuery(sanitizeQuery(query)).WillReturnRows(rows)
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		if err = (ScrapeInfoSchemaInnodbTablespaces{}).Scrape(context.Background(), inst, ch, log.NewNopLogger()); err != nil {
+			t.Errorf("error calling function on test: %s", err)
+		}
+		close(ch)
+	}()
+
+	expected := []MetricResult{
+		{labels: labelMap{"tablespace_name": "sys/sys_config", "file_format": "Barracuda", "row_format": "Dynamic", "space_type": ""}, value: 1, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"tablespace_name": "sys/sys_config"}, value: 100, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"tablespace_name": "sys/sys_config"}, value: 100, metricType: dto.MetricType_GAUGE},
+		{labels: labelMap{"tablespace_name": "db/compressed", "file_format": "Barracuda", "row_format": "Compressed", "space_type": ""}, value: 2, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{"tablespace_name": "db/compressed"}, value: 300, metricType: dto.MetricType_GAUGE},
 		{labels: labelMap{"tablespace_name": "db/compressed"}, value: 200, metricType: dto.MetricType_GAUGE},
 	}


### PR DESCRIPTION
- To be able to scrape the information_schema.innodb_sys_tablespaces tables
- MariaDB has [cleaned up the INFORMATION_SCHEMA.INNODB_ tables](https://jira.mariadb.org/browse/MDEV-19940) from version 10.5 on

Fixes:
- https://github.com/prometheus/mysqld_exporter/issues/528
- https://github.com/prometheus/mysqld_exporter/issues/662

Co-authored-by @businessbean 

Supersedes:
- https://github.com/prometheus/mysqld_exporter/pull/724