### PR TITLE
Fetch lock time and cpu time from performance schema

### DIFF
--- a/collector/perf_schema_events_statements.go
+++ b/collector/perf_schema_events_statements.go
@@ -31,6 +31,8 @@ const perfEventsStatementsQuery = `
 	    LEFT(DIGEST_TEXT, %d) as DIGEST_TEXT,
 	    COUNT_STAR,
 	    SUM_TIMER_WAIT,
+	    SUM_LOCK_TIME,
+	    SUM_CPU_TIME,
 	    SUM_ERRORS,
 	    SUM_WARNINGS,
 	    SUM_ROWS_AFFECTED,
@@ -54,6 +56,8 @@ const perfEventsStatementsQuery = `
 	    Q.DIGEST_TEXT,
 	    Q.COUNT_STAR,
 	    Q.SUM_TIMER_WAIT,
+	    Q.SUM_LOCK_TIME,
+	    Q.SUM_CPU_TIME,
 	    Q.SUM_ERRORS,
 	    Q.SUM_WARNINGS,
 	    Q.SUM_ROWS_AFFECTED,
@@ -94,6 +98,16 @@ var (
 	performanceSchemaEventsStatementsTimeDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_seconds_total"),
 		"The total time of events statements by digest.",
+		[]string{"schema", "digest", "digest_text"}, nil,
+	)
+	performanceSchemaEventsStatementsLockTimeDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_lock_time_seconds_total"),
+		"The total lock time of events statements by digest.",
+		[]string{"schema", "digest", "digest_text"}, nil,
+	)
+	performanceSchemaEventsStatementsCpuTimeDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_cpu_time_seconds_total"),
+		"The total cpu time of events statements by digest.",
 		[]string{"schema", "digest", "digest_text"}, nil,
 	)
 	performanceSchemaEventsStatementsErrorsDesc = prometheus.NewDesc(
@@ -184,7 +198,8 @@ func (ScrapePerfEventsStatements) Scrape(ctx context.Context, instance *instance
 
 	var (
 		schemaName, digest, digestText       string
-		count, queryTime, errors, warnings   uint64
+		count, queryTime, lockTime, cpuTime  uint64
+		errors, warnings                     uint64
 		rowsAffected, rowsSent, rowsExamined uint64
 		tmpTables, tmpDiskTables             uint64
 		sortMergePasses, sortRows            uint64
@@ -192,7 +207,7 @@ func (ScrapePerfEventsStatements) Scrape(ctx context.Context, instance *instance
 	)
 	for perfSchemaEventsStatementsRows.Next() {
 		if err := perfSchemaEventsStatementsRows.Scan(
-			&schemaName, &digest, &digestText, &count, &queryTime, &errors, &warnings, &rowsAffected, &rowsSent, &rowsExamined, &tmpDiskTables, &tmpTables, &sortMergePasses, &sortRows, &noIndexUsed,
+			&schemaName, &digest, &digestText, &count, &queryTime, &lockTime, &cpuTime, &errors, &warnings, &rowsAffected, &rowsSent, &rowsExamined, &tmpDiskTables, &tmpTables, &sortMergePasses, &sortRows, &noIndexUsed,
 		); err != nil {
 			return err
 		}
@@ -202,6 +217,14 @@ func (ScrapePerfEventsStatements) Scrape(ctx context.Context, instance *instance
 		)
 		ch <- prometheus.MustNewConstMetric(
 			performanceSchemaEventsStatementsTimeDesc, prometheus.CounterValue, float64(queryTime)/picoSeconds,
+			schemaName, digest, digestText,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsLockTimeDesc, prometheus.CounterValue, float64(lockTime)/picoSeconds,
+			schemaName, digest, digestText,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsCpuTimeDesc, prometheus.CounterValue, float64(cpuTime)/picoSeconds,
 			schemaName, digest, digestText,
 		)
 		ch <- prometheus.MustNewConstMetric(


### PR DESCRIPTION
Extend the query on `events_statements_summary_by_digest` to fetch `SUM_LOCK_TIME` and `SUM_CPU_TIME` and return them as counters. These are useful to report time spent running on the cpu (e.g. to sort results or run computations) vs waiting on locks (e.g. to acquire write lock on a table or row), by query digest.