### PR TITLE
info_schema_tables: do not collect the `sys` schema

### DIFF
--- a/collector/info_schema_tables.go
+++ b/collector/info_schema_tables.go
@@ -46,7 +46,7 @@ const (
 		SELECT
 		    SCHEMA_NAME
 		  FROM information_schema.schemata
-		  WHERE SCHEMA_NAME NOT IN ('mysql', 'performance_schema', 'information_schema')
+		  WHERE SCHEMA_NAME NOT IN ('mysql', 'performance_schema', 'information_schema', 'sys')
 		`
 )
 


### PR DESCRIPTION
This `sys` schema is a mariadb-specific "system" schema, introduced in MariaDB 10.6
cf: https://mariadb.com/kb/en/sys-schema/

And it's not useful to collect metrics for it (it's even counter-productive, cf cost of storing the metrics afterwards)
So, let's remove this schema, just like the other "system" schemas (ex: performance_schema) are already excluded today

Note:
It's my first PR here, so I'm not sure about the CI/tests