### PR TITLE
Release 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ Changes:
 * [ENHANCEMENT]
 * [BUGFIX]
 
+## 0.16.0 / 2024-11-08
+
+Changes:
+
+* [CHANGE] Replace logging library go-kit/log with slog #875
+* [FEATURE] Support for prometheus scrape timeout in probe endpoint #828
+* [ENHANCEMENT] Support MySQL 8.4 replicas syntax #837
+* [ENHANCEMENT] Fetch lock time and cpu time from performance schema #862
+* [ENHANCEMENT] Add the instance struct to handle connections #859
+* [ENHANCEMENT] Optimize code by using built-in constants in the standard lib #844
+* [BUGFIX] Fix fetching tmpTables vs tmpDiskTables from performance_schema #853
+* [BUGFIX] Skip SPACE_TYPE column for MariaDB >=10.5 #860
+* [BUGFIX] Fixed parsing of timestamps with non-zero padded days #841
+* [BUGFIX] Fix auto_increment metric collection errors caused by using collation in INFORMATION_SCHEMA searches #833
+* [BUGFIX] Fix race condition in ReloadConfig #760
+* [BUGFIX] Change processlist query to support ONLY_FULL_GROUP_BY sql_mode #684
+* [BUGFIX] replication_applier_status_by_worker requires mysql 8.0 #683
+* [BUGFIX] Update docker registry link in README.md #813
+* [BUGFIX] Fix Docker run command and update documentation for cnf file handling #843
+* [BUGFIX] info_schema_tables: do not collect the sys schema #879
+
 ## 0.15.1 / 2023-12-12
 
 * Rebuild for dependency updates


### PR DESCRIPTION
Changes:
* [CHANGE] Replace logging library go-kit/log with slog https://github.com/prometheus/mysqld_exporter/pull/875
* [FEATURE] Support for prometheus scrape timeout in probe endpoint https://github.com/prometheus/mysqld_exporter/pull/828
* [ENHANCEMENT] Support MySQL 8.4 replicas syntax https://github.com/prometheus/mysqld_exporter/pull/837
* [ENHANCEMENT] Fetch lock time and cpu time from performance schema https://github.com/prometheus/mysqld_exporter/pull/862
* [ENHANCEMENT] Add the instance struct to handle connections https://github.com/prometheus/mysqld_exporter/pull/859
* [ENHANCEMENT] Optimize code by using built-in constants in the standard lib https://github.com/prometheus/mysqld_exporter/pull/844
* [BUGFIX] Fix fetching tmpTables vs tmpDiskTables from performance_schema https://github.com/prometheus/mysqld_exporter/pull/853
* [BUGFIX] Skip SPACE_TYPE column for MariaDB >=10.5 https://github.com/prometheus/mysqld_exporter/pull/860
* [BUGFIX] Fixed parsing of timestamps with non-zero padded days https://github.com/prometheus/mysqld_exporter/pull/841
* [BUGFIX] Fix auto_increment metric collection errors caused by using collation in INFORMATION_SCHEMA searches https://github.com/prometheus/mysqld_exporter/pull/833
* [BUGFIX] Fix race condition in ReloadConfig https://github.com/prometheus/mysqld_exporter/pull/760
* [BUGFIX] Change processlist query to support ONLY_FULL_GROUP_BY sql_mode https://github.com/prometheus/mysqld_exporter/pull/684
* [BUGFIX] replication_applier_status_by_worker requires mysql 8.0 https://github.com/prometheus/mysqld_exporter/pull/683
* [BUGFIX] Update docker registry link in README.md https://github.com/prometheus/mysqld_exporter/pull/813
* [BUGFIX] Fix Docker run command and update documentation for cnf file handling https://github.com/prometheus/mysqld_exporter/pull/843
* [BUGFIX] info_schema_tables: do not collect the sys schema https://github.com/prometheus/mysqld_exporter/pull/879