### PR TITLE
Add perf_schema quantile columns to collector

### DIFF
--- a/collector/perf_schema_events_statements.go
+++ b/collector/perf_schema_events_statements.go
@@ -42,7 +42,10 @@ const perfEventsStatementsQuery = `
 	    SUM_CREATED_TMP_TABLES,
 	    SUM_SORT_MERGE_PASSES,
 	    SUM_SORT_ROWS,
-	    SUM_NO_INDEX_USED
+	    SUM_NO_INDEX_USED,
+	    QUANTILE_95,
+	    QUANTILE_99,
+	    QUANTILE_999
 	  FROM (
 	    SELECT *
 	    FROM performance_schema.events_statements_summary_by_digest
@@ -67,7 +70,10 @@ const perfEventsStatementsQuery = `
 	    Q.SUM_CREATED_TMP_TABLES,
 	    Q.SUM_SORT_MERGE_PASSES,
 	    Q.SUM_SORT_ROWS,
-	    Q.SUM_NO_INDEX_USED
+	    Q.SUM_NO_INDEX_USED,
+	    Q.QUANTILE_95,
+	    Q.QUANTILE_99,
+	    Q.QUANTILE_999
 	  ORDER BY SUM_TIMER_WAIT DESC
 	  LIMIT %d
 	`
@@ -160,6 +166,21 @@ var (
 		"The total number of statements that used full table scans by digest.",
 		[]string{"schema", "digest", "digest_text"}, nil,
 	)
+	performanceSchemaEventsStatementsQuantile95 = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_quantile_95"),
+		"The 95th percentile of the statement latency, in picoseconds.",
+		[]string{"schema", "digest", "digest_text"}, nil,
+	)
+	performanceSchemaEventsStatementsQuantile99 = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_quantile_99"),
+		"The 99th percentile of the statement latency, in picoseconds.",
+		[]string{"schema", "digest", "digest_text"}, nil,
+	)
+	performanceSchemaEventsStatementsQuantile999 = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, performanceSchema, "events_statements_quantile_999"),
+		"The 99.9th percentile of the statement latency, in picoseconds.",
+		[]string{"schema", "digest", "digest_text"}, nil,
+	)
 )
 
 // ScrapePerfEventsStatements collects from `performance_schema.events_statements_summary_by_digest`.
@@ -204,10 +225,11 @@ func (ScrapePerfEventsStatements) Scrape(ctx context.Context, instance *instance
 		tmpTables, tmpDiskTables             uint64
 		sortMergePasses, sortRows            uint64
 		noIndexUsed                          uint64
+		quantile95, quantile99, quantile999  uint64
 	)
 	for perfSchemaEventsStatementsRows.Next() {
 		if err := perfSchemaEventsStatementsRows.Scan(
-			&schemaName, &digest, &digestText, &count, &queryTime, &lockTime, &cpuTime, &errors, &warnings, &rowsAffected, &rowsSent, &rowsExamined, &tmpDiskTables, &tmpTables, &sortMergePasses, &sortRows, &noIndexUsed,
+			&schemaName, &digest, &digestText, &count, &queryTime, &lockTime, &cpuTime, &errors, &warnings, &rowsAffected, &rowsSent, &rowsExamined, &tmpDiskTables, &tmpTables, &sortMergePasses, &sortRows, &noIndexUsed, &quantile95, &quantile99, &quantile999,
 		); err != nil {
 			return err
 		}
@@ -265,6 +287,18 @@ func (ScrapePerfEventsStatements) Scrape(ctx context.Context, instance *instance
 		)
 		ch <- prometheus.MustNewConstMetric(
 			performanceSchemaEventsStatementsNoIndexUsedDesc, prometheus.CounterValue, float64(noIndexUsed),
+			schemaName, digest, digestText,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsQuantile95, prometheus.CounterValue, float64(quantile95),
+			schemaName, digest, digestText,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsQuantile99, prometheus.CounterValue, float64(quantile99),
+			schemaName, digest, digestText,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			performanceSchemaEventsStatementsQuantile999, prometheus.CounterValue, float64(quantile999),
 			schemaName, digest, digestText,
 		)
 	}


### PR DESCRIPTION
This change appends the 3 quantile columns exposed in the `events_statements_summary_by_digest` table to the
`perf_schema_events_statements` collector so that they are available as a summary metric.

We believe this to be a useful addition so that the various quantiles (p95, p99, p99.5) are available to query and spot changes in performance for a given query. Our use case is to visualise these quantiles for a specific digest to provide more insight than just average query times.

The new summary metric `mysql_perf_schema_events_statements_latency` has 3 quantiles: 95, 99, 99.5 and in addition has a `sum` and `count` metric that matches the values of `events_statements_seconds_total` and `events_statements_total` respectively. These metrics may be considered redundant with this addition.

There is mention of adding quantiles in a previous change from a colleague [here](https://github.com/prometheus/mysqld_exporter/pull/862#issuecomment-2310478376) which wasn't further investigated. 

Sample `/metrics` output that includes the new metrics:
```
# HELP mysql_perf_schema_events_statements_latency A summary of statement latency by digest
# TYPE mysql_perf_schema_events_statements_latency summary
mysql_perf_schema_events_statements_latency{digest="12fbbd91beb73676bfc7c0cf3cc73d8c29ccc0349a54e367556b6fb7d244a4f8",digest_text="SELECT DISTINCTROW `stack_id` FROM `jobs`",schema="hosted_exporters",quantile="95"} 0.000208929613
mysql_perf_schema_events_statements_latency{digest="12fbbd91beb73676bfc7c0cf3cc73d8c29ccc0349a54e367556b6fb7d244a4f8",digest_text="SELECT DISTINCTROW `stack_id` FROM `jobs`",schema="hosted_exporters",quantile="99"} 0.000239883291
mysql_perf_schema_events_statements_latency{digest="12fbbd91beb73676bfc7c0cf3cc73d8c29ccc0349a54e367556b6fb7d244a4f8",digest_text="SELECT DISTINCTROW `stack_id` FROM `jobs`",schema="hosted_exporters",quantile="999"} 0.001819700858
mysql_perf_schema_events_statements_latency_sum{digest="12fbbd91beb73676bfc7c0cf3cc73d8c29ccc0349a54e367556b6fb7d244a4f8",digest_text="SELECT DISTINCTROW `stack_id` FROM `jobs`",schema="hosted_exporters"} 2828.78780601
mysql_perf_schema_events_statements_latency_count{digest="12fbbd91beb73676bfc7c0cf3cc73d8c29ccc0349a54e367556b6fb7d244a4f8",digest_text="SELECT DISTINCTROW `stack_id` FROM `jobs`",schema="hosted_exporters"} 1.8455211e+07
```


