### PR TITLE
Add missing metrics_path to multi-target example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Sample config file for multiple configurations
 On the prometheus side you can set a scrape config as follows
 
         - job_name: mysql # To get metrics about the mysql exporter’s targets
+          metrics_path: /probe
           params:
             # Not required. Will match value to child in config file. Default value is `client`.
             auth_module: [client.servers]


### PR DESCRIPTION
Addresses issue 815:
https://github.com/prometheus/mysqld_exporter/issues/815

Like the author of the issue, I also used the example in the README file to setup scraping with Prometheus only to discover that by default the /metrics end-point is scraped instead.