### PR TITLE
Fix database quoting problem in collector 'info_schema.tables'

### DIFF
--- a/collector/info_schema_tables.go
+++ b/collector/info_schema_tables.go
@@ -17,7 +17,6 @@ package collector
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"strings"
 
@@ -40,7 +39,7 @@ const (
 		    ifnull(DATA_FREE, '0') as DATA_FREE,
 		    ifnull(CREATE_OPTIONS, 'NONE') as CREATE_OPTIONS
 		  FROM information_schema.tables
-		  WHERE TABLE_SCHEMA = '%s'
+		  WHERE TABLE_SCHEMA = ?
 		`
 	dbListQuery = `
 		SELECT
@@ -121,7 +120,7 @@ func (ScrapeTableSchema) Scrape(ctx context.Context, instance *instance, ch chan
 	}
 
 	for _, database := range dbList {
-		tableSchemaRows, err := db.QueryContext(ctx, fmt.Sprintf(tableSchemaQuery, database))
+		tableSchemaRows, err := db.QueryContext(ctx, tableSchemaQuery, database)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
In `collector/info_schema_tables.go`, the SQL it uses to retrieves the table meta data is

```
SELECT
	TABLE_SCHEMA,
	...
FROM information_schema.tables
WHERE TABLE_SCHEMA = '%s'
```

Which could cause a problem if the schema contains the single quote character `'` (It's indeed a vaild character in database/table name), we should use the placeholder `?` and pass the schema as an argument to `db.QueryContext(...)` to avoid this kind of problem. Also to avoid the SQL injection problem as user can pass anything to `--collect.info_schema.tables.databases` in reality (accidentally or on purpose).