### PR TITLE
Creating DSN using database name.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -61,6 +61,7 @@ type MySqlConfig struct {
 	User                  string `ini:"user"`
 	Password              string `ini:"password"`
 	Host                  string `ini:"host"`
+	Database              string `ini:"database"`
 	Port                  int    `ini:"port"`
 	Socket                string `ini:"socket"`
 	SslCa                 string `ini:"ssl-ca"`
@@ -166,6 +167,7 @@ func (m MySqlConfig) FormDSN(target string) (string, error) {
 	config := mysql.NewConfig()
 	config.User = m.User
 	config.Passwd = m.Password
+	config.DBName = m.Database
 	config.Net = "tcp"
 	if target == "" {
 		if m.Socket == "" {


### PR DESCRIPTION
This patch introduces the ability to specify a database name in the Data Source Name (DSN) configuration for the MySQL exporter.

Previously, the exporter would connect to the default database if no database name was provided.

With this change, users can define a specific database name in the configuration.

