### PR TITLE
Update Mixin dashboard to editable: false

### DIFF
--- a/mysqld-mixin/dashboards/mysql-overview.json
+++ b/mysqld-mixin/dashboards/mysql-overview.json
@@ -13,7 +13,7 @@
     ]
   },
   "description": "",
-  "editable": true,
+  "editable": false,
   "gnetId": 11323,
   "graphTooltip": 1,
   "id": 31,


### PR DESCRIPTION
This was reported by the mixtool lint:
  mixtool lint mixin.libsonnet
  [uneditable-dashboard] 'MySQL': Dashboard 'MySQL' is editable, it should be set to 'editable: false'

This is quick attempt at fixing the mixin CI error going by its error description. I haven't looked further on the implications of this.