### PR TITLE
Fix query on perf_schema.events_statements_summary_by_digest

### DIFF
--- a/collector/perf_schema_events_statements.go
+++ b/collector/perf_schema_events_statements.go
@@ -17,6 +17,7 @@ package collector
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -249,6 +250,13 @@ func (ScrapePerfEventsStatements) Scrape(ctx context.Context, instance *instance
 	if mysqlVersion8028 {
 		perfQuery = perfEventsStatementsQueryMySQL
 	}
+
+	perfQuery = fmt.Sprintf(
+		perfQuery,
+		*perfEventsStatementsDigestTextLimit,
+		*perfEventsStatementsTimeLimit,
+		*perfEventsStatementsLimit,
+	)
 
 	db := instance.getDB()
 	// Timers here are returned in picoseconds.

--- a/collector/perf_schema_events_statements_test.go
+++ b/collector/perf_schema_events_statements_test.go
@@ -15,6 +15,7 @@ package collector
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -50,7 +51,8 @@ func TestScrapePerfEventsStatements(t *testing.T) {
 			100, 1,
 			100, 150, 200)
 
-	mock.ExpectQuery(sanitizeQuery(perfEventsStatementsQuery)).WillReturnRows(rows)
+	query := fmt.Sprintf(perfEventsStatementsQuery, 120, 86400, 250)
+	mock.ExpectQuery(sanitizeQuery(query)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
 	go func() {
@@ -125,7 +127,8 @@ func TestScrapePerfEventsStatementsMySQL8028(t *testing.T) {
 			100, 1,
 			100, 150, 200)
 
-	mock.ExpectQuery(sanitizeQuery(perfEventsStatementsQueryMySQL)).WillReturnRows(rows)
+	query := fmt.Sprintf(perfEventsStatementsQueryMySQL, 120, 86400, 250)
+	mock.ExpectQuery(sanitizeQuery(query)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
 	go func() {


### PR DESCRIPTION
Followup of https://github.com/prometheus/mysqld_exporter/pull/916, where I wrongly deleted query params formatting.