### PR TITLE
Use QUANTILE columns only with mysql >= 8.0.28

### DIFF
--- a/collector/perf_schema_events_statements.go
+++ b/collector/perf_schema_events_statements.go
@@ -41,10 +41,7 @@ const perfEventsStatementsQuery = `
 	    SUM_CREATED_TMP_TABLES,
 	    SUM_SORT_MERGE_PASSES,
 	    SUM_SORT_ROWS,
-	    SUM_NO_INDEX_USED,
-	    QUANTILE_95,
-	    QUANTILE_99,
-	    QUANTILE_999
+	    SUM_NO_INDEX_USED
 	  FROM (
 	    SELECT *
 	    FROM performance_schema.events_statements_summary_by_digest

--- a/collector/perf_schema_events_statements.go
+++ b/collector/perf_schema_events_statements.go
@@ -67,10 +67,7 @@ const perfEventsStatementsQuery = `
 	    Q.SUM_CREATED_TMP_TABLES,
 	    Q.SUM_SORT_MERGE_PASSES,
 	    Q.SUM_SORT_ROWS,
-	    Q.SUM_NO_INDEX_USED,
-	    Q.QUANTILE_95,
-	    Q.QUANTILE_99,
-	    Q.QUANTILE_999
+	    Q.SUM_NO_INDEX_USED
 	  ORDER BY SUM_TIMER_WAIT DESC
 	  LIMIT %d
 	`
@@ -284,7 +281,7 @@ func (ScrapePerfEventsStatements) Scrape(ctx context.Context, instance *instance
 			)
 		} else {
 			err = perfSchemaEventsStatementsRows.Scan(
-				&schemaName, &digest, &digestText, &count, &queryTime, &errors, &warnings, &rowsAffected, &rowsSent, &rowsExamined, &tmpDiskTables, &tmpTables, &sortMergePasses, &sortRows, &noIndexUsed, &quantile95, &quantile99, &quantile999,
+				&schemaName, &digest, &digestText, &count, &queryTime, &errors, &warnings, &rowsAffected, &rowsSent, &rowsExamined, &tmpDiskTables, &tmpTables, &sortMergePasses, &sortRows, &noIndexUsed,
 			)
 		}
 		if err != nil {

--- a/collector/perf_schema_events_statements_test.go
+++ b/collector/perf_schema_events_statements_test.go
@@ -39,7 +39,6 @@ func TestScrapePerfEventsStatements(t *testing.T) {
 		"SUM_ROWS_AFFECTED", "SUM_ROWS_SENT", "SUM_ROWS_EXAMINED",
 		"SUM_CREATED_TMP_DISK_TABLES", "SUM_CREATED_TMP_TABLES", "SUM_SORT_MERGE_PASSES",
 		"SUM_SORT_ROWS", "SUM_NO_INDEX_USED",
-		"QUANTILE_95", "QUANTILE_99", "QUANTILE_999",
 	}
 
 	rows := sqlmock.NewRows(columns).
@@ -48,8 +47,7 @@ func TestScrapePerfEventsStatements(t *testing.T) {
 			100, 1000, 1, 2,
 			50, 100, 150,
 			1, 2, 3,
-			100, 1,
-			100, 150, 200)
+			100, 1)
 
 	query := fmt.Sprintf(perfEventsStatementsQuery, 120, 86400, 250)
 	mock.ExpectQuery(sanitizeQuery(query)).WillReturnRows(rows)


### PR DESCRIPTION
Followup of #916 and #920. These columns are not available in MariaDB.