### PR TITLE
Mixin: Use std.parseYaml instead of Tanka native function.

### DIFF
--- a/mysqld-mixin/mixin.libsonnet
+++ b/mysqld-mixin/mixin.libsonnet
@@ -1,12 +1,12 @@
 {
-  grafanaDashboards: {
+  grafanaDashboards+: {
     'mysql-overview.json': (import 'dashboards/mysql-overview.json'),
   },
 
   // Helper function to ensure that we don't override other rules, by forcing
   // the patching of the groups list, and not the overall rules object.
   local importRules(rules) = {
-    groups+: std.native('parseYaml')(rules)[0].groups,
+    groups+: std.parseYaml(rules).groups,
   },
 
   prometheusRules+: importRules(importstr 'rules/rules.yaml'),


### PR DESCRIPTION
This little fix allows to use mysql-mixin as a jsonnet library using standard jsonnet tools.

Resolves: #518
