### PR TITLE
fix: Fixed the problem that password verification failed when there i…

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -48,6 +48,10 @@ var (
 		Loose: true,
 		// MySQL ini file can have boolean keys.
 		AllowBooleanKeys: true,
+		// Ignore the # character in the line to avoid password parsing failure when the MySQL password contains the # symbol
+		IgnoreInlineComment: true,
+		// Remove the first and last quotation marks
+		UnescapeValueDoubleQuotes: true,
 	}
 
 	err error


### PR DESCRIPTION
Fixes #933  
Fixes #930  
Fixed the problem that password verification failed when there is a # symbol in the MySQL password (msg="Error opening connection to database" err="Error 1045 (28000): Access denied for user 'USER'@'*.*.*.*' (using password: YES)")