### PR TITLE
Review regex declarations in innodb and global variables collectors

### DIFF
--- a/collector/engine_innodb.go
+++ b/collector/engine_innodb.go
@@ -75,7 +75,7 @@ func (ScrapeEngineInnodbStatus) Scrape(ctx context.Context, instance *instance, 
 	}
 
 	for _, line := range strings.Split(statusCol, "\n") {
-		if data := rQueries.FindStringSubmatch(line); data != nil {
+		if data := queriesRe.FindStringSubmatch(line); data != nil {
 			value, _ := strconv.ParseFloat(data[1], 64)
 			ch <- prometheus.MustNewConstMetric(
 				newDesc(innodb, "queries_inside_innodb", "Queries inside InnoDB."),
@@ -88,7 +88,7 @@ func (ScrapeEngineInnodbStatus) Scrape(ctx context.Context, instance *instance, 
 				prometheus.GaugeValue,
 				value,
 			)
-		} else if data := rViews.FindStringSubmatch(line); data != nil {
+		} else if data := viewsRe.FindStringSubmatch(line); data != nil {
 			value, _ := strconv.ParseFloat(data[1], 64)
 			ch <- prometheus.MustNewConstMetric(
 				newDesc(innodb, "read_views_open_inside_innodb", "Read views open inside InnoDB."),

--- a/collector/engine_innodb.go
+++ b/collector/engine_innodb.go
@@ -32,6 +32,13 @@ const (
 	engineInnodbStatusQuery = `SHOW ENGINE INNODB STATUS`
 )
 
+var (
+	// 0 queries inside InnoDB, 0 queries in queue
+	// 0 read views open inside InnoDB
+	rQueries = regexp.MustCompile(`(\d+) queries inside InnoDB, (\d+) queries in queue`)
+	rViews   = regexp.MustCompile(`(\d+) read views open inside InnoDB`)
+)
+
 // ScrapeEngineInnodbStatus scrapes from `SHOW ENGINE INNODB STATUS`.
 type ScrapeEngineInnodbStatus struct{}
 
@@ -66,11 +73,6 @@ func (ScrapeEngineInnodbStatus) Scrape(ctx context.Context, instance *instance, 
 			return err
 		}
 	}
-
-	// 0 queries inside InnoDB, 0 queries in queue
-	// 0 read views open inside InnoDB
-	rQueries, _ := regexp.Compile(`(\d+) queries inside InnoDB, (\d+) queries in queue`)
-	rViews, _ := regexp.Compile(`(\d+) read views open inside InnoDB`)
 
 	for _, line := range strings.Split(statusCol, "\n") {
 		if data := rQueries.FindStringSubmatch(line); data != nil {

--- a/collector/engine_innodb.go
+++ b/collector/engine_innodb.go
@@ -35,8 +35,8 @@ const (
 var (
 	// 0 queries inside InnoDB, 0 queries in queue
 	// 0 read views open inside InnoDB
-	rQueries = regexp.MustCompile(`(\d+) queries inside InnoDB, (\d+) queries in queue`)
-	rViews   = regexp.MustCompile(`(\d+) read views open inside InnoDB`)
+	queriesRe = regexp.MustCompile(`(\d+) queries inside InnoDB, (\d+) queries in queue`)
+	viewsRe   = regexp.MustCompile(`(\d+) read views open inside InnoDB`)
 )
 
 // ScrapeEngineInnodbStatus scrapes from `SHOW ENGINE INNODB STATUS`.


### PR DESCRIPTION
Move regex vars to package level to avoid re-compilation on each scrape.