### PR TITLE
add support for cleartext authentication

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -67,6 +67,7 @@ type MySqlConfig struct {
 	Host                  string `ini:"host"`
 	Port                  int    `ini:"port"`
 	Socket                string `ini:"socket"`
+	EnableCleartextPlugin bool   `ini:"enable-cleartext-plugin"`
 	SslCa                 string `ini:"ssl-ca"`
 	SslCert               string `ini:"ssl-cert"`
 	SslKey                string `ini:"ssl-key"`
@@ -207,6 +208,10 @@ func (m MySqlConfig) FormDSN(target string) (string, error) {
 			}
 			config.TLSConfig = "custom"
 		}
+	}
+
+	if m.EnableCleartextPlugin {
+		config.AllowCleartextPasswords = true
 	}
 
 	return config.FormatDSN(), nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -138,6 +138,21 @@ func TestValidateConfig(t *testing.T) {
 		convey.So(section.User, convey.ShouldEqual, "abc")
 		convey.So(section.Password, convey.ShouldEqual, "")
 	})
+
+	convey.Convey("Client with cleartext password enabled", t, func() {
+		c := MySqlConfigHandler{
+			Config: &Config{},
+		}
+		os.Clearenv()
+		if err := c.ReloadConfig("testdata/client.cnf", "localhost:3306", "", true, promslog.NewNopLogger()); err != nil {
+			t.Error(err)
+		}
+		cfg := c.GetConfig()
+		section := cfg.Sections["client.cleartextPlugin"]
+		convey.So(section.User, convey.ShouldEqual, "test")
+		convey.So(section.Password, convey.ShouldEqual, "foo")
+		convey.So(section.EnableCleartextPlugin, convey.ShouldBeTrue)
+	})
 }
 
 func TestFormDSN(t *testing.T) {
@@ -176,6 +191,14 @@ func TestFormDSN(t *testing.T) {
 				t.Error(err)
 			}
 			convey.So(dsn, convey.ShouldEqual, "test:foo@unix(/run/mysqld/mysqld.sock)/")
+		})
+		convey.Convey("With cleartext password enabled", func() {
+			cfg := c.GetConfig()
+			section := cfg.Sections["client.cleartextPlugin"]
+			if dsn, err = section.FormDSN(""); err != nil {
+				t.Error(err)
+			}
+			convey.So(dsn, convey.ShouldEqual, "test:foo@tcp(server2:3306)/?allowCleartextPasswords=true")
 		})
 	})
 }

--- a/config/testdata/client.cnf
+++ b/config/testdata/client.cnf
@@ -5,3 +5,7 @@ host = server2
 [client.server1]
 user = test
 password = foo
+[client.cleartextPlugin]
+user = test
+password = foo
+enable-cleartext-plugin = true


### PR DESCRIPTION
This PR adds support for authentication via the cleartext plugin. While the driver had supported it for a while, it wasn't supported at the exporter level.

We recently [added this to the Percona fork](https://github.com/percona/mysqld_exporter/pull/307/) (which we ship with PMM), and was hoping we can contribute it here as well - considering there has been a couple of issues around it (#884, #785).

Closes: https://github.com/prometheus/mysqld_exporter/issues/884