### PR TITLE
sys.user_summary: Fix handling of negative current_memory values

### DIFF
--- a/collector/sys_user_summary.go
+++ b/collector/sys_user_summary.go
@@ -118,7 +118,7 @@ func (ScrapeSysUserSummary) Scrape(ctx context.Context, instance *instance, ch c
 		current_connections    uint64
 		total_connections      uint64
 		unique_hosts           uint64
-		current_memory         uint64
+		current_memory         int64
 		total_memory_allocated uint64
 	)
 

--- a/collector/sys_user_summary_test.go
+++ b/collector/sys_user_summary_test.go
@@ -77,6 +77,19 @@ func TestScrapeSysUserSummary(t *testing.T) {
 			"210",
 			"211",
 		},
+		{
+			"user3",
+			"310",
+			"320",
+			"340",
+			"350",
+			"360",
+			"370",
+			"380",
+			"390",
+			"-16360",
+			"411",
+		},
 	}
 	expectedMetrics := []MetricResult{}
 	// Register the query results with mock SQL driver and assemble expected metric results list


### PR DESCRIPTION
MySQL's sys.user_summary.current_memory column can contain negative values
when memory is freed faster than allocated. This is valid MySQL behavior.

Changes:
- Changed current_memory type from uint64 to int64
- Added test case with negative current_memory value (-16360)

Fixes scan error: 'converting driver.Value type []uint8 to uint64: invalid syntax'

Signed-off-by: Ali Maleki <alimaleki.wit@gmail.com>