### PR TITLE
Resolve ambiguous column reference in processlist query

### DIFF
--- a/collector/info_schema_processlist.go
+++ b/collector/info_schema_processlist.go
@@ -38,7 +38,7 @@ const infoSchemaProcesslistQuery = `
 		  FROM information_schema.processlist
 		  WHERE ID != connection_id()
 		    AND TIME >= %d
-		  GROUP BY user, host, command, state
+		  GROUP BY user, SUBSTRING_INDEX(host, ':', 1), COALESCE(command, ''), COALESCE(state, '')
 	`
 
 // Tunable flags.

--- a/collector/info_schema_processlist.go
+++ b/collector/info_schema_processlist.go
@@ -28,17 +28,18 @@ import (
 )
 
 const infoSchemaProcesslistQuery = `
-		  SELECT
-		    user,
-		    SUBSTRING_INDEX(host, ':', 1) AS host,
-		    COALESCE(command, '') AS command,
-		    COALESCE(state, '') AS state,
-		    COUNT(*) AS processes,
-		    SUM(time) AS seconds
-		  FROM information_schema.processlist
-		  WHERE ID != connection_id()
-		    AND TIME >= %d
-		  GROUP BY user, SUBSTRING_INDEX(host, ':', 1), COALESCE(command, ''), COALESCE(state, '')
+	SELECT user, host, command, state, COUNT(*) AS processes, SUM(time) AS seconds
+	FROM (
+	  SELECT user,
+	         SUBSTRING_INDEX(host, ':', 1) AS host,
+	         COALESCE(command, '') AS command,
+	         COALESCE(state, '')   AS state,
+	         time
+	  FROM information_schema.processlist
+	  WHERE ID != CONNECTION_ID()
+	  AND TIME >= %d
+	) p
+	GROUP BY user, host, command, state
 	`
 
 // Tunable flags.


### PR DESCRIPTION
Replace bare column names with COALESCE expressions in GROUP BY clause to match SELECT clause, eliminating MySQL warning 1052 for ambiguous 'state' column