### PR TITLE
chore: modernize WaitGroup usage

### DIFF
--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -173,9 +173,7 @@ func (e *Exporter) scrape(ctx context.Context, ch chan<- prometheus.Metric) floa
 			continue
 		}
 
-		wg.Add(1)
-		go func(scraper Scraper) {
-			defer wg.Done()
+		wg.Go(func() {
 			label := "collect." + scraper.Name()
 			scrapeTime := time.Now()
 			collectorSuccess := 1.0
@@ -185,7 +183,7 @@ func (e *Exporter) scrape(ctx context.Context, ch chan<- prometheus.Metric) floa
 			}
 			ch <- prometheus.MustNewConstMetric(mysqlScrapeCollectorSuccess, prometheus.GaugeValue, collectorSuccess, label)
 			ch <- prometheus.MustNewConstMetric(mysqlScrapeDurationSeconds, prometheus.GaugeValue, time.Since(scrapeTime).Seconds(), label)
-		}(scraper)
+		})
 	}
 	return 1.0
 }

--- a/collector/info_schema_processlist.go
+++ b/collector/info_schema_processlist.go
@@ -19,8 +19,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"reflect"
-	"sort"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -155,35 +155,25 @@ func (ScrapeProcesslist) Scrape(ctx context.Context, instance *instance, ch chan
 		stateUserCounts[user] += count
 	}
 
-	for _, command := range sortedMapKeys(stateCounts) {
-		for _, state := range sortedMapKeys(stateCounts[command]) {
+	for _, command := range slices.Sorted(maps.Keys(stateCounts)) {
+		for _, state := range slices.Sorted(maps.Keys(stateCounts[command])) {
 			ch <- prometheus.MustNewConstMetric(processlistCountDesc, prometheus.GaugeValue, float64(stateCounts[command][state]), command, state)
 			ch <- prometheus.MustNewConstMetric(processlistTimeDesc, prometheus.GaugeValue, float64(stateTime[command][state]), command, state)
 		}
 	}
 
 	if *processesByHostFlag {
-		for _, host := range sortedMapKeys(stateHostCounts) {
+		for _, host := range slices.Sorted(maps.Keys(stateHostCounts)) {
 			ch <- prometheus.MustNewConstMetric(processesByHostDesc, prometheus.GaugeValue, float64(stateHostCounts[host]), host)
 		}
 	}
 	if *processesByUserFlag {
-		for _, user := range sortedMapKeys(stateUserCounts) {
+		for _, user := range slices.Sorted(maps.Keys(stateUserCounts)) {
 			ch <- prometheus.MustNewConstMetric(processesByUserDesc, prometheus.GaugeValue, float64(stateUserCounts[user]), user)
 		}
 	}
 
 	return nil
-}
-
-func sortedMapKeys(m interface{}) []string {
-	v := reflect.ValueOf(m)
-	keys := make([]string, 0, len(v.MapKeys()))
-	for _, key := range v.MapKeys() {
-		keys = append(keys, key.String())
-	}
-	sort.Strings(keys)
-	return keys
 }
 
 func sanitizeState(state string) string {

--- a/mysqld_exporter_test.go
+++ b/mysqld_exporter_test.go
@@ -89,7 +89,6 @@ func TestBin(t *testing.T) {
 	portStart := 56000
 	t.Run(binName, func(t *testing.T) {
 		for _, f := range tests {
-			f := f // capture range variable
 			fName := runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
 			portStart++
 			data := bin{
@@ -284,21 +283,26 @@ func Test_filterScrapers(t *testing.T) {
 		args args
 		want []collector.Scraper
 	}{
-		{"args_appears_in_collector",
+		{
+			"args_appears_in_collector",
 			args{
 				[]collector.Scraper{collector.ScrapeGlobalStatus{}},
 				[]string{collector.ScrapeGlobalStatus{}.Name()},
 			},
 			[]collector.Scraper{
 				collector.ScrapeGlobalStatus{},
-			}},
-		{"args_absent_in_collector",
+			},
+		},
+		{
+			"args_absent_in_collector",
 			args{
 				[]collector.Scraper{collector.ScrapeGlobalStatus{}},
 				[]string{collector.ScrapeGlobalVariables{}.Name()},
 			},
-			[]collector.Scraper{collector.ScrapeGlobalStatus{}}},
-		{"respect_params",
+			[]collector.Scraper{collector.ScrapeGlobalStatus{}},
+		},
+		{
+			"respect_params",
 			args{
 				[]collector.Scraper{
 					collector.ScrapeGlobalStatus{},
@@ -331,44 +335,51 @@ func Test_getScrapeTimeoutSeconds(t *testing.T) {
 		wantTimeout float64
 		wantErr     bool
 	}{
-		{"no_timeout_header",
+		{
+			"no_timeout_header",
 			args{},
 			0, false,
 		},
-		{"zero_timeout_header",
+		{
+			"zero_timeout_header",
 			args{
 				timeoutHeader: "0",
 			},
 			0, false,
 		},
-		{"negative_timeout_header",
+		{
+			"negative_timeout_header",
 			args{
 				timeoutHeader: "-5",
 			},
 			0, true,
 		},
-		{"offset_greater_than_timeout",
+		{
+			"offset_greater_than_timeout",
 			args{
 				timeoutHeader: "5",
 				offset:        6,
 			},
 			0, true,
 		},
-		{"offset_equal_timeout",
+		{
+			"offset_equal_timeout",
 			args{
 				timeoutHeader: "5",
 				offset:        5,
 			},
 			0, true,
 		},
-		{"offset_less_than_timeout",
+		{
+			"offset_less_than_timeout",
 			args{
 				timeoutHeader: "5",
 				offset:        1,
 			},
 			4, false,
 		},
-		{"no_offset",
+		{
+			"no_offset",
 			args{
 				timeoutHeader: "5",
 			},


### PR DESCRIPTION
In this PR:
- use `wg.Go()` instead of `wg.Add(1)` and `defer wg.Done()`
- remove the `sortedMapKeys` function and replace it with modern `maps.Keys` and `slices.Sorted`
- remove loop variable capture in tests