### PR TITLE
chore: Fix metric detection in acceptance tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
           persist-credentials: false
       - run: make build
       - run: make test
+        env:
+          TEST_MYSQL_DSN: root@tcp(mysqld:3306)/
       - run: git diff --exit-code
 
   build:

--- a/collector/exporter_test.go
+++ b/collector/exporter_test.go
@@ -15,10 +15,10 @@ package collector
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/promslog"
 	"github.com/smartystreets/goconvey/convey"
 )
@@ -26,13 +26,14 @@ import (
 const dsn = "root@/mysql"
 
 func TestExporter(t *testing.T) {
-	if testing.Short() {
-		t.Skip("-short is passed, skipping test")
+	connDSN := os.Getenv("TEST_MYSQL_DSN")
+	if connDSN == "" {
+		t.Skip("TEST_MYSQL_DSN is not set")
 	}
 
 	exporter := New(
 		context.Background(),
-		dsn,
+		connDSN,
 		[]Scraper{
 			ScrapeGlobalStatus{},
 		},
@@ -57,12 +58,15 @@ func TestExporter(t *testing.T) {
 			close(ch)
 		}()
 
+		seen := false
 		for m := range ch {
-			got := readMetric(m)
-			if got.labels[model.MetricNameLabel] == "mysql_up" {
+			if m.Desc() == mysqlUp {
+				seen = true
+				got := readMetric(m)
 				convey.So(got.value, convey.ShouldEqual, 1)
 			}
 		}
+		convey.SoMsg("mysql_up metric was not collected", seen, convey.ShouldBeTrue)
 	})
 }
 


### PR DESCRIPTION
readMetric calls m.Write() into a dto.Metric protobuf struct where the metric name is not stored as a label (only the metric's own labels are). Matching on MetricNameLabel therefore always misses, and mysql_up was never found.

Switching to descriptor comparison (m.Desc() == mysqlUp) avoids the protobuf DTO entirely, operating directly on the in-memory Go object.

The test also silently passed if mysql_up was never emitted: the for loop would complete without error. Adding a seen flag with an explicit assertion ensures the metric must actually be collected.