### PR TITLE
feat: per-scraper query timeout to prevent slow scraper from cascading-failing the rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ BREAKING CHANGES:
 Changes:
 
 * [CHANGE]
-* [FEATURE]
-* [ENHANCEMENT]
+* [FEATURE] Add `--exporter.query_timeout` to apply a per-scraper timeout so a single slow scraper cannot cancel the others sharing the request context
+* [ENHANCEMENT] Allow up to 2 connections per scrape and set a 1 minute connection lifetime to prevent scrapers from cascade-failing behind a slow query
 * [BUGFIX]
 
 ## 0.19.0 / 2026-03-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changes:
 
 * [CHANGE]
 * [FEATURE] Add `--exporter.query_timeout` to apply a per-scraper timeout so a single slow scraper cannot cancel the others sharing the request context
-* [ENHANCEMENT] Allow up to 2 connections per scrape and set a 1 minute connection lifetime to prevent scrapers from cascade-failing behind a slow query
+* [ENHANCEMENT] Allow up to 2 connections per scrape to prevent scrapers from cascade-failing behind a slow query
 * [BUGFIX]
 
 ## 0.19.0 / 2026-03-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ BREAKING CHANGES:
 Changes:
 
 * [CHANGE]
-* [FEATURE]
-* [ENHANCEMENT]
+* [FEATURE] Add `--exporter.query_timeout` to apply a per-scraper timeout so a single slow scraper cannot cancel the others sharing the request context
+* [ENHANCEMENT] Allow up to 2 connections per scrape and set a 1 minute connection lifetime to prevent scrapers from cascade-failing behind a slow query
 * [BUGFIX]
 
 * [FEATURE] Add tls-min-version and tls-max-version config options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changes:
 
 * [CHANGE]
 * [FEATURE] Add `--exporter.query_timeout` to apply a per-scraper timeout so a single slow scraper cannot cancel the others sharing the request context
-* [ENHANCEMENT] Allow up to 2 connections per scrape and set a 1 minute connection lifetime to prevent scrapers from cascade-failing behind a slow query
+* [ENHANCEMENT] Allow up to 2 connections per scrape to prevent scrapers from cascade-failing behind a slow query
 * [BUGFIX]
 
 * [FEATURE] Add tls-min-version and tls-max-version config options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changes:
 
 * [CHANGE]
 * [FEATURE] Add `--exporter.query_timeout` to apply a per-scraper timeout so a single slow scraper cannot cancel the others sharing the request context
-* [ENHANCEMENT] Allow up to 2 connections per scrape to prevent scrapers from cascade-failing behind a slow query
+* [ENHANCEMENT] Raise the default per-scrape connection limit from 1 to 2 and add `--exporter.max_open_connections` to configure it, preventing scrapers from cascade-failing behind a slow query
 * [BUGFIX]
 
 * [FEATURE] Add tls-min-version and tls-max-version config options

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ log.level                                  | Logging verbosity (default: info)
 exporter.lock_wait_timeout                 | Set a lock_wait_timeout (in seconds) on the connection to avoid long metadata locking. (default: 2)
 exporter.enable_lock_wait_timeout          | Enable the lock_wait_timeout connection parameter. Makes the exporter compatible with older versions of MySQL. (default: true)
 exporter.log_slow_filter                   | Add a log_slow_filter to avoid slow query logging of scrapes.  NOTE: Not supported by Oracle MySQL.
+exporter.query_timeout                     | Per-scraper query timeout (in seconds). 0 disables the timeout. (default: 0, disabled)
 tls.insecure-skip-verify                   | Ignore tls verification errors.
 web.config.file                            | Path to a [web configuration file](#tls-and-basic-authentication)
 web.listen-address                         | Address to listen on for web interface and telemetry.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ exporter.lock_wait_timeout                 | Set a lock_wait_timeout (in seconds
 exporter.enable_lock_wait_timeout          | Enable the lock_wait_timeout connection parameter. Makes the exporter compatible with older versions of MySQL. (default: true)
 exporter.log_slow_filter                   | Add a log_slow_filter to avoid slow query logging of scrapes.  NOTE: Not supported by Oracle MySQL.
 exporter.query_timeout                     | Per-scraper query timeout (in seconds). 0 disables the timeout. (default: 0, disabled)
+exporter.max_open_connections              | Maximum number of open connections to the database per scrape. Must be >= 1. The pool is per scrape request, so in multi-target mode total connections scale with concurrent targets; keep the value within the exporter user's `MAX_USER_CONNECTIONS` grant. (default: 2)
 tls.insecure-skip-verify                   | Ignore tls verification errors.
 web.config.file                            | Path to a [web configuration file](#tls-and-basic-authentication)
 web.listen-address                         | Address to listen on for web interface and telemetry.

--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -74,6 +74,7 @@ type Exporter struct {
 	enableLockWaitTimeout bool
 	lockWaitTimeout       int
 	slowLogFilter         bool
+	queryTimeout          time.Duration
 }
 
 type ExporterOpt func(*Exporter)
@@ -93,6 +94,14 @@ func SetLockWaitTimeout(timeout int) ExporterOpt {
 func SetSlowLogFilter(b bool) ExporterOpt {
 	return func(e *Exporter) {
 		e.slowLogFilter = b
+	}
+}
+
+// SetQueryTimeout sets a per-scraper query timeout. Zero disables the timeout
+// and falls back to the parent (request) context.
+func SetQueryTimeout(timeout time.Duration) ExporterOpt {
+	return func(e *Exporter) {
+		e.queryTimeout = timeout
 	}
 }
 
@@ -157,7 +166,13 @@ func (e *Exporter) scrape(ctx context.Context, ch chan<- prometheus.Metric) floa
 	defer instance.Close()
 	e.instance = instance
 
-	if err := instance.Ping(); err != nil {
+	pingCtx := ctx
+	if e.queryTimeout > 0 {
+		var pingCancel context.CancelFunc
+		pingCtx, pingCancel = context.WithTimeout(ctx, e.queryTimeout)
+		defer pingCancel()
+	}
+	if err := instance.Ping(pingCtx); err != nil {
 		e.logger.Error("Error pinging mysqld", "err", err)
 		return 0.0
 	}
@@ -177,7 +192,13 @@ func (e *Exporter) scrape(ctx context.Context, ch chan<- prometheus.Metric) floa
 			label := "collect." + scraper.Name()
 			scrapeTime := time.Now()
 			collectorSuccess := 1.0
-			if err := scraper.Scrape(ctx, instance, ch, e.logger.With("scraper", scraper.Name())); err != nil {
+			scrapeCtx := ctx
+			if e.queryTimeout > 0 {
+				var cancel context.CancelFunc
+				scrapeCtx, cancel = context.WithTimeout(ctx, e.queryTimeout)
+				defer cancel()
+			}
+			if err := scraper.Scrape(scrapeCtx, instance, ch, e.logger.With("scraper", scraper.Name())); err != nil {
 				e.logger.Error("Error from scraper", "scraper", scraper.Name(), "target", e.getTargetFromDsn(), "err", err)
 				collectorSuccess = 0.0
 			}

--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -105,6 +105,16 @@ func SetQueryTimeout(timeout time.Duration) ExporterOpt {
 	}
 }
 
+// withQueryTimeout derives a context bounded by the configured query timeout.
+// When the timeout is disabled (0), it returns the parent context and a no-op
+// cancel so callers can unconditionally `defer cancel()`.
+func (e *Exporter) withQueryTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if e.queryTimeout > 0 {
+		return context.WithTimeout(ctx, e.queryTimeout)
+	}
+	return ctx, func() {}
+}
+
 // New returns a new MySQL exporter for the provided DSN.
 func New(ctx context.Context, dsn string, scrapers []Scraper, logger *slog.Logger, opts ...ExporterOpt) *Exporter {
 	e := &Exporter{
@@ -166,12 +176,8 @@ func (e *Exporter) scrape(ctx context.Context, ch chan<- prometheus.Metric) floa
 	defer instance.Close()
 	e.instance = instance
 
-	pingCtx := ctx
-	if e.queryTimeout > 0 {
-		var pingCancel context.CancelFunc
-		pingCtx, pingCancel = context.WithTimeout(ctx, e.queryTimeout)
-		defer pingCancel()
-	}
+	pingCtx, pingCancel := e.withQueryTimeout(ctx)
+	defer pingCancel()
 	if err := instance.Ping(pingCtx); err != nil {
 		e.logger.Error("Error pinging mysqld", "err", err)
 		return 0.0
@@ -192,12 +198,8 @@ func (e *Exporter) scrape(ctx context.Context, ch chan<- prometheus.Metric) floa
 			label := "collect." + scraper.Name()
 			scrapeTime := time.Now()
 			collectorSuccess := 1.0
-			scrapeCtx := ctx
-			if e.queryTimeout > 0 {
-				var cancel context.CancelFunc
-				scrapeCtx, cancel = context.WithTimeout(ctx, e.queryTimeout)
-				defer cancel()
-			}
+			scrapeCtx, cancel := e.withQueryTimeout(ctx)
+			defer cancel()
 			if err := scraper.Scrape(scrapeCtx, instance, ch, e.logger.With("scraper", scraper.Name())); err != nil {
 				e.logger.Error("Error from scraper", "scraper", scraper.Name(), "target", e.getTargetFromDsn(), "err", err)
 				collectorSuccess = 0.0

--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -108,7 +108,7 @@ func SetQueryTimeout(timeout time.Duration) ExporterOpt {
 // withQueryTimeout derives a context bounded by the configured query timeout.
 // When the timeout is disabled (0), it returns the parent context and a no-op
 // cancel so callers can unconditionally `defer cancel()`.
-func (e *Exporter) withQueryTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+func (e *Exporter) withQueryTimeoutContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	if e.queryTimeout > 0 {
 		return context.WithTimeout(ctx, e.queryTimeout)
 	}

--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -105,7 +105,7 @@ func SetQueryTimeout(timeout time.Duration) ExporterOpt {
 	}
 }
 
-// withQueryTimeout derives a context bounded by the configured query timeout.
+// withQueryTimeoutContext derives a context bounded by the configured query timeout.
 // When the timeout is disabled (0), it returns the parent context and a no-op
 // cancel so callers can unconditionally `defer cancel()`.
 func (e *Exporter) withQueryTimeoutContext(ctx context.Context) (context.Context, context.CancelFunc) {
@@ -176,7 +176,7 @@ func (e *Exporter) scrape(ctx context.Context, ch chan<- prometheus.Metric) floa
 	defer instance.Close()
 	e.instance = instance
 
-	pingCtx, pingCancel := e.withQueryTimeout(ctx)
+	pingCtx, pingCancel := e.withQueryTimeoutContext(ctx)
 	defer pingCancel()
 	if err := instance.Ping(pingCtx); err != nil {
 		e.logger.Error("Error pinging mysqld", "err", err)
@@ -198,7 +198,7 @@ func (e *Exporter) scrape(ctx context.Context, ch chan<- prometheus.Metric) floa
 			label := "collect." + scraper.Name()
 			scrapeTime := time.Now()
 			collectorSuccess := 1.0
-			scrapeCtx, cancel := e.withQueryTimeout(ctx)
+			scrapeCtx, cancel := e.withQueryTimeoutContext(ctx)
 			defer cancel()
 			if err := scraper.Scrape(scrapeCtx, instance, ch, e.logger.With("scraper", scraper.Name())); err != nil {
 				e.logger.Error("Error from scraper", "scraper", scraper.Name(), "target", e.getTargetFromDsn(), "err", err)

--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -178,7 +178,9 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 func (e *Exporter) scrape(ctx context.Context, ch chan<- prometheus.Metric) float64 {
 	var err error
 	scrapeTime := time.Now()
-	instance, err := newInstance(e.dsn, e.maxOpenConns)
+	versionCtx, versionCancel := e.withQueryTimeoutContext(ctx)
+	instance, err := newInstance(versionCtx, e.dsn, e.maxOpenConns)
+	versionCancel()
 	if err != nil {
 		e.logger.Error("Error opening connection to database", "err", err)
 		return 0.0

--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -75,6 +75,7 @@ type Exporter struct {
 	lockWaitTimeout       int
 	slowLogFilter         bool
 	queryTimeout          time.Duration
+	maxOpenConns          int
 }
 
 type ExporterOpt func(*Exporter)
@@ -105,6 +106,14 @@ func SetQueryTimeout(timeout time.Duration) ExporterOpt {
 	}
 }
 
+// SetMaxOpenConns sets the maximum number of open connections to the
+// database used for each scrape.
+func SetMaxOpenConns(n int) ExporterOpt {
+	return func(e *Exporter) {
+		e.maxOpenConns = n
+	}
+}
+
 // withQueryTimeoutContext derives a context bounded by the configured query timeout.
 // When the timeout is disabled (0), it returns the parent context and a no-op
 // cancel so callers can unconditionally `defer cancel()`.
@@ -118,9 +127,10 @@ func (e *Exporter) withQueryTimeoutContext(ctx context.Context) (context.Context
 // New returns a new MySQL exporter for the provided DSN.
 func New(ctx context.Context, dsn string, scrapers []Scraper, logger *slog.Logger, opts ...ExporterOpt) *Exporter {
 	e := &Exporter{
-		ctx:      ctx,
-		logger:   logger,
-		scrapers: scrapers,
+		ctx:          ctx,
+		logger:       logger,
+		scrapers:     scrapers,
+		maxOpenConns: 2,
 	}
 
 	for _, opt := range opts {
@@ -168,7 +178,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 func (e *Exporter) scrape(ctx context.Context, ch chan<- prometheus.Metric) float64 {
 	var err error
 	scrapeTime := time.Now()
-	instance, err := newInstance(e.dsn)
+	instance, err := newInstance(e.dsn, e.maxOpenConns)
 	if err != nil {
 		e.logger.Error("Error opening connection to database", "err", err)
 		return 0.0

--- a/collector/exporter_test.go
+++ b/collector/exporter_test.go
@@ -15,8 +15,10 @@ package collector
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/promslog"
@@ -145,4 +147,60 @@ func TestExporterWithOpts(t *testing.T) {
 			convey.So(exporter.dsn, convey.ShouldEqual, "root@/mysql?parseTime=true&lock_wait_timeout=30&log_slow_filter=%27tmp_table_on_disk,filesort_on_disk%27")
 		})
 	})
+}
+
+type mockScraper struct {
+	name     string
+	validate func(ctx context.Context) error
+}
+
+func (s *mockScraper) Name() string     { return s.name }
+func (s *mockScraper) Help() string     { return "mock scraper for testing" }
+func (s *mockScraper) Version() float64 { return 0 }
+
+func (s *mockScraper) Scrape(ctx context.Context, _ *instance, _ chan<- prometheus.Metric, _ *slog.Logger) error {
+	if s.validate != nil {
+		return s.validate(ctx)
+	}
+	return nil
+}
+
+func TestScrapeContextTimeout(t *testing.T) {
+	connDSN := os.Getenv("TEST_MYSQL_DSN")
+	if connDSN == "" {
+		t.Skip("TEST_MYSQL_DSN is not set")
+	}
+
+	const timeout = 5 * time.Second
+	scraper := &mockScraper{
+		name: "timeout_test",
+		validate: func(ctx context.Context) error {
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				t.Error("scraper context should have a deadline")
+				return nil
+			}
+			remaining := time.Until(deadline)
+			if remaining > timeout || remaining < timeout-time.Second {
+				t.Errorf("expected deadline ~%v from now, got %v", timeout, remaining)
+			}
+			return nil
+		},
+	}
+
+	exporter := New(
+		context.Background(),
+		connDSN,
+		[]Scraper{scraper},
+		promslog.NewNopLogger(),
+		SetQueryTimeout(timeout),
+	)
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		exporter.Collect(ch)
+		close(ch)
+	}()
+	for range ch {
+	}
 }

--- a/collector/exporter_test.go
+++ b/collector/exporter_test.go
@@ -15,6 +15,7 @@ package collector
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"testing"
@@ -151,16 +152,16 @@ func TestExporterWithOpts(t *testing.T) {
 
 type mockScraper struct {
 	name     string
-	validate func(ctx context.Context) error
+	validate func(ctx context.Context, instance *instance) error
 }
 
 func (s *mockScraper) Name() string     { return s.name }
 func (s *mockScraper) Help() string     { return "mock scraper for testing" }
 func (s *mockScraper) Version() float64 { return 0 }
 
-func (s *mockScraper) Scrape(ctx context.Context, _ *instance, _ chan<- prometheus.Metric, _ *slog.Logger) error {
+func (s *mockScraper) Scrape(ctx context.Context, instance *instance, _ chan<- prometheus.Metric, _ *slog.Logger) error {
 	if s.validate != nil {
-		return s.validate(ctx)
+		return s.validate(ctx, instance)
 	}
 	return nil
 }
@@ -174,7 +175,7 @@ func TestScrapeContextTimeout(t *testing.T) {
 	const timeout = 5 * time.Second
 	scraper := &mockScraper{
 		name: "timeout_test",
-		validate: func(ctx context.Context) error {
+		validate: func(ctx context.Context, _ *instance) error {
 			deadline, ok := ctx.Deadline()
 			if !ok {
 				t.Error("scraper context should have a deadline")
@@ -212,7 +213,7 @@ func TestNewInstanceMaxOpenConnections(t *testing.T) {
 	}
 
 	const want = 5
-	inst, err := newInstance(connDSN, want)
+	inst, err := newInstance(context.Background(), connDSN, want)
 	if err != nil {
 		t.Fatalf("newInstance: %v", err)
 	}
@@ -220,5 +221,111 @@ func TestNewInstanceMaxOpenConnections(t *testing.T) {
 
 	if got := inst.getDB().Stats().MaxOpenConnections; got != want {
 		t.Errorf("MaxOpenConnections = %d, want %d", got, want)
+	}
+}
+
+func TestSlowScraperDoesNotBlockFastScraper(t *testing.T) {
+	connDSN := os.Getenv("TEST_MYSQL_DSN")
+	if connDSN == "" {
+		t.Skip("TEST_MYSQL_DSN is not set")
+	}
+
+	const queryTimeout = 2 * time.Second
+	testCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	slowReady := make(chan struct{})
+	slowResult := make(chan error, 1)
+	fastResult := make(chan error, 1)
+
+	slowScraper := &mockScraper{
+		name: "slow",
+		validate: func(ctx context.Context, instance *instance) error {
+			conn, err := instance.getDB().Conn(ctx)
+			if err != nil {
+				close(slowReady)
+				slowResult <- err
+				return err
+			}
+			defer conn.Close()
+
+			// Signal only after reserving one of the pool's connections.
+			close(slowReady)
+
+			var result int
+			err = conn.QueryRowContext(ctx, "SELECT SLEEP(10)").Scan(&result)
+			slowResult <- err
+			return err
+		},
+	}
+
+	fastScraper := &mockScraper{
+		name: "fast",
+		validate: func(ctx context.Context, instance *instance) error {
+			select {
+			case <-slowReady:
+			case <-ctx.Done():
+				fastResult <- ctx.Err()
+				return ctx.Err()
+			}
+
+			var result int
+			err := instance.getDB().QueryRowContext(ctx, "SELECT 1").Scan(&result)
+			fastResult <- err
+			return err
+		},
+	}
+
+	exporter := New(
+		testCtx,
+		connDSN,
+		[]Scraper{slowScraper, fastScraper},
+		promslog.NewNopLogger(),
+		SetQueryTimeout(queryTimeout),
+		SetMaxOpenConns(2),
+	)
+
+	ch := make(chan prometheus.Metric)
+	collectDone := make(chan struct{})
+	go func() {
+		exporter.Collect(ch)
+		close(ch)
+	}()
+	go func() {
+		for range ch {
+		}
+		close(collectDone)
+	}()
+
+	select {
+	case err := <-fastResult:
+		if err != nil {
+			t.Fatalf("fast query failed behind slow query: %v", err)
+		}
+	case err := <-slowResult:
+		t.Fatalf("slow query completed before fast query: %v", err)
+	case <-testCtx.Done():
+		t.Fatal("timed out waiting for fast query result")
+	}
+
+	select {
+	case err := <-slowResult:
+		t.Fatalf("slow query completed before fast result was asserted: %v", err)
+	default:
+	}
+
+	select {
+	case err := <-slowResult:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("slow query error = %v, want context deadline exceeded", err)
+		}
+	case <-testCtx.Done():
+		t.Fatal("timed out waiting for slow query result")
+	}
+
+	select {
+	case <-collectDone:
+	case <-testCtx.Done():
+		t.Fatal("timed out waiting for collection to finish")
 	}
 }

--- a/collector/exporter_test.go
+++ b/collector/exporter_test.go
@@ -204,3 +204,21 @@ func TestScrapeContextTimeout(t *testing.T) {
 	for range ch {
 	}
 }
+
+func TestNewInstanceMaxOpenConnections(t *testing.T) {
+	connDSN := os.Getenv("TEST_MYSQL_DSN")
+	if connDSN == "" {
+		t.Skip("TEST_MYSQL_DSN is not set")
+	}
+
+	const want = 5
+	inst, err := newInstance(connDSN, want)
+	if err != nil {
+		t.Fatalf("newInstance: %v", err)
+	}
+	defer inst.Close()
+
+	if got := inst.getDB().Stats().MaxOpenConnections; got != want {
+		t.Errorf("MaxOpenConnections = %d, want %d", got, want)
+	}
+}

--- a/collector/instance.go
+++ b/collector/instance.go
@@ -14,11 +14,13 @@
 package collector
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/blang/semver/v4"
 )
@@ -41,8 +43,9 @@ func newInstance(dsn string) (*instance, error) {
 	if err != nil {
 		return nil, err
 	}
-	db.SetMaxOpenConns(1)
+	db.SetMaxOpenConns(2)
 	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(1 * time.Minute)
 	i.db = db
 
 	version, versionString, err := queryVersion(db)
@@ -79,8 +82,8 @@ func (i *instance) Close() error {
 }
 
 // Ping checks connection availability and possibly invalidates the connection if it fails.
-func (i *instance) Ping() error {
-	if err := i.db.Ping(); err != nil {
+func (i *instance) Ping(ctx context.Context) error {
+	if err := i.db.PingContext(ctx); err != nil {
 		if cerr := i.Close(); cerr != nil {
 			return err
 		}

--- a/collector/instance.go
+++ b/collector/instance.go
@@ -20,7 +20,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/blang/semver/v4"
 )
@@ -45,7 +44,6 @@ func newInstance(dsn string) (*instance, error) {
 	}
 	db.SetMaxOpenConns(2)
 	db.SetMaxIdleConns(1)
-	db.SetConnMaxLifetime(1 * time.Minute)
 	i.db = db
 
 	version, versionString, err := queryVersion(db)

--- a/collector/instance.go
+++ b/collector/instance.go
@@ -36,7 +36,7 @@ type instance struct {
 	versionMajorMinor float64
 }
 
-func newInstance(dsn string, maxOpenConns int) (*instance, error) {
+func newInstance(ctx context.Context, dsn string, maxOpenConns int) (*instance, error) {
 	i := &instance{}
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
@@ -46,7 +46,7 @@ func newInstance(dsn string, maxOpenConns int) (*instance, error) {
 	db.SetMaxIdleConns(1)
 	i.db = db
 
-	version, versionString, err := queryVersion(db)
+	version, versionString, err := queryVersion(ctx, db)
 	if err != nil {
 		db.Close()
 		return nil, err
@@ -95,9 +95,9 @@ func (i *instance) Ping(ctx context.Context) error {
 // for MySQL: "8.0.36-28.1"
 var versionRegex = regexp.MustCompile(`^((\d+)(\.\d+)(\.\d+))`)
 
-func queryVersion(db *sql.DB) (semver.Version, string, error) {
+func queryVersion(ctx context.Context, db *sql.DB) (semver.Version, string, error) {
 	var version string
-	err := db.QueryRow("SELECT @@version;").Scan(&version)
+	err := db.QueryRowContext(ctx, "SELECT @@version;").Scan(&version)
 	if err != nil {
 		return semver.Version{}, version, err
 	}

--- a/collector/instance.go
+++ b/collector/instance.go
@@ -36,13 +36,13 @@ type instance struct {
 	versionMajorMinor float64
 }
 
-func newInstance(dsn string) (*instance, error) {
+func newInstance(dsn string, maxOpenConns int) (*instance, error) {
 	i := &instance{}
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
 		return nil, err
 	}
-	db.SetMaxOpenConns(2)
+	db.SetMaxOpenConns(maxOpenConns)
 	db.SetMaxIdleConns(1)
 	i.db = db
 

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -73,6 +73,10 @@ var (
 		"exporter.log_slow_filter",
 		"Add a log_slow_filter to avoid slow query logging of scrapes. NOTE: Not supported by Oracle MySQL.",
 	).Default("false").Bool()
+	exporterQueryTimeout = kingpin.Flag(
+		"exporter.query_timeout",
+		"Per-scraper query timeout (in seconds). 0 disables the timeout.",
+	).Default("0").Int()
 	toolkitFlags = webflag.AddFlags(kingpin.CommandLine, ":9104")
 	c            = config.MySqlConfigHandler{
 		Config: &config.Config{},
@@ -216,6 +220,7 @@ func newHandler(scrapers []collector.Scraper, logger *slog.Logger) http.HandlerF
 			collector.EnableLockWaitTimeout(*enableExporterLockTimeout),
 			collector.SetLockWaitTimeout(*exporterLockTimeout),
 			collector.SetSlowLogFilter(*slowLogFilter),
+			collector.SetQueryTimeout(time.Duration(*exporterQueryTimeout)*time.Second),
 		))
 
 		gatherers := prometheus.Gatherers{

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -242,6 +242,16 @@ func newHandler(scrapers []collector.Scraper, logger *slog.Logger) http.HandlerF
 	}
 }
 
+func validateExporterFlags(maxOpenConns, queryTimeout int) error {
+	if maxOpenConns < 1 {
+		return fmt.Errorf("invalid value for --exporter.max_open_connections, must be >= 1: %d", maxOpenConns)
+	}
+	if queryTimeout < 0 {
+		return fmt.Errorf("invalid value for --exporter.query_timeout, must be >= 0: %d", queryTimeout)
+	}
+	return nil
+}
+
 func main() {
 	// Sort scrapers by name so that flag registration and processing happen
 	// in a deterministic order, as map iteration order is undefined.
@@ -275,8 +285,8 @@ func main() {
 	logger.Info("Starting mysqld_exporter", "version", version.Info())
 	logger.Info("Build context", "build_context", version.BuildContext())
 
-	if *exporterMaxOpenConns < 1 {
-		logger.Error("Invalid value for --exporter.max_open_connections, must be >= 1", "value", *exporterMaxOpenConns)
+	if err := validateExporterFlags(*exporterMaxOpenConns, *exporterQueryTimeout); err != nil {
+		logger.Error(err.Error())
 		os.Exit(1)
 	}
 

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -80,6 +80,10 @@ var (
 		"exporter.query_timeout",
 		"Per-scraper query timeout (in seconds). 0 disables the timeout.",
 	).Default("0").Int()
+	exporterMaxOpenConns = kingpin.Flag(
+		"exporter.max_open_connections",
+		"Maximum number of open connections to the database per scrape. Must be >= 1.",
+	).Default("2").Int()
 	toolkitFlags = webflag.AddFlags(kingpin.CommandLine, ":9104")
 	c            = config.MySqlConfigHandler{
 		Config: &config.Config{},
@@ -225,6 +229,7 @@ func newHandler(scrapers []collector.Scraper, logger *slog.Logger) http.HandlerF
 			collector.SetLockWaitTimeout(*exporterLockTimeout),
 			collector.SetSlowLogFilter(*slowLogFilter),
 			collector.SetQueryTimeout(time.Duration(*exporterQueryTimeout)*time.Second),
+			collector.SetMaxOpenConns(*exporterMaxOpenConns),
 		))
 
 		gatherers := prometheus.Gatherers{
@@ -269,6 +274,11 @@ func main() {
 
 	logger.Info("Starting mysqld_exporter", "version", version.Info())
 	logger.Info("Build context", "build_context", version.BuildContext())
+
+	if *exporterMaxOpenConns < 1 {
+		logger.Error("Invalid value for --exporter.max_open_connections, must be >= 1", "value", *exporterMaxOpenConns)
+		os.Exit(1)
+	}
 
 	var err error
 	if err = c.ReloadConfig(*configMycnf, *mysqldAddress, *mysqldUser, *tlsInsecureSkipVerify, logger); err != nil {

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -76,6 +76,10 @@ var (
 		"exporter.log_slow_filter",
 		"Add a log_slow_filter to avoid slow query logging of scrapes. NOTE: Not supported by Oracle MySQL.",
 	).Default("false").Bool()
+	exporterQueryTimeout = kingpin.Flag(
+		"exporter.query_timeout",
+		"Per-scraper query timeout (in seconds). 0 disables the timeout.",
+	).Default("0").Int()
 	toolkitFlags = webflag.AddFlags(kingpin.CommandLine, ":9104")
 	c            = config.MySqlConfigHandler{
 		Config: &config.Config{},
@@ -220,6 +224,7 @@ func newHandler(scrapers []collector.Scraper, logger *slog.Logger) http.HandlerF
 			collector.EnableLockWaitTimeout(*enableExporterLockTimeout),
 			collector.SetLockWaitTimeout(*exporterLockTimeout),
 			collector.SetSlowLogFilter(*slowLogFilter),
+			collector.SetQueryTimeout(time.Duration(*exporterQueryTimeout)*time.Second),
 		))
 
 		gatherers := prometheus.Gatherers{

--- a/mysqld_exporter_test.go
+++ b/mysqld_exporter_test.go
@@ -103,6 +103,31 @@ func TestBin(t *testing.T) {
 	})
 }
 
+func TestValidateExporterFlags(t *testing.T) {
+	tests := []struct {
+		name         string
+		maxOpenConns int
+		queryTimeout int
+		wantErr      bool
+	}{
+		{name: "defaults", maxOpenConns: 2},
+		{name: "disabled query timeout", maxOpenConns: 2, queryTimeout: 0},
+		{name: "positive query timeout", maxOpenConns: 2, queryTimeout: 1},
+		{name: "zero max open connections", maxOpenConns: 0, wantErr: true},
+		{name: "negative max open connections", maxOpenConns: -1, wantErr: true},
+		{name: "negative query timeout", maxOpenConns: 2, queryTimeout: -1, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateExporterFlags(tt.maxOpenConns, tt.queryTimeout)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateExporterFlags() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func testLanding(t *testing.T, data bin) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/probe.go
+++ b/probe.go
@@ -76,6 +76,7 @@ func handleProbe(scrapers []collector.Scraper, logger *slog.Logger) http.Handler
 			collector.EnableLockWaitTimeout(*enableExporterLockTimeout),
 			collector.SetLockWaitTimeout(*exporterLockTimeout),
 			collector.SetSlowLogFilter(*slowLogFilter),
+			collector.SetQueryTimeout(time.Duration(*exporterQueryTimeout)*time.Second),
 		))
 
 		h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})

--- a/probe.go
+++ b/probe.go
@@ -77,6 +77,7 @@ func handleProbe(scrapers []collector.Scraper, logger *slog.Logger) http.Handler
 			collector.SetLockWaitTimeout(*exporterLockTimeout),
 			collector.SetSlowLogFilter(*slowLogFilter),
 			collector.SetQueryTimeout(time.Duration(*exporterQueryTimeout)*time.Second),
+			collector.SetMaxOpenConns(*exporterMaxOpenConns),
 		))
 
 		h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})


### PR DESCRIPTION
  ## Summary

  A single slow scraper currently causes every other scraper to fail on the same `/metrics` request. Two coupled changes fix this:

  1. **Per-scraper context timeout** — each scraper gets its own `context.WithTimeout(parent, --exporter.query_timeout)` instead of sharing the request context. A new `--exporter.query_timeout` flag controls
  the timeout. Default is `0` (disabled), so existing deployments see no behavior change.

  2. **Connection pool capacity** — `MaxOpenConns` raised from `1` to `2` and `ConnMaxLifetime` set to `1m`. With only one connection, scrapers serialize behind a slow query and timeout while waiting for the
  connection rather than while running, which the per-scraper timeout cannot catch on its own.

  The `instance.Ping()` call also takes a context now and uses `db.PingContext` so the ping respects the same timeout.

  ## Why both changes are needed

  Per-scraper timeout alone is not sufficient. With `MaxOpenConns(1)`, fast scrapers queue behind a slow one waiting for the connection, then hit their per-scraper deadline while still in the queue and fail
  with `context deadline exceeded`. Bumping the pool to 2 lets the fast scrapers run on a second connection while the slow one is in flight, so the per-scraper timeout fires only on the genuinely slow
  scraper.


  ## Reproduction

  A scraper that runs `SELECT SLEEP(15)` was added locally to reproduce the failure mode against MySQL 8.4 with a 5s scrape budget (`X-Prometheus-Scrape-Timeout-Seconds: 5`).

  | Configuration | Scrape time | Failed scrapers | Notes |
  |---|---|---|---|
  | `MaxOpenConns=1`, no per-scraper timeout (pre-fix) | 4.8s | 3 of 7 | slow + 2 queued behind it |
  | `MaxOpenConns=2` + `--exporter.query_timeout=3` (post-fix) | 3.0s | 1 of 7 | only the slow scraper |

  Pre-fix uses the entire scrape budget regardless of what's actually slow; post-fix uses exactly the per-scraper timeout that's configured.

Also full credit to @joshbroughton for this PR.