### PR TITLE
Add TLS version config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changes:
 * [ENHANCEMENT]
 * [BUGFIX]
 
+* [FEATURE] Add tls-min-version and tls-max-version config options
+
 ## 0.19.0 / 2026-03-18
 
 Changes:

--- a/README.md
+++ b/README.md
@@ -186,6 +186,13 @@ ssl-key=/path/to/ssl/client/key
 ssl-cert=/path/to/ssl/client/cert
 ```
 
+It's possible to also restrict the TLS versions that can be used between the MySQL server and mysqld exporter by specifying versions in the mysql cnf file like this:
+
+```
+tls-min-version=TLSv1.2
+tls-max-version=TLSv1.3
+```
+
 
 ## Using Docker
 

--- a/config/config.go
+++ b/config/config.go
@@ -18,8 +18,10 @@ import (
 	"crypto/x509"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -55,6 +57,14 @@ var (
 	}
 
 	err error
+
+	// Use the same pattern of TLS version strings as the mysql client binary.
+	tlsVersions = map[string]uint16{
+		"TLSv1.0": tls.VersionTLS10,
+		"TLSv1.1": tls.VersionTLS11,
+		"TLSv1.2": tls.VersionTLS12,
+		"TLSv1.3": tls.VersionTLS13,
+	}
 )
 
 type Config struct {
@@ -73,6 +83,8 @@ type MySqlConfig struct {
 	SslKey                string `ini:"ssl-key"`
 	TlsInsecureSkipVerify bool   `ini:"ssl-skip-verfication"` //nolint:misspell
 	Tls                   string `ini:"tls"`
+	TlsMinVersion         string `ini:"tls-min-version"`
+	TlsMaxVersion         string `ini:"tls-max-version"`
 }
 
 type MySqlConfigHandler struct {
@@ -172,6 +184,19 @@ func (m MySqlConfig) validateConfig() error {
 		return fmt.Errorf("no user specified in section or parent")
 	}
 
+	allowedTLSVersions := strings.Join(slices.Sorted(maps.Keys(tlsVersions)), ", ")
+	if _, ok := tlsVersions[m.TlsMinVersion]; !ok && m.TlsMinVersion != "" {
+		return fmt.Errorf("tls-min-version=%s is not allowed, use one of: %s", m.TlsMinVersion, allowedTLSVersions)
+	}
+	if _, ok := tlsVersions[m.TlsMaxVersion]; !ok && m.TlsMaxVersion != "" {
+		return fmt.Errorf("tls-max-version=%s is not allowed, use one of: %s", m.TlsMaxVersion, allowedTLSVersions)
+	}
+	if m.TlsMinVersion != "" && m.TlsMaxVersion != "" {
+		if tlsVersions[m.TlsMinVersion] > tlsVersions[m.TlsMaxVersion] {
+			return fmt.Errorf("tls-min-version must not be higher than tls-max-version: %s > %s", m.TlsMinVersion, m.TlsMaxVersion)
+		}
+	}
+
 	return nil
 }
 
@@ -209,7 +234,7 @@ func (m MySqlConfig) FormDSN(target string) (string, error) {
 		config.TLSConfig = "skip-verify"
 	} else {
 		config.TLSConfig = m.Tls
-		if m.SslCa != "" {
+		if m.SslCa != "" || m.TlsMinVersion != "" || m.TlsMaxVersion != "" {
 			if err := m.CustomizeTLS(); err != nil {
 				err = fmt.Errorf("failed to register a custom TLS configuration for mysql dsn: %w", err)
 				return "", err
@@ -227,25 +252,33 @@ func (m MySqlConfig) FormDSN(target string) (string, error) {
 
 func (m MySqlConfig) CustomizeTLS() error {
 	var tlsCfg tls.Config
-	caBundle := x509.NewCertPool()
-	pemCA, err := os.ReadFile(m.SslCa)
-	if err != nil {
-		return err
-	}
-	if ok := caBundle.AppendCertsFromPEM(pemCA); ok {
-		tlsCfg.RootCAs = caBundle
-	} else {
-		return fmt.Errorf("failed parse pem-encoded CA certificates from %s", m.SslCa)
-	}
-	if m.SslCert != "" && m.SslKey != "" {
-		certPairs := make([]tls.Certificate, 0, 1)
-		keypair, err := tls.LoadX509KeyPair(m.SslCert, m.SslKey)
+	if m.SslCa != "" {
+		caBundle := x509.NewCertPool()
+		pemCA, err := os.ReadFile(m.SslCa)
 		if err != nil {
-			return fmt.Errorf("failed to parse pem-encoded SSL cert %s or SSL key %s: %w",
-				m.SslCert, m.SslKey, err)
+			return err
 		}
-		certPairs = append(certPairs, keypair)
-		tlsCfg.Certificates = certPairs
+		if ok := caBundle.AppendCertsFromPEM(pemCA); ok {
+			tlsCfg.RootCAs = caBundle
+		} else {
+			return fmt.Errorf("failed parse pem-encoded CA certificates from %s", m.SslCa)
+		}
+		if m.SslCert != "" && m.SslKey != "" {
+			certPairs := make([]tls.Certificate, 0, 1)
+			keypair, err := tls.LoadX509KeyPair(m.SslCert, m.SslKey)
+			if err != nil {
+				return fmt.Errorf("failed to parse pem-encoded SSL cert %s or SSL key %s: %w",
+					m.SslCert, m.SslKey, err)
+			}
+			certPairs = append(certPairs, keypair)
+			tlsCfg.Certificates = certPairs
+		}
+	}
+	if m.TlsMinVersion != "" {
+		tlsCfg.MinVersion = tlsVersions[m.TlsMinVersion]
+	}
+	if m.TlsMaxVersion != "" {
+		tlsCfg.MaxVersion = tlsVersions[m.TlsMaxVersion]
 	}
 	tlsCfg.InsecureSkipVerify = m.TlsInsecureSkipVerify
 	mysql.RegisterTLSConfig("custom", &tlsCfg)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,10 +14,12 @@
 package config
 
 import (
+	"crypto/tls"
 	"fmt"
 	"os"
 	"testing"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/prometheus/common/promslog"
 	"github.com/smartystreets/goconvey/convey"
 )
@@ -169,6 +171,49 @@ func TestValidateConfig(t *testing.T) {
 		convey.So(section.Password, convey.ShouldEqual, "foo")
 		convey.So(section.EnableCleartextPlugin, convey.ShouldBeTrue)
 	})
+
+	convey.Convey("Client with TLS min version config higher than TLS max version config", t, func() {
+		conf := MySqlConfig{
+			User:          "test",
+			TlsMinVersion: "TLSv1.3",
+			TlsMaxVersion: "TLSv1.2",
+		}
+		os.Clearenv()
+		err := conf.validateConfig()
+		convey.So(
+			err,
+			convey.ShouldResemble,
+			fmt.Errorf("tls-min-version must not be higher than tls-max-version: TLSv1.3 > TLSv1.2"),
+		)
+	})
+
+	convey.Convey("Client with unknown TLS min version configuration", t, func() {
+		conf := MySqlConfig{
+			User:          "test",
+			TlsMinVersion: "TLSv-something",
+		}
+		os.Clearenv()
+		err := conf.validateConfig()
+		convey.So(
+			err,
+			convey.ShouldResemble,
+			fmt.Errorf("tls-min-version=TLSv-something is not allowed, use one of: TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3"),
+		)
+	})
+
+	convey.Convey("Client with unknown TLS max version configuration", t, func() {
+		conf := MySqlConfig{
+			User:          "test",
+			TlsMaxVersion: "TLSv-something",
+		}
+		os.Clearenv()
+		err := conf.validateConfig()
+		convey.So(
+			err,
+			convey.ShouldResemble,
+			fmt.Errorf("tls-max-version=TLSv-something is not allowed, use one of: TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3"),
+		)
+	})
 }
 
 func TestFormDSN(t *testing.T) {
@@ -291,5 +336,16 @@ func TestFormDSNWithCustomTls(t *testing.T) {
 			convey.So(dsn, convey.ShouldEqual, "usr:pwd@tcp(server3:3306)/?tls=skip-verify")
 		})
 
+		convey.Convey("Target tls custom with TLS versions configured", func() {
+			cfg := c.GetConfig()
+			section := cfg.Sections["client_tls_with_version_config"]
+			if dsn, err = section.FormDSN(""); err != nil {
+				t.Error(err)
+			}
+			parsed, _ := mysql.ParseDSN(dsn)
+			convey.So(parsed.TLS.MinVersion, convey.ShouldEqual, uint16(tls.VersionTLS12))
+			convey.So(parsed.TLS.MaxVersion, convey.ShouldEqual, uint16(tls.VersionTLS13))
+			convey.So(dsn, convey.ShouldEqual, "usr:pwd@tcp(server3:3306)/?tls=custom")
+		})
 	})
 }

--- a/config/testdata/client_custom_tls.cnf
+++ b/config/testdata/client_custom_tls.cnf
@@ -16,3 +16,10 @@ port = 3306
 user = usr
 password = pwd
 tls=skip-verify
+[client_tls_with_version_config]
+host = server3
+port = 3306
+user = usr
+password = pwd
+tls-min-version = TLSv1.2
+tls-max-version = TLSv1.3


### PR DESCRIPTION
Add tls-min-version and tls-max-version config options. These allow restrictions on which TLS version will be used for communicating with the database server. The values follow the same pattern as the mysql client, so "TLSv1.2, TLSv1.3, etc"