### PR TITLE
ci: migrate publish_release job to use github.token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,8 @@ jobs:
   publish_release:
     name: Publish release artifacts
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: [test_go, build, integration]
     if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     steps:
@@ -120,4 +122,4 @@ jobs:
           docker_hub_password: ${{ secrets.docker_hub_password }}
           quay_io_login: ${{ secrets.quay_io_login }}
           quay_io_password: ${{ secrets.quay_io_password }}
-          github_token: ${{ secrets.PROMBOT_GITHUB_TOKEN }}
+          github_token: ${{ github.token }}


### PR DESCRIPTION
Replace secrets.PROMBOT_GITHUB_TOKEN with the built-in github.token and add the required permissions block (contents: write) to the publish_release job.