### PR TITLE
docs: fix typos in clientstats/userstats comments

### DIFF
--- a/collector/info_schema_clientstats.go
+++ b/collector/info_schema_clientstats.go
@@ -204,8 +204,8 @@ func (ScrapeClientStat) Scrape(ctx context.Context, instance *instance, ch chan<
 		}
 
 		// Loop over column names, and match to scan data. Unknown columns
-		// will be filled with an untyped metric number. We assume other then
-		// cient, that we'll only get numbers.
+		// will be filled with an untyped metric number. We assume other than
+		// client, that we'll only get numbers.
 		for idx, columnName := range columnNames[1:] {
 			if metricType, ok := informationSchemaClientStatisticsTypes[columnName]; ok {
 				ch <- prometheus.MustNewConstMetric(metricType.desc, metricType.vtype, float64(clientStatData[idx]), client)

--- a/collector/info_schema_userstats.go
+++ b/collector/info_schema_userstats.go
@@ -199,7 +199,7 @@ func (ScrapeUserStat) Scrape(ctx context.Context, instance *instance, ch chan<- 
 		}
 
 		// Loop over column names, and match to scan data. Unknown columns
-		// will be filled with an untyped metric number. We assume other then
+		// will be filled with an untyped metric number. We assume other than
 		// user, that we'll only get numbers.
 		for idx, columnName := range columnNames[1:] {
 			if metricType, ok := informationSchemaUserStatisticsTypes[columnName]; ok {


### PR DESCRIPTION
Fixes "cient" -> "client" and "other then" -> "other than" in the info_schema collector comments.
