### PR TITLE
Refactor mysqld_exporter to make it re-usable as a Go library

### DIFF
--- a/collector/binlog.go
+++ b/collector/binlog.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const (
@@ -53,7 +54,7 @@ var (
 )
 
 // ScrapeBinlogSize collects from `SHOW BINARY LOGS`.
-type ScrapeBinlogSize struct{}
+type ScrapeBinlogSize config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeBinlogSize) Name() string {

--- a/collector/engine_innodb.go
+++ b/collector/engine_innodb.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const (
@@ -40,7 +41,7 @@ var (
 )
 
 // ScrapeEngineInnodbStatus scrapes from `SHOW ENGINE INNODB STATUS`.
-type ScrapeEngineInnodbStatus struct{}
+type ScrapeEngineInnodbStatus config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeEngineInnodbStatus) Name() string {

--- a/collector/engine_tokudb.go
+++ b/collector/engine_tokudb.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const (
@@ -32,7 +33,7 @@ const (
 )
 
 // ScrapeEngineTokudbStatus scrapes from `SHOW ENGINE TOKUDB STATUS`.
-type ScrapeEngineTokudbStatus struct{}
+type ScrapeEngineTokudbStatus config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeEngineTokudbStatus) Name() string {

--- a/collector/global_status.go
+++ b/collector/global_status.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const (
@@ -81,7 +82,7 @@ var (
 )
 
 // ScrapeGlobalStatus collects from `SHOW GLOBAL STATUS`.
-type ScrapeGlobalStatus struct{}
+type ScrapeGlobalStatus config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeGlobalStatus) Name() string {

--- a/collector/global_variables.go
+++ b/collector/global_variables.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const (
@@ -123,7 +124,7 @@ var (
 )
 
 // ScrapeGlobalVariables collects from `SHOW GLOBAL VARIABLES`.
-type ScrapeGlobalVariables struct{}
+type ScrapeGlobalVariables config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeGlobalVariables) Name() string {

--- a/collector/heartbeat.go
+++ b/collector/heartbeat.go
@@ -22,8 +22,8 @@ import (
 	"log/slog"
 	"strconv"
 
-	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const (
@@ -34,21 +34,6 @@ const (
 	// The second column allows gets the server timestamp at the exact same
 	// time the query is run.
 	heartbeatQuery = "SELECT UNIX_TIMESTAMP(ts), UNIX_TIMESTAMP(%s), server_id from `%s`.`%s`"
-)
-
-var (
-	collectHeartbeatDatabase = kingpin.Flag(
-		"collect.heartbeat.database",
-		"Database from where to collect heartbeat data",
-	).Default("heartbeat").String()
-	collectHeartbeatTable = kingpin.Flag(
-		"collect.heartbeat.table",
-		"Table from where to collect heartbeat data",
-	).Default("heartbeat").String()
-	collectHeartbeatUtc = kingpin.Flag(
-		"collect.heartbeat.utc",
-		"Use UTC for timestamps of the current server (`pt-heartbeat` is called with `--utc`)",
-	).Bool()
 )
 
 // Metric descriptors.
@@ -74,7 +59,7 @@ var (
 //	server_id             int unsigned NOT NULL PRIMARY KEY,
 //
 // );
-type ScrapeHeartbeat struct{}
+type ScrapeHeartbeat config.HeartbeatConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeHeartbeat) Name() string {
@@ -92,17 +77,17 @@ func (ScrapeHeartbeat) Version() float64 {
 }
 
 // nowExpr returns a current timestamp expression.
-func nowExpr() string {
-	if *collectHeartbeatUtc {
+func (s ScrapeHeartbeat) nowExpr() string {
+	if s.UTC {
 		return "UTC_TIMESTAMP(6)"
 	}
 	return "NOW(6)"
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeHeartbeat) Scrape(ctx context.Context, instance *instance, ch chan<- prometheus.Metric, logger *slog.Logger) error {
+func (s ScrapeHeartbeat) Scrape(ctx context.Context, instance *instance, ch chan<- prometheus.Metric, logger *slog.Logger) error {
 	db := instance.getDB()
-	query := fmt.Sprintf(heartbeatQuery, nowExpr(), *collectHeartbeatDatabase, *collectHeartbeatTable)
+	query := fmt.Sprintf(heartbeatQuery, s.nowExpr(), s.Database, s.Table)
 	heartbeatRows, err := db.QueryContext(ctx, query)
 	if err != nil {
 		return err

--- a/collector/heartbeat_test.go
+++ b/collector/heartbeat_test.go
@@ -15,11 +15,9 @@ package collector
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/promslog"
@@ -27,26 +25,22 @@ import (
 )
 
 type ScrapeHeartbeatTestCase struct {
-	Args    []string
+	Name    string
+	Scraper ScrapeHeartbeat
 	Columns []string
 	Query   string
 }
 
 var ScrapeHeartbeatTestCases = []ScrapeHeartbeatTestCase{
 	{
-		[]string{
-			"--collect.heartbeat.database", "heartbeat-test",
-			"--collect.heartbeat.table", "heartbeat-test",
-		},
+		"local time",
+		ScrapeHeartbeat{Database: "heartbeat-test", Table: "heartbeat-test"},
 		[]string{"UNIX_TIMESTAMP(ts)", "UNIX_TIMESTAMP(NOW(6))", "server_id"},
 		"SELECT UNIX_TIMESTAMP(ts), UNIX_TIMESTAMP(NOW(6)), server_id from `heartbeat-test`.`heartbeat-test`",
 	},
 	{
-		[]string{
-			"--collect.heartbeat.database", "heartbeat-test",
-			"--collect.heartbeat.table", "heartbeat-test",
-			"--collect.heartbeat.utc",
-		},
+		"utc",
+		ScrapeHeartbeat{Database: "heartbeat-test", Table: "heartbeat-test", UTC: true},
 		[]string{"UNIX_TIMESTAMP(ts)", "UNIX_TIMESTAMP(UTC_TIMESTAMP(6))", "server_id"},
 		"SELECT UNIX_TIMESTAMP(ts), UNIX_TIMESTAMP(UTC_TIMESTAMP(6)), server_id from `heartbeat-test`.`heartbeat-test`",
 	},
@@ -54,12 +48,7 @@ var ScrapeHeartbeatTestCases = []ScrapeHeartbeatTestCase{
 
 func TestScrapeHeartbeat(t *testing.T) {
 	for _, tt := range ScrapeHeartbeatTestCases {
-		t.Run(fmt.Sprint(tt.Args), func(t *testing.T) {
-			_, err := kingpin.CommandLine.Parse(tt.Args)
-			if err != nil {
-				t.Fatal(err)
-			}
-
+		t.Run(tt.Name, func(t *testing.T) {
 			db, mock, err := sqlmock.New()
 			if err != nil {
 				t.Fatalf("error opening a stub database connection: %s", err)
@@ -73,7 +62,7 @@ func TestScrapeHeartbeat(t *testing.T) {
 
 			ch := make(chan prometheus.Metric)
 			go func() {
-				if err = (ScrapeHeartbeat{}).Scrape(context.Background(), inst, ch, promslog.NewNopLogger()); err != nil {
+				if err = tt.Scraper.Scrape(context.Background(), inst, ch, promslog.NewNopLogger()); err != nil {
 					t.Errorf("error calling function on test: %s", err)
 				}
 				close(ch)

--- a/collector/info_schema_auto_increment.go
+++ b/collector/info_schema_auto_increment.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const infoSchemaAutoIncrementQuery = `
@@ -51,7 +52,7 @@ var (
 )
 
 // ScrapeAutoIncrementColumns collects auto_increment column information.
-type ScrapeAutoIncrementColumns struct{}
+type ScrapeAutoIncrementColumns config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeAutoIncrementColumns) Name() string {

--- a/collector/info_schema_clientstats.go
+++ b/collector/info_schema_clientstats.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const clientStatQuery = `SELECT * FROM information_schema.client_statistics`
@@ -141,7 +142,7 @@ var (
 )
 
 // ScrapeClientStat collects from `information_schema.client_statistics`.
-type ScrapeClientStat struct{}
+type ScrapeClientStat config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeClientStat) Name() string {

--- a/collector/info_schema_innodb_cmp.go
+++ b/collector/info_schema_innodb_cmp.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const innodbCmpQuery = `
@@ -58,7 +59,7 @@ var (
 )
 
 // ScrapeInnodbCmp collects from `information_schema.innodb_cmp`.
-type ScrapeInnodbCmp struct{}
+type ScrapeInnodbCmp config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeInnodbCmp) Name() string {

--- a/collector/info_schema_innodb_cmpmem.go
+++ b/collector/info_schema_innodb_cmpmem.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const innodbCmpMemQuery = `
@@ -53,7 +54,7 @@ var (
 )
 
 // ScrapeInnodbCmp collects from `information_schema.innodb_cmp`.
-type ScrapeInnodbCmpMem struct{}
+type ScrapeInnodbCmpMem config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeInnodbCmpMem) Name() string {

--- a/collector/info_schema_innodb_metrics.go
+++ b/collector/info_schema_innodb_metrics.go
@@ -23,6 +23,7 @@ import (
 	"regexp"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const infoSchemaInnodbMetricsEnabledColumnQuery = `
@@ -73,7 +74,7 @@ var (
 )
 
 // ScrapeInnodbMetrics collects from `information_schema.innodb_metrics`.
-type ScrapeInnodbMetrics struct{}
+type ScrapeInnodbMetrics config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeInnodbMetrics) Name() string {

--- a/collector/info_schema_innodb_sys_tablespaces.go
+++ b/collector/info_schema_innodb_sys_tablespaces.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const innodbTablespacesTablenameQuery = `
@@ -83,7 +84,7 @@ var (
 )
 
 // ScrapeInfoSchemaInnodbTablespaces collects from `information_schema.innodb_sys_tablespaces`.
-type ScrapeInfoSchemaInnodbTablespaces struct{}
+type ScrapeInfoSchemaInnodbTablespaces config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeInfoSchemaInnodbTablespaces) Name() string {

--- a/collector/info_schema_processlist.go
+++ b/collector/info_schema_processlist.go
@@ -23,8 +23,8 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const infoSchemaProcesslistQuery = `
@@ -40,22 +40,6 @@ const infoSchemaProcesslistQuery = `
 		    AND TIME >= %d
 		  GROUP BY user, host, command, state
 	`
-
-// Tunable flags.
-var (
-	processlistMinTime = kingpin.Flag(
-		"collect.info_schema.processlist.min_time",
-		"Minimum time a thread must be in each state to be counted",
-	).Default("0").Int()
-	processesByUserFlag = kingpin.Flag(
-		"collect.info_schema.processlist.processes_by_user",
-		"Enable collecting the number of processes by user",
-	).Default("true").Bool()
-	processesByHostFlag = kingpin.Flag(
-		"collect.info_schema.processlist.processes_by_host",
-		"Enable collecting the number of processes by host",
-	).Default("true").Bool()
-)
 
 // Metric descriptors.
 var (
@@ -78,7 +62,7 @@ var (
 )
 
 // ScrapeProcesslist collects from `information_schema.processlist`.
-type ScrapeProcesslist struct{}
+type ScrapeProcesslist config.InfoSchemaProcesslistConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeProcesslist) Name() string {
@@ -96,11 +80,8 @@ func (ScrapeProcesslist) Version() float64 {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeProcesslist) Scrape(ctx context.Context, instance *instance, ch chan<- prometheus.Metric, logger *slog.Logger) error {
-	processQuery := fmt.Sprintf(
-		infoSchemaProcesslistQuery,
-		*processlistMinTime,
-	)
+func (s ScrapeProcesslist) Scrape(ctx context.Context, instance *instance, ch chan<- prometheus.Metric, logger *slog.Logger) error {
+	processQuery := fmt.Sprintf(infoSchemaProcesslistQuery, s.MinTime)
 	db := instance.getDB()
 	processlistRows, err := db.QueryContext(ctx, processQuery)
 	if err != nil {
@@ -162,12 +143,12 @@ func (ScrapeProcesslist) Scrape(ctx context.Context, instance *instance, ch chan
 		}
 	}
 
-	if *processesByHostFlag {
+	if s.ProcessesByHost {
 		for _, host := range slices.Sorted(maps.Keys(stateHostCounts)) {
 			ch <- prometheus.MustNewConstMetric(processesByHostDesc, prometheus.GaugeValue, float64(stateHostCounts[host]), host)
 		}
 	}
-	if *processesByUserFlag {
+	if s.ProcessesByUser {
 		for _, user := range slices.Sorted(maps.Keys(stateUserCounts)) {
 			ch <- prometheus.MustNewConstMetric(processesByUserDesc, prometheus.GaugeValue, float64(stateUserCounts[user]), user)
 		}

--- a/collector/info_schema_processlist_test.go
+++ b/collector/info_schema_processlist_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/promslog"
@@ -27,14 +26,6 @@ import (
 )
 
 func TestScrapeProcesslist(t *testing.T) {
-	_, err := kingpin.CommandLine.Parse([]string{
-		"--collect.info_schema.processlist.processes_by_user",
-		"--collect.info_schema.processlist.processes_by_host",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("error opening a stub database connection: %s", err)
@@ -57,7 +48,11 @@ func TestScrapeProcesslist(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapeProcesslist{}).Scrape(context.Background(), inst, ch, promslog.NewNopLogger()); err != nil {
+		scraper := ScrapeProcesslist{
+			ProcessesByUser: true,
+			ProcessesByHost: true,
+		}
+		if err = scraper.Scrape(context.Background(), inst, ch, promslog.NewNopLogger()); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/info_schema_query_response_time.go
+++ b/collector/info_schema_query_response_time.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const queryResponseCheckQuery = `SELECT @@query_response_time_stats`
@@ -100,7 +101,7 @@ func processQueryResponseTimeTable(ctx context.Context, instance *instance, ch c
 }
 
 // ScrapeQueryResponseTime collects from `information_schema.query_response_time`.
-type ScrapeQueryResponseTime struct{}
+type ScrapeQueryResponseTime config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeQueryResponseTime) Name() string {

--- a/collector/info_schema_replica_host.go
+++ b/collector/info_schema_replica_host.go
@@ -21,6 +21,7 @@ import (
 
 	MySQL "github.com/go-sql-driver/mysql"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const replicaHostQuery = `
@@ -64,7 +65,7 @@ var (
 )
 
 // ScrapeReplicaHost collects from `information_schema.replica_host_status`.
-type ScrapeReplicaHost struct{}
+type ScrapeReplicaHost config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeReplicaHost) Name() string {

--- a/collector/info_schema_rocksdb_perf_context.go
+++ b/collector/info_schema_rocksdb_perf_context.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const rocksdbPerfContextQuery = `
@@ -225,7 +226,7 @@ var informationSchemaRocksDBPerfContextMetrics = map[string]struct {
 }
 
 // ScrapeInnodbCmp collects from `information_schema.innodb_cmp`.
-type ScrapeRocksDBPerfContext struct{}
+type ScrapeRocksDBPerfContext config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeRocksDBPerfContext) Name() string {

--- a/collector/info_schema_schemastats.go
+++ b/collector/info_schema_schemastats.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const schemaStatQuery = `
@@ -52,7 +53,7 @@ var (
 )
 
 // ScrapeSchemaStat collects from `information_schema.table_statistics` grouped by schema.
-type ScrapeSchemaStat struct{}
+type ScrapeSchemaStat config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeSchemaStat) Name() string {

--- a/collector/info_schema_tables.go
+++ b/collector/info_schema_tables.go
@@ -20,8 +20,8 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const (
@@ -49,14 +49,6 @@ const (
 		`
 )
 
-// Tunable flags.
-var (
-	tableSchemaDatabases = kingpin.Flag(
-		"collect.info_schema.tables.databases",
-		"The list of databases to collect table stats for, or '*' for all",
-	).Default("*").String()
-)
-
 // Metric descriptors.
 var (
 	infoSchemaTablesVersionDesc = prometheus.NewDesc(
@@ -77,7 +69,7 @@ var (
 )
 
 // ScrapeTableSchema collects from `information_schema.tables`.
-type ScrapeTableSchema struct{}
+type ScrapeTableSchema config.InfoSchemaTablesConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeTableSchema) Name() string {
@@ -95,10 +87,10 @@ func (ScrapeTableSchema) Version() float64 {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeTableSchema) Scrape(ctx context.Context, instance *instance, ch chan<- prometheus.Metric, logger *slog.Logger) error {
+func (s ScrapeTableSchema) Scrape(ctx context.Context, instance *instance, ch chan<- prometheus.Metric, logger *slog.Logger) error {
 	var dbList []string
 	db := instance.getDB()
-	if *tableSchemaDatabases == "*" {
+	if s.Databases == "*" {
 		dbListRows, err := db.QueryContext(ctx, dbListQuery)
 		if err != nil {
 			return err
@@ -116,7 +108,7 @@ func (ScrapeTableSchema) Scrape(ctx context.Context, instance *instance, ch chan
 			dbList = append(dbList, database)
 		}
 	} else {
-		dbList = strings.Split(*tableSchemaDatabases, ",")
+		dbList = strings.Split(s.Databases, ",")
 	}
 
 	for _, database := range dbList {

--- a/collector/info_schema_tablestats.go
+++ b/collector/info_schema_tablestats.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const tableStatQuery = `
@@ -52,7 +53,7 @@ var (
 )
 
 // ScrapeTableStat collects from `information_schema.table_statistics`.
-type ScrapeTableStat struct{}
+type ScrapeTableStat config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeTableStat) Name() string {

--- a/collector/info_schema_userstats.go
+++ b/collector/info_schema_userstats.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const userStatQuery = `SELECT * FROM information_schema.user_statistics`
@@ -137,7 +138,7 @@ var (
 )
 
 // ScrapeUserStat collects from `information_schema.user_statistics`.
-type ScrapeUserStat struct{}
+type ScrapeUserStat config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeUserStat) Name() string {

--- a/collector/mysql_user.go
+++ b/collector/mysql_user.go
@@ -22,8 +22,8 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 // mysqlSubsystem used for metric names.
@@ -69,14 +69,6 @@ const mysqlUserQuery = `
 		  FROM mysql.user
 		`
 
-// Tunable flags.
-var (
-	userPrivilegesFlag = kingpin.Flag(
-		"collect.mysql.user.privileges",
-		"Enable collecting user privileges from mysql.user",
-	).Default("false").Bool()
-)
-
 var (
 	labelNames = []string{"mysql_user", "hostmask"}
 )
@@ -102,7 +94,7 @@ var (
 )
 
 // ScrapeUser collects from `information_schema.processlist`.
-type ScrapeUser struct{}
+type ScrapeUser config.MysqlUserConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeUser) Name() string {
@@ -120,7 +112,7 @@ func (ScrapeUser) Version() float64 {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapeUser) Scrape(ctx context.Context, instance *instance, ch chan<- prometheus.Metric, logger *slog.Logger) error {
+func (s ScrapeUser) Scrape(ctx context.Context, instance *instance, ch chan<- prometheus.Metric, logger *slog.Logger) error {
 	db := instance.getDB()
 	var (
 		userRows *sql.Rows
@@ -214,7 +206,7 @@ func (ScrapeUser) Scrape(ctx context.Context, instance *instance, ch chan<- prom
 			return err
 		}
 
-		if *userPrivilegesFlag {
+		if s.Privileges {
 			userCols, err := userRows.Columns()
 			if err != nil {
 				return err

--- a/collector/perf_schema_events_statements.go
+++ b/collector/perf_schema_events_statements.go
@@ -22,9 +22,9 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/alecthomas/kingpin/v2"
 	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const perfEventsStatementsQuery = `
@@ -125,26 +125,6 @@ const perfEventsStatementsQueryMySQL = `
 	  LIMIT %d
 	`
 
-// Tunable flags.
-var (
-	perfEventsStatementsLimit = kingpin.Flag(
-		"collect.perf_schema.eventsstatements.limit",
-		"Limit the number of events statements digests by response time",
-	).Default("250").Int()
-	perfEventsStatementsTimeLimit = kingpin.Flag(
-		"collect.perf_schema.eventsstatements.timelimit",
-		"Limit how old the 'last_seen' events statements can be, in seconds",
-	).Default("86400").Int()
-	perfEventsStatementsDigestTextLimit = kingpin.Flag(
-		"collect.perf_schema.eventsstatements.digest_text_limit",
-		"Maximum length of the normalized statement text",
-	).Default("120").Int()
-	perfEventsStatementsExcludeSchemas = kingpin.Flag(
-		"collect.perf_schema.eventsstatements.exclude_schemas",
-		"Additional schema name to exclude (always excludes mysql, performance_schema, information_schema). Repeatable",
-	).Default("").Strings()
-)
-
 var defaultExcludedSchemas = []string{"'mysql'", "'performance_schema'", "'information_schema'"}
 
 // Metric descriptors.
@@ -227,7 +207,7 @@ var (
 )
 
 // ScrapePerfEventsStatements collects from `performance_schema.events_statements_summary_by_digest`.
-type ScrapePerfEventsStatements struct{}
+type ScrapePerfEventsStatements config.PerfSchemaEventsStatementsConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapePerfEventsStatements) Name() string {
@@ -245,7 +225,7 @@ func (ScrapePerfEventsStatements) Version() float64 {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapePerfEventsStatements) Scrape(ctx context.Context, instance *instance, ch chan<- prometheus.Metric, logger *slog.Logger) error {
+func (s ScrapePerfEventsStatements) Scrape(ctx context.Context, instance *instance, ch chan<- prometheus.Metric, logger *slog.Logger) error {
 	mysqlVersion8028 := instance.flavor == FlavorMySQL && instance.version.GTE(semver.MustParse("8.0.28"))
 
 	perfQuery := perfEventsStatementsQuery
@@ -253,14 +233,14 @@ func (ScrapePerfEventsStatements) Scrape(ctx context.Context, instance *instance
 		perfQuery = perfEventsStatementsQueryMySQL
 	}
 
-	excludeSchemasList := buildExcludedSchemasList(*perfEventsStatementsExcludeSchemas)
+	excludeSchemasList := buildExcludedSchemasList(s.ExcludeSchemas)
 
 	perfQuery = fmt.Sprintf(
 		perfQuery,
-		*perfEventsStatementsDigestTextLimit,
+		s.DigestTextLimit,
 		excludeSchemasList,
-		*perfEventsStatementsTimeLimit,
-		*perfEventsStatementsLimit,
+		s.TimeLimit,
+		s.Limit,
 	)
 
 	db := instance.getDB()

--- a/collector/perf_schema_events_statements_sum.go
+++ b/collector/perf_schema_events_statements_sum.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const perfEventsStatementsSumQuery = `
@@ -158,7 +159,7 @@ var (
 )
 
 // ScrapePerfEventsStatementsSum collects from `performance_schema.events_statements_summary_by_digest`.
-type ScrapePerfEventsStatementsSum struct{}
+type ScrapePerfEventsStatementsSum config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapePerfEventsStatementsSum) Name() string {

--- a/collector/perf_schema_events_statements_test.go
+++ b/collector/perf_schema_events_statements_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/promslog"
+	"github.com/prometheus/mysqld_exporter/config"
 	"github.com/smartystreets/goconvey/convey"
 )
 
@@ -49,12 +50,17 @@ func TestScrapePerfEventsStatements(t *testing.T) {
 			1, 2, 3,
 			100, 1)
 
-	query := fmt.Sprintf(perfEventsStatementsQuery, *perfEventsStatementsDigestTextLimit, buildExcludedSchemasList(*perfEventsStatementsExcludeSchemas), *perfEventsStatementsTimeLimit, *perfEventsStatementsLimit)
+	scraper := ScrapePerfEventsStatements{
+		DigestTextLimit: config.DefaultPerfSchemaEventsStatementsDigestTextLimit,
+		TimeLimit:       config.DefaultPerfSchemaEventsStatementsTimeLimit,
+		Limit:           config.DefaultPerfSchemaEventsStatementsLimit,
+	}
+	query := fmt.Sprintf(perfEventsStatementsQuery, scraper.DigestTextLimit, buildExcludedSchemasList(scraper.ExcludeSchemas), scraper.TimeLimit, scraper.Limit)
 	mock.ExpectQuery(sanitizeQuery(query)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapePerfEventsStatements{}).Scrape(context.Background(), &instance{db: db}, ch, promslog.NewNopLogger()); err != nil {
+		if err = scraper.Scrape(context.Background(), &instance{db: db}, ch, promslog.NewNopLogger()); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)
@@ -125,12 +131,17 @@ func TestScrapePerfEventsStatementsMySQL8028(t *testing.T) {
 			100, 1,
 			100, 150, 200)
 
-	query := fmt.Sprintf(perfEventsStatementsQueryMySQL, *perfEventsStatementsDigestTextLimit, buildExcludedSchemasList(*perfEventsStatementsExcludeSchemas), *perfEventsStatementsTimeLimit, *perfEventsStatementsLimit)
+	scraper := ScrapePerfEventsStatements{
+		DigestTextLimit: config.DefaultPerfSchemaEventsStatementsDigestTextLimit,
+		TimeLimit:       config.DefaultPerfSchemaEventsStatementsTimeLimit,
+		Limit:           config.DefaultPerfSchemaEventsStatementsLimit,
+	}
+	query := fmt.Sprintf(perfEventsStatementsQueryMySQL, scraper.DigestTextLimit, buildExcludedSchemasList(scraper.ExcludeSchemas), scraper.TimeLimit, scraper.Limit)
 	mock.ExpectQuery(sanitizeQuery(query)).WillReturnRows(rows)
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapePerfEventsStatements{}).Scrape(context.Background(), inst, ch, promslog.NewNopLogger()); err != nil {
+		if err = scraper.Scrape(context.Background(), inst, ch, promslog.NewNopLogger()); err != nil {
 			t.Errorf("error calling function on test: %s", err)
 		}
 		close(ch)

--- a/collector/perf_schema_events_waits.go
+++ b/collector/perf_schema_events_waits.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const perfEventsWaitsQuery = `
@@ -42,7 +43,7 @@ var (
 )
 
 // ScrapePerfEventsWaits collects from `performance_schema.events_waits_summary_global_by_event_name`.
-type ScrapePerfEventsWaits struct{}
+type ScrapePerfEventsWaits config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapePerfEventsWaits) Name() string {

--- a/collector/perf_schema_file_events.go
+++ b/collector/perf_schema_file_events.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const perfFileEventsQuery = `
@@ -51,7 +52,7 @@ var (
 )
 
 // ScrapePerfFileEvents collects from `performance_schema.file_summary_by_event_name`.
-type ScrapePerfFileEvents struct{}
+type ScrapePerfFileEvents config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapePerfFileEvents) Name() string {

--- a/collector/perf_schema_file_instances.go
+++ b/collector/perf_schema_file_instances.go
@@ -20,8 +20,8 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const perfFileInstancesQuery = `
@@ -32,19 +32,6 @@ const perfFileInstancesQuery = `
 	  FROM performance_schema.file_summary_by_instance
 	     where FILE_NAME REGEXP ?
 	`
-
-// Tunable flags.
-var (
-	performanceSchemaFileInstancesFilter = kingpin.Flag(
-		"collect.perf_schema.file_instances.filter",
-		"RegEx file_name filter for performance_schema.file_summary_by_instance",
-	).Default(".*").String()
-
-	performanceSchemaFileInstancesRemovePrefix = kingpin.Flag(
-		"collect.perf_schema.file_instances.remove_prefix",
-		"Remove path prefix in performance_schema.file_summary_by_instance",
-	).Default("/var/lib/mysql/").String()
-)
 
 // Metric descriptors.
 var (
@@ -61,7 +48,7 @@ var (
 )
 
 // ScrapePerfFileInstances collects from `performance_schema.file_summary_by_instance`.
-type ScrapePerfFileInstances struct{}
+type ScrapePerfFileInstances config.PerfSchemaFileInstancesConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapePerfFileInstances) Name() string {
@@ -79,10 +66,10 @@ func (ScrapePerfFileInstances) Version() float64 {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapePerfFileInstances) Scrape(ctx context.Context, instance *instance, ch chan<- prometheus.Metric, logger *slog.Logger) error {
+func (s ScrapePerfFileInstances) Scrape(ctx context.Context, instance *instance, ch chan<- prometheus.Metric, logger *slog.Logger) error {
 	db := instance.getDB()
 	// Timers here are returned in picoseconds.
-	perfSchemaFileInstancesRows, err := db.QueryContext(ctx, perfFileInstancesQuery, *performanceSchemaFileInstancesFilter)
+	perfSchemaFileInstancesRows, err := db.QueryContext(ctx, perfFileInstancesQuery, s.Filter)
 	if err != nil {
 		return err
 	}
@@ -103,7 +90,7 @@ func (ScrapePerfFileInstances) Scrape(ctx context.Context, instance *instance, c
 			return err
 		}
 
-		fileName = strings.TrimPrefix(fileName, *performanceSchemaFileInstancesRemovePrefix)
+		fileName = strings.TrimPrefix(fileName, s.RemovePrefix)
 		ch <- prometheus.MustNewConstMetric(
 			performanceSchemaFileInstancesCountDesc, prometheus.CounterValue, float64(countRead),
 			fileName, eventName, "read",

--- a/collector/perf_schema_file_instances_test.go
+++ b/collector/perf_schema_file_instances_test.go
@@ -19,19 +19,14 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/promslog"
+	"github.com/prometheus/mysqld_exporter/config"
 	"github.com/smartystreets/goconvey/convey"
 )
 
 func TestScrapePerfFileInstances(t *testing.T) {
-	_, err := kingpin.CommandLine.Parse([]string{"--collect.perf_schema.file_instances.filter", ""})
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("error opening a stub database connection: %s", err)
@@ -49,7 +44,11 @@ func TestScrapePerfFileInstances(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapePerfFileInstances{}).Scrape(context.Background(), inst, ch, promslog.NewNopLogger()); err != nil {
+		scraper := ScrapePerfFileInstances{
+			Filter:       config.DefaultPerfSchemaFileInstancesFilter,
+			RemovePrefix: config.DefaultPerfSchemaFileInstancesRemovePrefix,
+		}
+		if err = scraper.Scrape(context.Background(), inst, ch, promslog.NewNopLogger()); err != nil {
 			panic(fmt.Sprintf("error calling function on test: %s", err))
 		}
 		close(ch)

--- a/collector/perf_schema_index_io_waits.go
+++ b/collector/perf_schema_index_io_waits.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const perfIndexIOWaitsQuery = `
@@ -45,7 +46,7 @@ var (
 )
 
 // ScrapePerfIndexIOWaits collects for `performance_schema.table_io_waits_summary_by_index_usage`.
-type ScrapePerfIndexIOWaits struct{}
+type ScrapePerfIndexIOWaits config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapePerfIndexIOWaits) Name() string {

--- a/collector/perf_schema_memory_events.go
+++ b/collector/perf_schema_memory_events.go
@@ -20,8 +20,8 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const perfMemoryEventsQuery = `
@@ -31,14 +31,6 @@ const perfMemoryEventsQuery = `
 	FROM performance_schema.memory_summary_global_by_event_name
 		where COUNT_ALLOC > 0;
 `
-
-// Tunable flags.
-var (
-	performanceSchemaMemoryEventsRemovePrefix = kingpin.Flag(
-		"collect.perf_schema.memory_events.remove_prefix",
-		"Remove instrument prefix in performance_schema.memory_summary_global_by_event_name",
-	).Default("memory/").String()
-)
 
 // Metric descriptors.
 var (
@@ -60,7 +52,7 @@ var (
 )
 
 // ScrapePerfMemoryEvents collects from `performance_schema.memory_summary_global_by_event_name`.
-type ScrapePerfMemoryEvents struct{}
+type ScrapePerfMemoryEvents config.PerfSchemaMemoryEventsConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapePerfMemoryEvents) Name() string {
@@ -78,7 +70,7 @@ func (ScrapePerfMemoryEvents) Version() float64 {
 }
 
 // Scrape collects data from database connection and sends it over channel as prometheus metric.
-func (ScrapePerfMemoryEvents) Scrape(ctx context.Context, instance *instance, ch chan<- prometheus.Metric, logger *slog.Logger) error {
+func (s ScrapePerfMemoryEvents) Scrape(ctx context.Context, instance *instance, ch chan<- prometheus.Metric, logger *slog.Logger) error {
 	db := instance.getDB()
 	perfSchemaMemoryEventsRows, err := db.QueryContext(ctx, perfMemoryEventsQuery)
 	if err != nil {
@@ -100,7 +92,7 @@ func (ScrapePerfMemoryEvents) Scrape(ctx context.Context, instance *instance, ch
 			return err
 		}
 
-		eventName := strings.TrimPrefix(eventName, *performanceSchemaMemoryEventsRemovePrefix)
+		eventName := strings.TrimPrefix(eventName, s.RemovePrefix)
 		ch <- prometheus.MustNewConstMetric(
 			performanceSchemaMemoryBytesAllocDesc, prometheus.CounterValue, float64(bytesAlloc), eventName,
 		)

--- a/collector/perf_schema_memory_events_test.go
+++ b/collector/perf_schema_memory_events_test.go
@@ -19,19 +19,14 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/promslog"
+	"github.com/prometheus/mysqld_exporter/config"
 	"github.com/smartystreets/goconvey/convey"
 )
 
 func TestScrapePerfMemoryEvents(t *testing.T) {
-	_, err := kingpin.CommandLine.Parse([]string{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("error opening a stub database connection: %s", err)
@@ -55,7 +50,10 @@ func TestScrapePerfMemoryEvents(t *testing.T) {
 
 	ch := make(chan prometheus.Metric)
 	go func() {
-		if err = (ScrapePerfMemoryEvents{}).Scrape(context.Background(), inst, ch, promslog.NewNopLogger()); err != nil {
+		scraper := ScrapePerfMemoryEvents{
+			RemovePrefix: config.DefaultPerfSchemaMemoryEventsRemovePrefix,
+		}
+		if err = scraper.Scrape(context.Background(), inst, ch, promslog.NewNopLogger()); err != nil {
 			panic(fmt.Sprintf("error calling function on test: %s", err))
 		}
 		close(ch)

--- a/collector/perf_schema_replication_applier_status_by_worker.go
+++ b/collector/perf_schema_replication_applier_status_by_worker.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const perfReplicationApplierStatsByWorkerQuery = `
@@ -82,7 +83,7 @@ var (
 )
 
 // ScrapePerfReplicationApplierStatsByWorker collects from `performance_schema.replication_applier_status_by_worker`.
-type ScrapePerfReplicationApplierStatsByWorker struct{}
+type ScrapePerfReplicationApplierStatsByWorker config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapePerfReplicationApplierStatsByWorker) Name() string {

--- a/collector/perf_schema_replication_group_member_stats.go
+++ b/collector/perf_schema_replication_group_member_stats.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const perfReplicationGroupMemberStatsQuery = `
@@ -61,7 +62,7 @@ var (
 )
 
 // ScrapePerfReplicationGroupMemberStats collects from `performance_schema.replication_group_member_stats`.
-type ScrapePerfReplicationGroupMemberStats struct{}
+type ScrapePerfReplicationGroupMemberStats config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapePerfReplicationGroupMemberStats) Name() string {

--- a/collector/perf_schema_replication_group_members.go
+++ b/collector/perf_schema_replication_group_members.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const perfReplicationGroupMembersQuery = `
@@ -27,7 +28,7 @@ const perfReplicationGroupMembersQuery = `
 	`
 
 // ScrapeReplicationGroupMembers collects from `performance_schema.replication_group_members`.
-type ScrapePerfReplicationGroupMembers struct{}
+type ScrapePerfReplicationGroupMembers config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapePerfReplicationGroupMembers) Name() string {

--- a/collector/perf_schema_table_io_waits.go
+++ b/collector/perf_schema_table_io_waits.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const perfTableIOWaitsQuery = `
@@ -46,7 +47,7 @@ var (
 )
 
 // ScrapePerfTableIOWaits collects from `performance_schema.table_io_waits_summary_by_table`.
-type ScrapePerfTableIOWaits struct{}
+type ScrapePerfTableIOWaits config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapePerfTableIOWaits) Name() string {

--- a/collector/perf_schema_table_lock_waits.go
+++ b/collector/perf_schema_table_lock_waits.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const perfTableLockWaitsQuery = `
@@ -75,7 +76,7 @@ var (
 )
 
 // ScrapePerfTableLockWaits collects from `performance_schema.table_lock_waits_summary_by_table`.
-type ScrapePerfTableLockWaits struct{}
+type ScrapePerfTableLockWaits config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapePerfTableLockWaits) Name() string {

--- a/collector/runtime.go
+++ b/collector/runtime.go
@@ -1,0 +1,119 @@
+// Copyright 2026 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
+)
+
+type Runtime struct {
+	exporter *Exporter
+}
+
+func NewRuntime(cfg *config.Config, logger *slog.Logger) (*Runtime, error) {
+	return NewRuntimeWithContext(context.Background(), cfg, logger)
+}
+
+func NewRuntimeWithContext(ctx context.Context, cfg *config.Config, logger *slog.Logger) (*Runtime, error) {
+	if cfg == nil {
+		return nil, errors.New("config is required")
+	}
+	if !cfg.Validated() {
+		return nil, errors.New("config has not been validated; call cfg.Validate before NewRuntime")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return &Runtime{
+		exporter: New(
+			ctx,
+			cfg.DataSourceName,
+			EnabledScrapers(*cfg),
+			logger,
+			EnableLockWaitTimeout(cfg.EnableExporterLockWaitTimeout),
+			SetLockWaitTimeout(cfg.ExporterLockWaitTimeout),
+			SetSlowLogFilter(cfg.SlowLogFilter),
+		),
+	}, nil
+}
+
+func (r *Runtime) Collectors() []prometheus.Collector {
+	if r == nil || r.exporter == nil {
+		return nil
+	}
+	return []prometheus.Collector{r.exporter}
+}
+
+func EnabledScrapers(cfg config.Config) []Scraper {
+	scrapers := AllScrapers(cfg)
+	enabled := make([]Scraper, 0, len(scrapers))
+	for _, scraper := range scrapers {
+		if cfg.Collectors[scraper.Name()] {
+			enabled = append(enabled, scraper)
+		}
+	}
+	return enabled
+}
+
+func AllScrapers(cfg config.Config) []Scraper {
+	emptyConfig := config.EmptyConfig{}
+
+	return []Scraper{
+		ScrapeGlobalStatus(emptyConfig),
+		ScrapeGlobalVariables(emptyConfig),
+		ScrapeSlaveStatus(emptyConfig),
+		ScrapeProcesslist(cfg.InfoSchemaProcesslist),
+		ScrapeUser(cfg.MysqlUser),
+		ScrapeTableSchema(cfg.InfoSchemaTables),
+		ScrapeInfoSchemaInnodbTablespaces(emptyConfig),
+		ScrapeInnodbMetrics(emptyConfig),
+		ScrapeAutoIncrementColumns(emptyConfig),
+		ScrapeBinlogSize(emptyConfig),
+		ScrapePerfTableIOWaits(emptyConfig),
+		ScrapePerfIndexIOWaits(emptyConfig),
+		ScrapePerfTableLockWaits(emptyConfig),
+		ScrapePerfEventsStatements(cfg.PerfSchemaEventsStatements),
+		ScrapePerfEventsStatementsSum(emptyConfig),
+		ScrapePerfEventsWaits(emptyConfig),
+		ScrapePerfFileEvents(emptyConfig),
+		ScrapePerfFileInstances(cfg.PerfSchemaFileInstances),
+		ScrapePerfMemoryEvents(cfg.PerfSchemaMemoryEvents),
+		ScrapePerfReplicationGroupMembers(emptyConfig),
+		ScrapePerfReplicationGroupMemberStats(emptyConfig),
+		ScrapePerfReplicationApplierStatsByWorker(emptyConfig),
+		ScrapeSysUserSummary(emptyConfig),
+		ScrapeUserStat(emptyConfig),
+		ScrapeClientStat(emptyConfig),
+		ScrapeTableStat(emptyConfig),
+		ScrapeSchemaStat(emptyConfig),
+		ScrapeInnodbCmp(emptyConfig),
+		ScrapeInnodbCmpMem(emptyConfig),
+		ScrapeQueryResponseTime(emptyConfig),
+		ScrapeEngineTokudbStatus(emptyConfig),
+		ScrapeEngineInnodbStatus(emptyConfig),
+		ScrapeHeartbeat(cfg.Heartbeat),
+		ScrapeSlaveHosts(emptyConfig),
+		ScrapeReplicaHost(emptyConfig),
+		ScrapeRocksDBPerfContext(emptyConfig),
+	}
+}

--- a/collector/runtime_test.go
+++ b/collector/runtime_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/promslog"
+	"github.com/prometheus/mysqld_exporter/config"
+)
+
+func TestNewRuntimeRequiresValidatedConfig(t *testing.T) {
+	if _, err := NewRuntime(nil, promslog.NewNopLogger()); err == nil {
+		t.Fatal("expected nil config to fail")
+	}
+
+	cfg := config.NewConfigWithDefaults()
+	cfg.DataSourceName = "root@tcp(localhost:3306)/"
+	if _, err := NewRuntime(&cfg, promslog.NewNopLogger()); err == nil {
+		t.Fatal("expected unvalidated config to fail")
+	}
+}
+
+func TestNewRuntimeCollectors(t *testing.T) {
+	cfg := config.NewConfigWithDefaults()
+	cfg.DataSourceName = "root@tcp(localhost:3306)/"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+
+	runtime, err := NewRuntime(&cfg, promslog.NewNopLogger())
+	if err != nil {
+		t.Fatalf("unexpected runtime error: %v", err)
+	}
+	if got := len(runtime.Collectors()); got != 1 {
+		t.Fatalf("unexpected collector count: got %d, want 1", got)
+	}
+}
+
+func TestEnabledScrapersUsesConfig(t *testing.T) {
+	cfg := config.NewConfigWithDefaults()
+	cfg.Collectors = map[string]bool{
+		"heartbeat": true,
+	}
+	cfg.Heartbeat.Database = "hb_db"
+	cfg.Heartbeat.Table = "hb_table"
+	cfg.Heartbeat.UTC = true
+
+	scrapers := EnabledScrapers(cfg)
+	if len(scrapers) != 1 {
+		t.Fatalf("unexpected scraper count: got %d, want 1", len(scrapers))
+	}
+	if scrapers[0].Name() != "heartbeat" {
+		t.Fatalf("unexpected scraper: got %s, want heartbeat", scrapers[0].Name())
+	}
+}

--- a/collector/slave_hosts.go
+++ b/collector/slave_hosts.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const (
@@ -45,7 +46,7 @@ var (
 )
 
 // ScrapeSlaveHosts scrapes metrics about the replicating slaves.
-type ScrapeSlaveHosts struct{}
+type ScrapeSlaveHosts config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeSlaveHosts) Name() string {

--- a/collector/slave_status.go
+++ b/collector/slave_status.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const (
@@ -52,7 +53,7 @@ func columnValue(scanArgs []interface{}, slaveCols []string, colName string) str
 }
 
 // ScrapeSlaveStatus collects from `SHOW SLAVE STATUS`.
-type ScrapeSlaveStatus struct{}
+type ScrapeSlaveStatus config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeSlaveStatus) Name() string {

--- a/collector/sys_user_summary.go
+++ b/collector/sys_user_summary.go
@@ -18,6 +18,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
 const sysUserSummaryQuery = `
@@ -80,7 +81,7 @@ var (
 		[]string{"user"}, nil)
 )
 
-type ScrapeSysUserSummary struct{}
+type ScrapeSysUserSummary config.EmptyConfig
 
 // Name of the Scraper. Should be unique.
 func (ScrapeSysUserSummary) Name() string {

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ package config
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -31,18 +32,6 @@ import (
 )
 
 var (
-	configReloadSuccess = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "mysqld_exporter",
-		Name:      "config_last_reload_successful",
-		Help:      "Mysqld exporter config loaded successfully.",
-	})
-
-	configReloadSeconds = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: "mysqld_exporter",
-		Name:      "config_last_reload_success_timestamp_seconds",
-		Help:      "Timestamp of the last successful configuration reload.",
-	})
-
 	opts = ini.LoadOptions{
 		// Do not error on nonexistent file to allow empty string as filename input
 		Loose: true,
@@ -57,7 +46,219 @@ var (
 	err error
 )
 
+const (
+	DefaultTimeoutOffset             = 0.25
+	DefaultExporterLockWaitTimeout   = 2
+	DefaultEnableExporterLockTimeout = true
+	DefaultSlowLogFilter             = false
+
+	DefaultHeartbeatDatabase = "heartbeat"
+	DefaultHeartbeatTable    = "heartbeat"
+	DefaultHeartbeatUTC      = false
+
+	DefaultInfoSchemaProcesslistMinTime         = 0
+	DefaultInfoSchemaProcesslistProcessesByUser = true
+	DefaultInfoSchemaProcesslistProcessesByHost = true
+
+	DefaultInfoSchemaTablesDatabases = "*"
+
+	DefaultPerfSchemaEventsStatementsLimit           = 250
+	DefaultPerfSchemaEventsStatementsTimeLimit       = 86400
+	DefaultPerfSchemaEventsStatementsDigestTextLimit = 120
+
+	DefaultPerfSchemaFileInstancesFilter       = ".*"
+	DefaultPerfSchemaFileInstancesRemovePrefix = "/var/lib/mysql/"
+	DefaultPerfSchemaMemoryEventsRemovePrefix  = "memory/"
+
+	DefaultMysqlUserPrivileges = false
+)
+
 type Config struct {
+	DataSourceName                string
+	Collectors                    map[string]bool
+	TimeoutOffset                 float64
+	EnableExporterLockWaitTimeout bool
+	ExporterLockWaitTimeout       int
+	SlowLogFilter                 bool
+	Heartbeat                     HeartbeatConfig
+	InfoSchemaProcesslist         InfoSchemaProcesslistConfig
+	InfoSchemaTables              InfoSchemaTablesConfig
+	PerfSchemaEventsStatements    PerfSchemaEventsStatementsConfig
+	PerfSchemaFileInstances       PerfSchemaFileInstancesConfig
+	PerfSchemaMemoryEvents        PerfSchemaMemoryEventsConfig
+	MysqlUser                     MysqlUserConfig
+
+	validated bool
+}
+
+type EmptyConfig struct{}
+
+type HeartbeatConfig struct {
+	Database string
+	Table    string
+	UTC      bool
+}
+
+type InfoSchemaProcesslistConfig struct {
+	MinTime         int
+	ProcessesByUser bool
+	ProcessesByHost bool
+}
+
+type InfoSchemaTablesConfig struct {
+	Databases string
+}
+
+type PerfSchemaEventsStatementsConfig struct {
+	Limit           int
+	TimeLimit       int
+	DigestTextLimit int
+	ExcludeSchemas  []string
+}
+
+type PerfSchemaFileInstancesConfig struct {
+	Filter       string
+	RemovePrefix string
+}
+
+type PerfSchemaMemoryEventsConfig struct {
+	RemovePrefix string
+}
+
+type MysqlUserConfig struct {
+	Privileges bool
+}
+
+func NewConfigWithDefaults() Config {
+	return Config{
+		Collectors:                    DefaultCollectorConfig(),
+		TimeoutOffset:                 DefaultTimeoutOffset,
+		EnableExporterLockWaitTimeout: DefaultEnableExporterLockTimeout,
+		ExporterLockWaitTimeout:       DefaultExporterLockWaitTimeout,
+		SlowLogFilter:                 DefaultSlowLogFilter,
+		Heartbeat: HeartbeatConfig{
+			Database: DefaultHeartbeatDatabase,
+			Table:    DefaultHeartbeatTable,
+			UTC:      DefaultHeartbeatUTC,
+		},
+		InfoSchemaProcesslist: InfoSchemaProcesslistConfig{
+			MinTime:         DefaultInfoSchemaProcesslistMinTime,
+			ProcessesByUser: DefaultInfoSchemaProcesslistProcessesByUser,
+			ProcessesByHost: DefaultInfoSchemaProcesslistProcessesByHost,
+		},
+		InfoSchemaTables: InfoSchemaTablesConfig{
+			Databases: DefaultInfoSchemaTablesDatabases,
+		},
+		PerfSchemaEventsStatements: PerfSchemaEventsStatementsConfig{
+			Limit:           DefaultPerfSchemaEventsStatementsLimit,
+			TimeLimit:       DefaultPerfSchemaEventsStatementsTimeLimit,
+			DigestTextLimit: DefaultPerfSchemaEventsStatementsDigestTextLimit,
+		},
+		PerfSchemaFileInstances: PerfSchemaFileInstancesConfig{
+			Filter:       DefaultPerfSchemaFileInstancesFilter,
+			RemovePrefix: DefaultPerfSchemaFileInstancesRemovePrefix,
+		},
+		PerfSchemaMemoryEvents: PerfSchemaMemoryEventsConfig{
+			RemovePrefix: DefaultPerfSchemaMemoryEventsRemovePrefix,
+		},
+		MysqlUser: MysqlUserConfig{
+			Privileges: DefaultMysqlUserPrivileges,
+		},
+	}
+}
+
+func DefaultCollectorConfig() map[string]bool {
+	return map[string]bool{
+		"global_status":                                    true,
+		"global_variables":                                 true,
+		"slave_status":                                     true,
+		"info_schema.processlist":                          false,
+		"mysql.user":                                       false,
+		"info_schema.tables":                               false,
+		"info_schema.innodb_tablespaces":                   false,
+		"info_schema.innodb_metrics":                       false,
+		"auto_increment.columns":                           false,
+		"binlog_size":                                      false,
+		"perf_schema.tableiowaits":                         false,
+		"perf_schema.indexiowaits":                         false,
+		"perf_schema.tablelocks":                           false,
+		"perf_schema.eventsstatements":                     false,
+		"perf_schema.eventsstatementssum":                  false,
+		"perf_schema.eventswaits":                          false,
+		"perf_schema.file_events":                          false,
+		"perf_schema.file_instances":                       false,
+		"perf_schema.memory_events":                        false,
+		"perf_schema.replication_group_members":            false,
+		"perf_schema.replication_group_member_stats":       false,
+		"perf_schema.replication_applier_status_by_worker": false,
+		"sys.user_summary":                                 false,
+		"info_schema.userstats":                            false,
+		"info_schema.clientstats":                          false,
+		"info_schema.tablestats":                           false,
+		"info_schema.schemastats":                          false,
+		"info_schema.innodb_cmp":                           true,
+		"info_schema.innodb_cmpmem":                        true,
+		"info_schema.query_response_time":                  true,
+		"engine_tokudb_status":                             false,
+		"engine_innodb_status":                             false,
+		"heartbeat":                                        false,
+		"slave_hosts":                                      false,
+		"info_schema.replica_host":                         false,
+		"info_schema.rocksdb_perf_context":                 false,
+	}
+}
+
+func (c *Config) Validate() error {
+	c.validated = false
+
+	if c.DataSourceName == "" {
+		return fmt.Errorf("data source name must not be empty")
+	}
+	if c.TimeoutOffset < 0 {
+		return fmt.Errorf("timeout offset must not be negative")
+	}
+	if c.ExporterLockWaitTimeout < 0 {
+		return fmt.Errorf("exporter lock wait timeout must not be negative")
+	}
+	if c.Heartbeat.Database == "" {
+		return fmt.Errorf("heartbeat database must not be empty")
+	}
+	if c.Heartbeat.Table == "" {
+		return fmt.Errorf("heartbeat table must not be empty")
+	}
+	if c.InfoSchemaProcesslist.MinTime < 0 {
+		return fmt.Errorf("info_schema processlist min time must not be negative")
+	}
+	if c.InfoSchemaTables.Databases == "" {
+		return fmt.Errorf("info_schema tables databases must not be empty")
+	}
+	if c.PerfSchemaEventsStatements.Limit <= 0 {
+		return fmt.Errorf("perf_schema events statements limit must be greater than zero")
+	}
+	if c.PerfSchemaEventsStatements.TimeLimit <= 0 {
+		return fmt.Errorf("perf_schema events statements time limit must be greater than zero")
+	}
+	if c.PerfSchemaEventsStatements.DigestTextLimit <= 0 {
+		return fmt.Errorf("perf_schema events statements digest text limit must be greater than zero")
+	}
+	if c.PerfSchemaFileInstances.Filter == "" {
+		return fmt.Errorf("perf_schema file instances filter must not be empty")
+	}
+	for name := range c.Collectors {
+		if _, ok := DefaultCollectorConfig()[name]; !ok {
+			return fmt.Errorf("unknown collector %q", name)
+		}
+	}
+
+	c.validated = true
+	return nil
+}
+
+func (c Config) Validated() bool {
+	return c.validated
+}
+
+type AuthConfig struct {
 	Sections map[string]MySqlConfig
 }
 
@@ -75,27 +276,47 @@ type MySqlConfig struct {
 	Tls                   string `ini:"tls"`
 }
 
-type MySqlConfigHandler struct {
+type AuthConfigHandler struct {
 	sync.RWMutex
 	TlsInsecureSkipVerify bool
-	Config                *Config
+	Config                *AuthConfig
+	configReloadSuccess   prometheus.Gauge
+	configReloadSeconds   prometheus.Gauge
 }
 
-func (ch *MySqlConfigHandler) GetConfig() *Config {
+type MySqlConfigHandler = AuthConfigHandler
+
+func NewAuthConfigHandler(registerer prometheus.Registerer) (*AuthConfigHandler, error) {
+	if registerer == nil {
+		return nil, errors.New("registerer is required")
+	}
+	ch := &AuthConfigHandler{
+		Config: &AuthConfig{},
+		configReloadSuccess: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "mysqld_exporter",
+			Name:      "config_last_reload_successful",
+			Help:      "Mysqld exporter config loaded successfully.",
+		}),
+		configReloadSeconds: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: "mysqld_exporter",
+			Name:      "config_last_reload_success_timestamp_seconds",
+			Help:      "Timestamp of the last successful configuration reload.",
+		}),
+	}
+	registerer.MustRegister(ch.configReloadSuccess, ch.configReloadSeconds)
+	return ch, nil
+}
+
+func (ch *AuthConfigHandler) GetConfig() *AuthConfig {
 	ch.RLock()
 	defer ch.RUnlock()
 	return ch.Config
 }
 
-func (ch *MySqlConfigHandler) ReloadConfig(filename string, mysqldAddress string, mysqldUser string, tlsInsecureSkipVerify bool, logger *slog.Logger) error {
+func (ch *AuthConfigHandler) ReloadConfig(filename string, mysqldAddress string, mysqldUser string, tlsInsecureSkipVerify bool, logger *slog.Logger) error {
 	var host, port string
 	defer func() {
-		if err != nil {
-			configReloadSuccess.Set(0)
-		} else {
-			configReloadSuccess.Set(1)
-			configReloadSeconds.SetToCurrentTime()
-		}
+		ch.observeReload(err)
 	}()
 
 	cfg, err := ini.LoadSources(
@@ -132,7 +353,7 @@ func (ch *MySqlConfigHandler) ReloadConfig(filename string, mysqldAddress string
 	}
 
 	cfg.ValueMapper = os.ExpandEnv
-	config := &Config{}
+	config := &AuthConfig{}
 	m := make(map[string]MySqlConfig)
 	for _, sec := range cfg.Sections() {
 		sectionName := sec.Name()
@@ -165,6 +386,20 @@ func (ch *MySqlConfigHandler) ReloadConfig(filename string, mysqldAddress string
 	ch.Config = config
 	ch.Unlock()
 	return nil
+}
+
+func (ch *AuthConfigHandler) observeReload(err error) {
+	if ch.configReloadSuccess == nil {
+		return
+	}
+	if err != nil {
+		ch.configReloadSuccess.Set(0)
+		return
+	}
+	ch.configReloadSuccess.Set(1)
+	if ch.configReloadSeconds != nil {
+		ch.configReloadSeconds.SetToCurrentTime()
+	}
 }
 
 func (m MySqlConfig) validateConfig() error {
@@ -210,11 +445,12 @@ func (m MySqlConfig) FormDSN(target string) (string, error) {
 	} else {
 		config.TLSConfig = m.Tls
 		if m.SslCa != "" {
-			if err := m.CustomizeTLS(); err != nil {
+			tlsKey, err := m.CustomizeTLS()
+			if err != nil {
 				err = fmt.Errorf("failed to register a custom TLS configuration for mysql dsn: %w", err)
 				return "", err
 			}
-			config.TLSConfig = "custom"
+			config.TLSConfig = tlsKey
 		}
 	}
 
@@ -225,29 +461,32 @@ func (m MySqlConfig) FormDSN(target string) (string, error) {
 	return config.FormatDSN(), nil
 }
 
-func (m MySqlConfig) CustomizeTLS() error {
+func (m MySqlConfig) CustomizeTLS() (string, error) {
 	var tlsCfg tls.Config
 	caBundle := x509.NewCertPool()
 	pemCA, err := os.ReadFile(m.SslCa)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if ok := caBundle.AppendCertsFromPEM(pemCA); ok {
 		tlsCfg.RootCAs = caBundle
 	} else {
-		return fmt.Errorf("failed parse pem-encoded CA certificates from %s", m.SslCa)
+		return "", fmt.Errorf("failed parse pem-encoded CA certificates from %s", m.SslCa)
 	}
 	if m.SslCert != "" && m.SslKey != "" {
 		certPairs := make([]tls.Certificate, 0, 1)
 		keypair, err := tls.LoadX509KeyPair(m.SslCert, m.SslKey)
 		if err != nil {
-			return fmt.Errorf("failed to parse pem-encoded SSL cert %s or SSL key %s: %w",
+			return "", fmt.Errorf("failed to parse pem-encoded SSL cert %s or SSL key %s: %w",
 				m.SslCert, m.SslKey, err)
 		}
 		certPairs = append(certPairs, keypair)
 		tlsCfg.Certificates = certPairs
 	}
 	tlsCfg.InsecureSkipVerify = m.TlsInsecureSkipVerify
-	mysql.RegisterTLSConfig("custom", &tlsCfg)
-	return nil
+	key := fmt.Sprintf("mysqld_exporter_%p", &tlsCfg)
+	if err := mysql.RegisterTLSConfig(key, &tlsCfg); err != nil {
+		return "", err
+	}
+	return key, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,14 +18,59 @@ import (
 	"os"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/promslog"
 	"github.com/smartystreets/goconvey/convey"
 )
 
+func TestConfigDefaultsAndValidation(t *testing.T) {
+	cfg := NewConfigWithDefaults()
+	if cfg.Validated() {
+		t.Fatal("new config should not be marked as validated")
+	}
+	if cfg.TimeoutOffset != DefaultTimeoutOffset {
+		t.Fatalf("unexpected timeout offset: got %f, want %f", cfg.TimeoutOffset, DefaultTimeoutOffset)
+	}
+	if cfg.ExporterLockWaitTimeout != DefaultExporterLockWaitTimeout {
+		t.Fatalf("unexpected lock wait timeout: got %d, want %d", cfg.ExporterLockWaitTimeout, DefaultExporterLockWaitTimeout)
+	}
+	if cfg.Collectors["global_status"] != true {
+		t.Fatal("global_status should be enabled by default")
+	}
+	if cfg.Collectors["info_schema.processlist"] != false {
+		t.Fatal("info_schema.processlist should be disabled by default")
+	}
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected missing data source name to fail validation")
+	}
+	if cfg.Validated() {
+		t.Fatal("failed validation should not mark config as validated")
+	}
+
+	cfg.DataSourceName = "root@tcp(localhost:3306)/"
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+	if !cfg.Validated() {
+		t.Fatal("successful validation should mark config as validated")
+	}
+}
+
+func TestNewAuthConfigHandler(t *testing.T) {
+	handler, err := NewAuthConfigHandler(prometheus.NewRegistry())
+	if err != nil {
+		t.Fatalf("unexpected handler error: %v", err)
+	}
+	if handler.GetConfig() == nil {
+		t.Fatal("handler should initialize auth config")
+	}
+}
+
 func TestValidateConfig(t *testing.T) {
 	convey.Convey("Working config validation", t, func() {
-		c := MySqlConfigHandler{
-			Config: &Config{},
+		c := AuthConfigHandler{
+			Config: &AuthConfig{},
 		}
 		if err := c.ReloadConfig("testdata/client.cnf", "localhost:3306", "", true, promslog.NewNopLogger()); err != nil {
 			t.Error(err)
@@ -56,8 +101,8 @@ func TestValidateConfig(t *testing.T) {
 	})
 
 	convey.Convey("Inherit from parent section", t, func() {
-		c := MySqlConfigHandler{
-			Config: &Config{},
+		c := AuthConfigHandler{
+			Config: &AuthConfig{},
 		}
 		if err := c.ReloadConfig("testdata/child_client.cnf", "localhost:3306", "", true, promslog.NewNopLogger()); err != nil {
 			t.Error(err)
@@ -68,8 +113,8 @@ func TestValidateConfig(t *testing.T) {
 	})
 
 	convey.Convey("Environment variable / CLI flags", t, func() {
-		c := MySqlConfigHandler{
-			Config: &Config{},
+		c := AuthConfigHandler{
+			Config: &AuthConfig{},
 		}
 		os.Setenv("MYSQLD_EXPORTER_PASSWORD", "supersecretpassword")
 		if err := c.ReloadConfig("", "testhost:5000", "testuser", true, promslog.NewNopLogger()); err != nil {
@@ -85,8 +130,8 @@ func TestValidateConfig(t *testing.T) {
 	})
 
 	convey.Convey("Environment variable / CLI flags error without port", t, func() {
-		c := MySqlConfigHandler{
-			Config: &Config{},
+		c := AuthConfigHandler{
+			Config: &AuthConfig{},
 		}
 		os.Setenv("MYSQLD_EXPORTER_PASSWORD", "supersecretpassword")
 		err := c.ReloadConfig("", "testhost", "testuser", true, promslog.NewNopLogger())
@@ -97,8 +142,8 @@ func TestValidateConfig(t *testing.T) {
 	})
 
 	convey.Convey("Unix socket address support", t, func() {
-		c := MySqlConfigHandler{
-			Config: &Config{},
+		c := AuthConfigHandler{
+			Config: &AuthConfig{},
 		}
 		os.Setenv("MYSQLD_EXPORTER_PASSWORD", "supersecretpassword")
 		if err := c.ReloadConfig("", "unix:///run/mysqld/mysqld.sock", "testuser", true, promslog.NewNopLogger()); err != nil {
@@ -113,8 +158,8 @@ func TestValidateConfig(t *testing.T) {
 	})
 
 	convey.Convey("Config file precedence over environment variables", t, func() {
-		c := MySqlConfigHandler{
-			Config: &Config{},
+		c := AuthConfigHandler{
+			Config: &AuthConfig{},
 		}
 		os.Setenv("MYSQLD_EXPORTER_PASSWORD", "supersecretpassword")
 		if err := c.ReloadConfig("testdata/client.cnf", "localhost:3306", "fakeuser", true, promslog.NewNopLogger()); err != nil {
@@ -128,8 +173,8 @@ func TestValidateConfig(t *testing.T) {
 	})
 
 	convey.Convey("Client without user", t, func() {
-		c := MySqlConfigHandler{
-			Config: &Config{},
+		c := AuthConfigHandler{
+			Config: &AuthConfig{},
 		}
 		os.Clearenv()
 		err := c.ReloadConfig("testdata/missing_user.cnf", "localhost:3306", "", true, promslog.NewNopLogger())
@@ -141,8 +186,8 @@ func TestValidateConfig(t *testing.T) {
 	})
 
 	convey.Convey("Client without password", t, func() {
-		c := MySqlConfigHandler{
-			Config: &Config{},
+		c := AuthConfigHandler{
+			Config: &AuthConfig{},
 		}
 		os.Clearenv()
 		if err := c.ReloadConfig("testdata/missing_password.cnf", "localhost:3306", "", true, promslog.NewNopLogger()); err != nil {
@@ -156,8 +201,8 @@ func TestValidateConfig(t *testing.T) {
 	})
 
 	convey.Convey("Client with cleartext password enabled", t, func() {
-		c := MySqlConfigHandler{
-			Config: &Config{},
+		c := AuthConfigHandler{
+			Config: &AuthConfig{},
 		}
 		os.Clearenv()
 		if err := c.ReloadConfig("testdata/client.cnf", "localhost:3306", "", true, promslog.NewNopLogger()); err != nil {
@@ -173,8 +218,8 @@ func TestValidateConfig(t *testing.T) {
 
 func TestFormDSN(t *testing.T) {
 	var (
-		c = MySqlConfigHandler{
-			Config: &Config{},
+		c = AuthConfigHandler{
+			Config: &AuthConfig{},
 		}
 		err error
 		dsn string
@@ -221,8 +266,8 @@ func TestFormDSN(t *testing.T) {
 
 func TestFormDSNWithSslSkipVerify(t *testing.T) {
 	var (
-		c = MySqlConfigHandler{
-			Config: &Config{},
+		c = AuthConfigHandler{
+			Config: &AuthConfig{},
 		}
 		err error
 		dsn string
@@ -253,8 +298,8 @@ func TestFormDSNWithSslSkipVerify(t *testing.T) {
 
 func TestFormDSNWithCustomTls(t *testing.T) {
 	var (
-		c = MySqlConfigHandler{
-			Config: &Config{},
+		c = AuthConfigHandler{
+			Config: &AuthConfig{},
 		}
 		err error
 		dsn string

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -73,51 +73,69 @@ var (
 		"exporter.log_slow_filter",
 		"Add a log_slow_filter to avoid slow query logging of scrapes. NOTE: Not supported by Oracle MySQL.",
 	).Default("false").Bool()
+	collectHeartbeatDatabase = kingpin.Flag(
+		"collect.heartbeat.database",
+		"Database from where to collect heartbeat data",
+	).Default(config.DefaultHeartbeatDatabase).String()
+	collectHeartbeatTable = kingpin.Flag(
+		"collect.heartbeat.table",
+		"Table from where to collect heartbeat data",
+	).Default(config.DefaultHeartbeatTable).String()
+	collectHeartbeatUTC = kingpin.Flag(
+		"collect.heartbeat.utc",
+		"Use UTC for timestamps of the current server (`pt-heartbeat` is called with `--utc`)",
+	).Bool()
+	processlistMinTime = kingpin.Flag(
+		"collect.info_schema.processlist.min_time",
+		"Minimum time a thread must be in each state to be counted",
+	).Default(strconv.Itoa(config.DefaultInfoSchemaProcesslistMinTime)).Int()
+	processesByUserFlag = kingpin.Flag(
+		"collect.info_schema.processlist.processes_by_user",
+		"Enable collecting the number of processes by user",
+	).Default(strconv.FormatBool(config.DefaultInfoSchemaProcesslistProcessesByUser)).Bool()
+	processesByHostFlag = kingpin.Flag(
+		"collect.info_schema.processlist.processes_by_host",
+		"Enable collecting the number of processes by host",
+	).Default(strconv.FormatBool(config.DefaultInfoSchemaProcesslistProcessesByHost)).Bool()
+	tableSchemaDatabases = kingpin.Flag(
+		"collect.info_schema.tables.databases",
+		"The list of databases to collect table stats for, or '*' for all",
+	).Default(config.DefaultInfoSchemaTablesDatabases).String()
+	perfEventsStatementsLimit = kingpin.Flag(
+		"collect.perf_schema.eventsstatements.limit",
+		"Limit the number of events statements digests by response time",
+	).Default(strconv.Itoa(config.DefaultPerfSchemaEventsStatementsLimit)).Int()
+	perfEventsStatementsTimeLimit = kingpin.Flag(
+		"collect.perf_schema.eventsstatements.timelimit",
+		"Limit how old the 'last_seen' events statements can be, in seconds",
+	).Default(strconv.Itoa(config.DefaultPerfSchemaEventsStatementsTimeLimit)).Int()
+	perfEventsStatementsDigestTextLimit = kingpin.Flag(
+		"collect.perf_schema.eventsstatements.digest_text_limit",
+		"Maximum length of the normalized statement text",
+	).Default(strconv.Itoa(config.DefaultPerfSchemaEventsStatementsDigestTextLimit)).Int()
+	perfEventsStatementsExcludeSchemas = kingpin.Flag(
+		"collect.perf_schema.eventsstatements.exclude_schemas",
+		"Additional schema name to exclude (always excludes mysql, performance_schema, information_schema). Repeatable",
+	).Strings()
+	performanceSchemaFileInstancesFilter = kingpin.Flag(
+		"collect.perf_schema.file_instances.filter",
+		"RegEx file_name filter for performance_schema.file_summary_by_instance",
+	).Default(config.DefaultPerfSchemaFileInstancesFilter).String()
+	performanceSchemaFileInstancesRemovePrefix = kingpin.Flag(
+		"collect.perf_schema.file_instances.remove_prefix",
+		"Remove path prefix in performance_schema.file_summary_by_instance",
+	).Default(config.DefaultPerfSchemaFileInstancesRemovePrefix).String()
+	performanceSchemaMemoryEventsRemovePrefix = kingpin.Flag(
+		"collect.perf_schema.memory_events.remove_prefix",
+		"Remove instrument prefix in performance_schema.memory_summary_global_by_event_name",
+	).Default(config.DefaultPerfSchemaMemoryEventsRemovePrefix).String()
+	userPrivilegesFlag = kingpin.Flag(
+		"collect.mysql.user.privileges",
+		"Enable collecting user privileges from mysql.user",
+	).Default(strconv.FormatBool(config.DefaultMysqlUserPrivileges)).Bool()
 	toolkitFlags = webflag.AddFlags(kingpin.CommandLine, ":9104")
-	c            = config.MySqlConfigHandler{
-		Config: &config.Config{},
-	}
+	c            *config.AuthConfigHandler
 )
-
-// scrapers lists all possible collection methods and if they should be enabled by default.
-var scrapers = map[collector.Scraper]bool{
-	collector.ScrapeGlobalStatus{}:                        true,
-	collector.ScrapeGlobalVariables{}:                     true,
-	collector.ScrapeSlaveStatus{}:                         true,
-	collector.ScrapeProcesslist{}:                         false,
-	collector.ScrapeUser{}:                                false,
-	collector.ScrapeTableSchema{}:                         false,
-	collector.ScrapeInfoSchemaInnodbTablespaces{}:         false,
-	collector.ScrapeInnodbMetrics{}:                       false,
-	collector.ScrapeAutoIncrementColumns{}:                false,
-	collector.ScrapeBinlogSize{}:                          false,
-	collector.ScrapePerfTableIOWaits{}:                    false,
-	collector.ScrapePerfIndexIOWaits{}:                    false,
-	collector.ScrapePerfTableLockWaits{}:                  false,
-	collector.ScrapePerfEventsStatements{}:                false,
-	collector.ScrapePerfEventsStatementsSum{}:             false,
-	collector.ScrapePerfEventsWaits{}:                     false,
-	collector.ScrapePerfFileEvents{}:                      false,
-	collector.ScrapePerfFileInstances{}:                   false,
-	collector.ScrapePerfMemoryEvents{}:                    false,
-	collector.ScrapePerfReplicationGroupMembers{}:         false,
-	collector.ScrapePerfReplicationGroupMemberStats{}:     false,
-	collector.ScrapePerfReplicationApplierStatsByWorker{}: false,
-	collector.ScrapeSysUserSummary{}:                      false,
-	collector.ScrapeUserStat{}:                            false,
-	collector.ScrapeClientStat{}:                          false,
-	collector.ScrapeTableStat{}:                           false,
-	collector.ScrapeSchemaStat{}:                          false,
-	collector.ScrapeInnodbCmp{}:                           true,
-	collector.ScrapeInnodbCmpMem{}:                        true,
-	collector.ScrapeQueryResponseTime{}:                   true,
-	collector.ScrapeEngineTokudbStatus{}:                  false,
-	collector.ScrapeEngineInnodbStatus{}:                  false,
-	collector.ScrapeHeartbeat{}:                           false,
-	collector.ScrapeSlaveHosts{}:                          false,
-	collector.ScrapeReplicaHost{}:                         false,
-	collector.ScrapeRocksDBPerfContext{}:                  false,
-}
 
 func filterScrapers(scrapers []collector.Scraper, collectParams []string) []collector.Scraper {
 	var filteredScrapers []collector.Scraper
@@ -167,11 +185,69 @@ func getScrapeTimeoutSeconds(r *http.Request, offset float64) (float64, error) {
 	return timeoutSeconds, nil
 }
 
+func configForCollectParams(cfg config.Config, collectParams []string) config.Config {
+	enabledScrapers := collector.EnabledScrapers(cfg)
+	filteredScrapers := filterScrapers(enabledScrapers, collectParams)
+	if len(collectParams) == 0 || len(filteredScrapers) == len(enabledScrapers) {
+		return cfg
+	}
+
+	cfg.Collectors = make(map[string]bool, len(cfg.Collectors))
+	for name := range config.DefaultCollectorConfig() {
+		cfg.Collectors[name] = false
+	}
+	for _, scraper := range filteredScrapers {
+		cfg.Collectors[scraper.Name()] = true
+	}
+	return cfg
+}
+
+func configFromFlags(collectorFlags map[string]*bool) config.Config {
+	cfg := config.NewConfigWithDefaults()
+	for name, enabled := range collectorFlags {
+		cfg.Collectors[name] = *enabled
+	}
+	cfg.TimeoutOffset = *timeoutOffset
+	cfg.EnableExporterLockWaitTimeout = *enableExporterLockTimeout
+	cfg.ExporterLockWaitTimeout = *exporterLockTimeout
+	cfg.SlowLogFilter = *slowLogFilter
+	cfg.Heartbeat = config.HeartbeatConfig{
+		Database: *collectHeartbeatDatabase,
+		Table:    *collectHeartbeatTable,
+		UTC:      *collectHeartbeatUTC,
+	}
+	cfg.InfoSchemaProcesslist = config.InfoSchemaProcesslistConfig{
+		MinTime:         *processlistMinTime,
+		ProcessesByUser: *processesByUserFlag,
+		ProcessesByHost: *processesByHostFlag,
+	}
+	cfg.InfoSchemaTables = config.InfoSchemaTablesConfig{
+		Databases: *tableSchemaDatabases,
+	}
+	cfg.PerfSchemaEventsStatements = config.PerfSchemaEventsStatementsConfig{
+		Limit:           *perfEventsStatementsLimit,
+		TimeLimit:       *perfEventsStatementsTimeLimit,
+		DigestTextLimit: *perfEventsStatementsDigestTextLimit,
+		ExcludeSchemas:  *perfEventsStatementsExcludeSchemas,
+	}
+	cfg.PerfSchemaFileInstances = config.PerfSchemaFileInstancesConfig{
+		Filter:       *performanceSchemaFileInstancesFilter,
+		RemovePrefix: *performanceSchemaFileInstancesRemovePrefix,
+	}
+	cfg.PerfSchemaMemoryEvents = config.PerfSchemaMemoryEventsConfig{
+		RemovePrefix: *performanceSchemaMemoryEventsRemovePrefix,
+	}
+	cfg.MysqlUser = config.MysqlUserConfig{
+		Privileges: *userPrivilegesFlag,
+	}
+	return cfg
+}
+
 func init() {
 	prometheus.MustRegister(versioncollector.NewCollector("mysqld_exporter"))
 }
 
-func newHandler(scrapers []collector.Scraper, logger *slog.Logger) http.HandlerFunc {
+func newHandler(baseConfig config.Config, logger *slog.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var dsn string
 		var err error
@@ -181,8 +257,8 @@ func newHandler(scrapers []collector.Scraper, logger *slog.Logger) http.HandlerF
 			target = q.Get("target")
 		}
 
-		cfg := c.GetConfig()
-		cfgsection, ok := cfg.Sections["client"]
+		authConfig := c.GetConfig()
+		cfgsection, ok := authConfig.Sections["client"]
 		if !ok {
 			logger.Error("Failed to parse section [client] from config file", "err", err)
 		}
@@ -195,7 +271,7 @@ func newHandler(scrapers []collector.Scraper, logger *slog.Logger) http.HandlerF
 		// Use request context for cancellation when connection gets closed.
 		ctx := r.Context()
 		// If a timeout is configured via the Prometheus header, add it to the context.
-		timeoutSeconds, err := getScrapeTimeoutSeconds(r, *timeoutOffset)
+		timeoutSeconds, err := getScrapeTimeoutSeconds(r, baseConfig.TimeoutOffset)
 		if err != nil {
 			logger.Error("Error getting timeout from Prometheus header", "err", err)
 		}
@@ -208,15 +284,25 @@ func newHandler(scrapers []collector.Scraper, logger *slog.Logger) http.HandlerF
 			r = r.WithContext(ctx)
 		}
 
-		filteredScrapers := filterScrapers(scrapers, collect)
+		cfg := configForCollectParams(baseConfig, collect)
+		cfg.DataSourceName = dsn
+		if err := cfg.Validate(); err != nil {
+			logger.Error("Invalid runtime config", "err", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 
 		registry := prometheus.NewRegistry()
+		runtime, err := collector.NewRuntimeWithContext(ctx, &cfg, logger)
+		if err != nil {
+			logger.Error("Error creating runtime", "err", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 
-		registry.MustRegister(collector.New(ctx, dsn, filteredScrapers, logger,
-			collector.EnableLockWaitTimeout(*enableExporterLockTimeout),
-			collector.SetLockWaitTimeout(*exporterLockTimeout),
-			collector.SetSlowLogFilter(*slowLogFilter),
-		))
+		for _, c := range runtime.Collectors() {
+			registry.MustRegister(c)
+		}
 
 		gatherers := prometheus.Gatherers{
 			prometheus.DefaultGatherer,
@@ -230,8 +316,10 @@ func newHandler(scrapers []collector.Scraper, logger *slog.Logger) http.HandlerF
 
 func main() {
 	// Generate ON/OFF flags for all scrapers.
-	scraperFlags := map[collector.Scraper]*bool{}
-	for scraper, enabledByDefault := range scrapers {
+	defaultConfig := config.NewConfigWithDefaults()
+	scraperFlags := map[string]*bool{}
+	for _, scraper := range collector.AllScrapers(defaultConfig) {
+		enabledByDefault := defaultConfig.Collectors[scraper.Name()]
 		defaultOn := "false"
 		if enabledByDefault {
 			defaultOn = "true"
@@ -242,7 +330,7 @@ func main() {
 			scraper.Help(),
 		).Default(defaultOn).Bool()
 
-		scraperFlags[scraper] = f
+		scraperFlags[scraper.Name()] = f
 	}
 
 	// Parse flags.
@@ -257,20 +345,27 @@ func main() {
 	logger.Info("Build context", "build_context", version.BuildContext())
 
 	var err error
+	c, err = config.NewAuthConfigHandler(prometheus.DefaultRegisterer)
+	if err != nil {
+		logger.Error("Error creating config handler", "err", err)
+		os.Exit(1)
+	}
 	if err = c.ReloadConfig(*configMycnf, *mysqldAddress, *mysqldUser, *tlsInsecureSkipVerify, logger); err != nil {
 		logger.Info("Error parsing host config", "file", *configMycnf, "err", err)
 		os.Exit(1)
 	}
 
 	// Register only scrapers enabled by flag.
-	enabledScrapers := []collector.Scraper{}
-	for scraper, enabled := range scraperFlags {
+	cfg := configFromFlags(scraperFlags)
+	for _, scraper := range collector.EnabledScrapers(cfg) {
+		logger.Info("Scraper enabled", "scraper", scraper.Name())
+	}
+	for scraperName, enabled := range scraperFlags {
 		if *enabled {
-			logger.Info("Scraper enabled", "scraper", scraper.Name())
-			enabledScrapers = append(enabledScrapers, scraper)
+			cfg.Collectors[scraperName] = true
 		}
 	}
-	handlerFunc := newHandler(enabledScrapers, logger)
+	handlerFunc := newHandler(cfg, logger)
 	http.Handle(*metricsPath, promhttp.InstrumentMetricHandler(prometheus.DefaultRegisterer, handlerFunc))
 	if *metricsPath != "/" && *metricsPath != "" {
 		landingConfig := web.LandingConfig{
@@ -291,7 +386,7 @@ func main() {
 		}
 		http.Handle("/", landingPage)
 	}
-	http.HandleFunc("/probe", handleProbe(enabledScrapers, logger))
+	http.HandleFunc("/probe", handleProbe(cfg, logger))
 	http.HandleFunc("/-/reload", func(w http.ResponseWriter, r *http.Request) {
 		if err = c.ReloadConfig(*configMycnf, *mysqldAddress, *mysqldUser, *tlsInsecureSkipVerify, logger); err != nil {
 			logger.Warn("Error reloading host config", "file", *configMycnf, "error", err)

--- a/probe.go
+++ b/probe.go
@@ -23,9 +23,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/mysqld_exporter/collector"
+	"github.com/prometheus/mysqld_exporter/config"
 )
 
-func handleProbe(scrapers []collector.Scraper, logger *slog.Logger) http.HandlerFunc {
+func handleProbe(baseConfig config.Config, logger *slog.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		params := r.URL.Query()
@@ -56,7 +57,7 @@ func handleProbe(scrapers []collector.Scraper, logger *slog.Logger) http.Handler
 		}
 
 		// If a timeout is configured via the Prometheus header, add it to the context.
-		timeoutSeconds, err := getScrapeTimeoutSeconds(r, *timeoutOffset)
+		timeoutSeconds, err := getScrapeTimeoutSeconds(r, baseConfig.TimeoutOffset)
 		if err != nil {
 			logger.Error("Error getting timeout from Prometheus header", "err", err)
 		}
@@ -69,14 +70,24 @@ func handleProbe(scrapers []collector.Scraper, logger *slog.Logger) http.Handler
 			r = r.WithContext(ctx)
 		}
 
-		filteredScrapers := filterScrapers(scrapers, collectParams)
+		runtimeConfig := configForCollectParams(baseConfig, collectParams)
+		runtimeConfig.DataSourceName = dsn
+		if err := runtimeConfig.Validate(); err != nil {
+			logger.Error("Invalid probe runtime config", "err", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 
 		registry := prometheus.NewRegistry()
-		registry.MustRegister(collector.New(ctx, dsn, filteredScrapers, logger,
-			collector.EnableLockWaitTimeout(*enableExporterLockTimeout),
-			collector.SetLockWaitTimeout(*exporterLockTimeout),
-			collector.SetSlowLogFilter(*slowLogFilter),
-		))
+		runtime, err := collector.NewRuntimeWithContext(ctx, &runtimeConfig, logger.With("target", target))
+		if err != nil {
+			logger.Error("Error creating probe runtime", "err", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		for _, c := range runtime.Collectors() {
+			registry.MustRegister(c)
+		}
 
 		h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 		h.ServeHTTP(w, r)


### PR DESCRIPTION
Refactors the mysqld_exporter, following the guidelines documented [here](https://github.com/prometheus/prometheus-opentelemetry-collector/blob/main/docs/embeddable-exporters.md). 

The goal is to facilitate the use case where mysql_exporter runs as part of other applications, using mysqld_exporter as a Go library.
