### PR TITLE
Add a tls-server-name config option and fix TLS config race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changes:
 * [BUGFIX]
 
 * [FEATURE] Add tls-min-version and tls-max-version config options
+* [FEATURE] Add an optional tls-server-name config option used to verify the server hostname
 
 ## 0.19.0 / 2026-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changes:
 
 * [FEATURE] Add tls-min-version and tls-max-version config options
 * [FEATURE] Add an optional tls-server-name config option used to verify the server hostname
+* [BUGFIX] Fix a race condition due to which targets could use custom CA from different config sections
 
 ## 0.19.0 / 2026-03-18
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,11 @@ tls-min-version=TLSv1.2
 tls-max-version=TLSv1.3
 ```
 
+In some environments the MySQL server's TLS certificate SN or SAN may not include the host that mysqld exporter uses to connect to it. This could happen in cases when the certificate includes only DNS names, while mysqld exporter uses an IP address to connect. To allow secure connections in these cases, tls-server-name can be used to specify the server's name to use during verification. The parameter works the same as server_name in Prometheus's scrape config configuration.
+
+```
+tls-server-name=mysql.example
+```
 
 ## Using Docker
 

--- a/config/config.go
+++ b/config/config.go
@@ -85,6 +85,7 @@ type MySqlConfig struct {
 	Tls                   string `ini:"tls"`
 	TlsMinVersion         string `ini:"tls-min-version"`
 	TlsMaxVersion         string `ini:"tls-max-version"`
+	TlsServerName         string `ini:"tls-server-name"`
 }
 
 type MySqlConfigHandler struct {
@@ -234,7 +235,13 @@ func (m MySqlConfig) FormDSN(target string) (string, error) {
 		config.TLSConfig = "skip-verify"
 	} else {
 		config.TLSConfig = m.Tls
-		if m.SslCa != "" || m.TlsMinVersion != "" || m.TlsMaxVersion != "" {
+
+		hasCustomTLS := m.SslCa != "" ||
+			m.TlsMinVersion != "" ||
+			m.TlsMaxVersion != "" ||
+			m.TlsServerName != ""
+
+		if hasCustomTLS {
 			if err := m.CustomizeTLS(); err != nil {
 				err = fmt.Errorf("failed to register a custom TLS configuration for mysql dsn: %w", err)
 				return "", err
@@ -279,6 +286,9 @@ func (m MySqlConfig) CustomizeTLS() error {
 	}
 	if m.TlsMaxVersion != "" {
 		tlsCfg.MaxVersion = tlsVersions[m.TlsMaxVersion]
+	}
+	if m.TlsServerName != "" {
+		tlsCfg.ServerName = m.TlsServerName
 	}
 	tlsCfg.InsecureSkipVerify = m.TlsInsecureSkipVerify
 	mysql.RegisterTLSConfig("custom", &tlsCfg)

--- a/config/config.go
+++ b/config/config.go
@@ -201,7 +201,7 @@ func (m MySqlConfig) validateConfig() error {
 	return nil
 }
 
-func (m MySqlConfig) FormDSN(target string) (string, error) {
+func (m MySqlConfig) FormDSN(target string, configSectionName string) (string, error) {
 	config := mysql.NewConfig()
 	config.User = m.User
 	config.Passwd = m.Password
@@ -242,11 +242,11 @@ func (m MySqlConfig) FormDSN(target string) (string, error) {
 			m.TlsServerName != ""
 
 		if hasCustomTLS {
-			if err := m.CustomizeTLS(); err != nil {
+			if err := m.CustomizeTLS(configSectionName); err != nil {
 				err = fmt.Errorf("failed to register a custom TLS configuration for mysql dsn: %w", err)
 				return "", err
 			}
-			config.TLSConfig = "custom"
+			config.TLSConfig = configSectionName
 		}
 	}
 
@@ -257,7 +257,7 @@ func (m MySqlConfig) FormDSN(target string) (string, error) {
 	return config.FormatDSN(), nil
 }
 
-func (m MySqlConfig) CustomizeTLS() error {
+func (m MySqlConfig) CustomizeTLS(configSectionName string) error {
 	var tlsCfg tls.Config
 	if m.SslCa != "" {
 		caBundle := x509.NewCertPool()
@@ -291,6 +291,6 @@ func (m MySqlConfig) CustomizeTLS() error {
 		tlsCfg.ServerName = m.TlsServerName
 	}
 	tlsCfg.InsecureSkipVerify = m.TlsInsecureSkipVerify
-	mysql.RegisterTLSConfig("custom", &tlsCfg)
+	mysql.RegisterTLSConfig(configSectionName, &tlsCfg)
 	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -347,5 +347,16 @@ func TestFormDSNWithCustomTls(t *testing.T) {
 			convey.So(parsed.TLS.MaxVersion, convey.ShouldEqual, uint16(tls.VersionTLS13))
 			convey.So(dsn, convey.ShouldEqual, "usr:pwd@tcp(server3:3306)/?tls=custom")
 		})
+
+		convey.Convey("Target tls custom with TLS server name configured", func() {
+			cfg := c.GetConfig()
+			section := cfg.Sections["client_tls_with_server_name"]
+			if dsn, err = section.FormDSN(""); err != nil {
+				t.Error(err)
+			}
+			parsed, _ := mysql.ParseDSN(dsn)
+			convey.So(parsed.TLS.ServerName, convey.ShouldEqual, "mysql.example")
+			convey.So(dsn, convey.ShouldEqual, "usr:pwd@tcp(server3:3306)/?tls=custom")
+		})
 	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -232,7 +232,7 @@ func TestFormDSN(t *testing.T) {
 		convey.Convey("Default Client", func() {
 			cfg := c.GetConfig()
 			section := cfg.Sections["client"]
-			if dsn, err = section.FormDSN(""); err != nil {
+			if dsn, err = section.FormDSN("", "client"); err != nil {
 				t.Error(err)
 			}
 			convey.So(dsn, convey.ShouldEqual, "root:abc@tcp(server2:3306)/")
@@ -240,7 +240,7 @@ func TestFormDSN(t *testing.T) {
 		convey.Convey("Target specific with explicit port", func() {
 			cfg := c.GetConfig()
 			section := cfg.Sections["client.server1"]
-			if dsn, err = section.FormDSN("server1:5000"); err != nil {
+			if dsn, err = section.FormDSN("server1:5000", "client.server1"); err != nil {
 				t.Error(err)
 			}
 			convey.So(dsn, convey.ShouldEqual, "test:foo@tcp(server1:5000)/")
@@ -248,7 +248,7 @@ func TestFormDSN(t *testing.T) {
 		convey.Convey("UNIX domain socket", func() {
 			cfg := c.GetConfig()
 			section := cfg.Sections["client.server1"]
-			if dsn, err = section.FormDSN("unix:///run/mysqld/mysqld.sock"); err != nil {
+			if dsn, err = section.FormDSN("unix:///run/mysqld/mysqld.sock", "client.server1"); err != nil {
 				t.Error(err)
 			}
 			convey.So(dsn, convey.ShouldEqual, "test:foo@unix(/run/mysqld/mysqld.sock)/")
@@ -256,7 +256,7 @@ func TestFormDSN(t *testing.T) {
 		convey.Convey("With cleartext password enabled", func() {
 			cfg := c.GetConfig()
 			section := cfg.Sections["client.cleartextPlugin"]
-			if dsn, err = section.FormDSN(""); err != nil {
+			if dsn, err = section.FormDSN("", "client.cleartextPlugin"); err != nil {
 				t.Error(err)
 			}
 			convey.So(dsn, convey.ShouldEqual, "test:foo@tcp(server2:3306)/?allowCleartextPasswords=true")
@@ -280,7 +280,7 @@ func TestFormDSNWithSslSkipVerify(t *testing.T) {
 		convey.Convey("Default Client", func() {
 			cfg := c.GetConfig()
 			section := cfg.Sections["client"]
-			if dsn, err = section.FormDSN(""); err != nil {
+			if dsn, err = section.FormDSN("", "client"); err != nil {
 				t.Error(err)
 			}
 			convey.So(dsn, convey.ShouldEqual, "root:abc@tcp(server2:3306)/?tls=skip-verify")
@@ -288,7 +288,7 @@ func TestFormDSNWithSslSkipVerify(t *testing.T) {
 		convey.Convey("Target specific with explicit port", func() {
 			cfg := c.GetConfig()
 			section := cfg.Sections["client.server1"]
-			if dsn, err = section.FormDSN("server1:5000"); err != nil {
+			if dsn, err = section.FormDSN("server1:5000", "client.server1"); err != nil {
 				t.Error(err)
 			}
 			convey.So(dsn, convey.ShouldEqual, "test:foo@tcp(server1:5000)/?tls=skip-verify")
@@ -312,7 +312,7 @@ func TestFormDSNWithCustomTls(t *testing.T) {
 		convey.Convey("Target tls enabled", func() {
 			cfg := c.GetConfig()
 			section := cfg.Sections["client_tls_true"]
-			if dsn, err = section.FormDSN(""); err != nil {
+			if dsn, err = section.FormDSN("", "client_tls_true"); err != nil {
 				t.Error(err)
 			}
 			convey.So(dsn, convey.ShouldEqual, "usr:pwd@tcp(server2:3306)/?tls=true")
@@ -321,7 +321,7 @@ func TestFormDSNWithCustomTls(t *testing.T) {
 		convey.Convey("Target tls preferred", func() {
 			cfg := c.GetConfig()
 			section := cfg.Sections["client_tls_preferred"]
-			if dsn, err = section.FormDSN(""); err != nil {
+			if dsn, err = section.FormDSN("", "client_tls_preferred"); err != nil {
 				t.Error(err)
 			}
 			convey.So(dsn, convey.ShouldEqual, "usr:pwd@tcp(server3:3306)/?tls=preferred")
@@ -330,7 +330,7 @@ func TestFormDSNWithCustomTls(t *testing.T) {
 		convey.Convey("Target tls skip-verify", func() {
 			cfg := c.GetConfig()
 			section := cfg.Sections["client_tls_skip_verify"]
-			if dsn, err = section.FormDSN(""); err != nil {
+			if dsn, err = section.FormDSN("", "client_tls_skip_verify"); err != nil {
 				t.Error(err)
 			}
 			convey.So(dsn, convey.ShouldEqual, "usr:pwd@tcp(server3:3306)/?tls=skip-verify")
@@ -339,24 +339,24 @@ func TestFormDSNWithCustomTls(t *testing.T) {
 		convey.Convey("Target tls custom with TLS versions configured", func() {
 			cfg := c.GetConfig()
 			section := cfg.Sections["client_tls_with_version_config"]
-			if dsn, err = section.FormDSN(""); err != nil {
+			if dsn, err = section.FormDSN("", "client_tls_with_version_config"); err != nil {
 				t.Error(err)
 			}
 			parsed, _ := mysql.ParseDSN(dsn)
 			convey.So(parsed.TLS.MinVersion, convey.ShouldEqual, uint16(tls.VersionTLS12))
 			convey.So(parsed.TLS.MaxVersion, convey.ShouldEqual, uint16(tls.VersionTLS13))
-			convey.So(dsn, convey.ShouldEqual, "usr:pwd@tcp(server3:3306)/?tls=custom")
+			convey.So(dsn, convey.ShouldEqual, "usr:pwd@tcp(server3:3306)/?tls=client_tls_with_version_config")
 		})
 
 		convey.Convey("Target tls custom with TLS server name configured", func() {
 			cfg := c.GetConfig()
 			section := cfg.Sections["client_tls_with_server_name"]
-			if dsn, err = section.FormDSN(""); err != nil {
+			if dsn, err = section.FormDSN("", "client_tls_with_server_name"); err != nil {
 				t.Error(err)
 			}
 			parsed, _ := mysql.ParseDSN(dsn)
 			convey.So(parsed.TLS.ServerName, convey.ShouldEqual, "mysql.example")
-			convey.So(dsn, convey.ShouldEqual, "usr:pwd@tcp(server3:3306)/?tls=custom")
+			convey.So(dsn, convey.ShouldEqual, "usr:pwd@tcp(server3:3306)/?tls=client_tls_with_server_name")
 		})
 	})
 }

--- a/config/testdata/client_custom_tls.cnf
+++ b/config/testdata/client_custom_tls.cnf
@@ -23,3 +23,9 @@ user = usr
 password = pwd
 tls-min-version = TLSv1.2
 tls-max-version = TLSv1.3
+[client_tls_with_server_name]
+host = server3
+port = 3306
+user = usr
+password = pwd
+tls-server-name = mysql.example

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -173,6 +173,7 @@ func init() {
 
 func newHandler(scrapers []collector.Scraper, logger *slog.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		const authModule string = "client"
 		var dsn string
 		var err error
 		target := ""
@@ -182,12 +183,12 @@ func newHandler(scrapers []collector.Scraper, logger *slog.Logger) http.HandlerF
 		}
 
 		cfg := c.GetConfig()
-		cfgsection, ok := cfg.Sections["client"]
+		cfgsection, ok := cfg.Sections[authModule]
 		if !ok {
-			logger.Error("Failed to parse section [client] from config file", "err", err)
+			logger.Error(fmt.Sprintf("Failed to parse section [%s] from config file", authModule), "err", err)
 		}
-		if dsn, err = cfgsection.FormDSN(target); err != nil {
-			logger.Error("Failed to form dsn from section [client]", "err", err)
+		if dsn, err = cfgsection.FormDSN(target, authModule); err != nil {
+			logger.Error(fmt.Sprintf("Failed to form dsn from section [%s]", authModule), "err", err)
 		}
 
 		collect := q["collect[]"]

--- a/probe.go
+++ b/probe.go
@@ -48,7 +48,7 @@ func handleProbe(scrapers []collector.Scraper, logger *slog.Logger) http.Handler
 			http.Error(w, fmt.Sprintf("Could not find config section [%s]", authModule), http.StatusBadRequest)
 			return
 		}
-		dsn, err := cfgsection.FormDSN(target)
+		dsn, err := cfgsection.FormDSN(target, authModule)
 		if err != nil {
 			logger.Error(fmt.Sprintf("Failed to form dsn from section [%s]", authModule), "err", err)
 			http.Error(w, fmt.Sprintf("Error forming dsn from config section [%s]", authModule), http.StatusBadRequest)


### PR DESCRIPTION
This allows specifying a hostname for TLS verification of the server certificates when accessing mysql server through its IP. This is the same as the server_name config option used in prometheus configuration.

Also a pre-existing race condition in TLS configuration was discovered during review. This would heavily impact the new tls-server-name config option. So the race condition is fixed as well.