### PR TITLE
docs: restore Docker Compose local setup and clarify MySQL grant host

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,22 @@ Prometheus uses GitHub to manage reviews of pull requests.
 
 ## Local setup
 
-The easiest way to make a local development setup is to use Docker Compose.
+The easiest way to get a local MySQL instance for development is Docker Compose.
+A minimal `docker-compose.yml` is provided in the repository root.
 
 ```
-docker-compose up
+docker compose up -d
+# wait until MySQL accepts connections (healthcheck runs mysqladmin ping)
 make
 make test
 ```
+
+MySQL will be available on `127.0.0.1:3306` with an empty root password.
+Override the image if needed, for example:
+
+```
+MYSQL_IMAGE=mysql:5.7 docker compose up -d
+```
+
+You can also point the exporter at any existing MySQL/MariaDB instance; Compose
+is only a convenience for contributors who do not already have one running.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,12 @@ The easiest way to get a local MySQL instance for development is Docker Compose.
 A minimal `docker-compose.yml` is provided in the repository root.
 
 ```
-docker compose up -d
-# wait until MySQL accepts connections (healthcheck runs mysqladmin ping)
-make
-make test
+docker compose up -d --wait
+TEST_MYSQL_DSN='root@tcp(127.0.0.1:3306)/' make test
 ```
+
+The tests that require a running MySQL instance are only run when
+`TEST_MYSQL_DSN` is set.
 
 MySQL will be available on `127.0.0.1:3306` with an empty root password.
 Override the image if needed, for example:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ NOTE: Not all collection methods are supported on MySQL/MariaDB < 5.6
 
 ### Required Grants
 
+The default `--mysqld.address` is `localhost:3306`, which connects over **TCP**
+(typically to `127.0.0.1`). In MySQL, the account host `'localhost'` is special
+and matches **Unix socket** connections only, not TCP. Prefer granting for
+`'127.0.0.1'` (or `'%'` / the actual client host) when using the default address:
+
+```sql
+CREATE USER 'exporter'@'127.0.0.1' IDENTIFIED BY 'XXXXXXXX' WITH MAX_USER_CONNECTIONS 3;
+GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'exporter'@'127.0.0.1';
+```
+
+If you connect via a Unix socket (for example `--mysqld.address=unix:///run/mysqld/mysqld.sock`
+or a `socket=` entry in the config file), use `'localhost'` instead:
+
 ```sql
 CREATE USER 'exporter'@'localhost' IDENTIFIED BY 'XXXXXXXX' WITH MAX_USER_CONNECTIONS 3;
 GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'exporter'@'localhost';

--- a/README.md
+++ b/README.md
@@ -17,18 +17,22 @@ NOTE: Not all collection methods are supported on MySQL/MariaDB < 5.6
 
 ### Required Grants
 
-The default `--mysqld.address` is `localhost:3306`, which connects over **TCP**
-(typically to `127.0.0.1`). In MySQL, the account host `'localhost'` is special
-and matches **Unix socket** connections only, not TCP. Prefer granting for
-`'127.0.0.1'` (or `'%'` / the actual client host) when using the default address:
+The default `--mysqld.address=localhost:3306` uses TCP. Because `localhost`
+may resolve to either `127.0.0.1` or `::1`, use an explicit address when
+creating a host-specific MySQL account. For a local IPv4 connection:
 
 ```sql
 CREATE USER 'exporter'@'127.0.0.1' IDENTIFIED BY 'XXXXXXXX' WITH MAX_USER_CONNECTIONS 3;
 GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'exporter'@'127.0.0.1';
 ```
 
-If you connect via a Unix socket (for example `--mysqld.address=unix:///run/mysqld/mysqld.sock`
-or a `socket=` entry in the config file), use `'localhost'` instead:
+Run the exporter with `--mysqld.address=127.0.0.1:3306`. For remote or
+containerized deployments, replace `127.0.0.1` with the client host or address
+that the MySQL server observes.
+
+For a Unix socket connection, such as
+`--mysqld.address=unix:///run/mysqld/mysqld.sock` or a `socket=` entry in the
+configuration file, use a `localhost` account:
 
 ```sql
 CREATE USER 'exporter'@'localhost' IDENTIFIED BY 'XXXXXXXX' WITH MAX_USER_CONNECTIONS 3;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+# Local MySQL instance for development and manual testing.
+# See CONTRIBUTING.md.
+services:
+  mysql:
+    image: ${MYSQL_IMAGE:-mysql:8.0}
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MYSQL_ROOT_HOST: "%"
+    ports:
+      - "127.0.0.1:3306:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1"]
+      interval: 5s
+      timeout: 5s
+      retries: 20


### PR DESCRIPTION
## Summary

Fixes a couple of long-standing documentation nits that trip up new contributors and operators.

### Local setup (`docker-compose`) — Fixes #680

`CONTRIBUTING.md` still told people to run `docker-compose up`, but `docker-compose.yml` was removed in cecdaeae when CI moved off compose. That left the "easiest" local setup instructions broken.

This PR:
- Adds a minimal `docker-compose.yml` (MySQL 8.0 by default, overridable via `MYSQL_IMAGE`)
- Updates `CONTRIBUTING.md` to the current `docker compose` CLI and a realistic flow (`up -d`, wait for health, `make` / `make test`)

### Grant host: `localhost` vs TCP — Fixes #1000

MySQL treats account host `'localhost'` as **Unix socket** only. The exporter's default `--mysqld.address=localhost:3306` connects over **TCP** (to `127.0.0.1`), so the README grant examples often fail with access denied for a "correct looking" setup.

This PR updates the examples to use `'exporter'@'127.0.0.1'` for the default TCP case, and keeps a separate `'localhost'` example for socket-based connections.

## Test plan

- [x] Docs-only; no code changes
- [ ] `docker compose config` validates the compose file (optional local check)