### PR TITLE
fix: handle SUM_TIMER_WAIT overflow in perf_schema.eventsstatementssum

### DIFF
--- a/collector/perf_schema_events_statements_sum.go
+++ b/collector/perf_schema_events_statements_sum.go
@@ -185,13 +185,18 @@ func (ScrapePerfEventsStatementsSum) Scrape(ctx context.Context, instance *insta
 	}
 	defer perfEventsStatementsSumRows.Close()
 
+	// Scan into float64 rather than uint64. MySQL SUM() over long-lived
+	// performance_schema digests can return values larger than math.MaxUint64
+	// (especially SUM_TIMER_WAIT in picoseconds), and the driver then fails to
+	// convert the []byte decimal into a uint64. Prometheus metrics are float64
+	// anyway, so this matches the wire format we expose.
 	var (
-		total, createdTmpDiskTables, createdTmpTables, errors uint64
-		lockTime, noGoodIndexUsed, noIndexUsed, rowsAffected  uint64
-		rowsExamined, rowsSent, selectFullJoin                uint64
-		selectFullRangeJoin, selectRange, selectRangeCheck    uint64
-		selectScan, sortMergePasses, sortRange, sortRows      uint64
-		sortScan, timerWait, warnings                         uint64
+		total, createdTmpDiskTables, createdTmpTables, errors float64
+		lockTime, noGoodIndexUsed, noIndexUsed, rowsAffected  float64
+		rowsExamined, rowsSent, selectFullJoin                float64
+		selectFullRangeJoin, selectRange, selectRangeCheck    float64
+		selectScan, sortMergePasses, sortRange, sortRows      float64
+		sortScan, timerWait, warnings                         float64
 	)
 
 	for perfEventsStatementsSumRows.Next() {
@@ -206,67 +211,67 @@ func (ScrapePerfEventsStatementsSum) Scrape(ctx context.Context, instance *insta
 			return err
 		}
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaEventsStatementsSumTotalDesc, prometheus.CounterValue, float64(total),
+			performanceSchemaEventsStatementsSumTotalDesc, prometheus.CounterValue, total,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaEventsStatementsSumCreatedTmpDiskTablesDesc, prometheus.CounterValue, float64(createdTmpDiskTables),
+			performanceSchemaEventsStatementsSumCreatedTmpDiskTablesDesc, prometheus.CounterValue, createdTmpDiskTables,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaEventsStatementsSumCreatedTmpTablesDesc, prometheus.CounterValue, float64(createdTmpTables),
+			performanceSchemaEventsStatementsSumCreatedTmpTablesDesc, prometheus.CounterValue, createdTmpTables,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaEventsStatementsSumErrorsDesc, prometheus.CounterValue, float64(errors),
+			performanceSchemaEventsStatementsSumErrorsDesc, prometheus.CounterValue, errors,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaEventsStatementsSumLockTimeDesc, prometheus.CounterValue, float64(lockTime),
+			performanceSchemaEventsStatementsSumLockTimeDesc, prometheus.CounterValue, lockTime,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaEventsStatementsSumNoGoodIndexUsedDesc, prometheus.CounterValue, float64(noGoodIndexUsed),
+			performanceSchemaEventsStatementsSumNoGoodIndexUsedDesc, prometheus.CounterValue, noGoodIndexUsed,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaEventsStatementsSumNoIndexUsedDesc, prometheus.CounterValue, float64(noIndexUsed),
+			performanceSchemaEventsStatementsSumNoIndexUsedDesc, prometheus.CounterValue, noIndexUsed,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaEventsStatementsSumRowsAffectedDesc, prometheus.CounterValue, float64(rowsAffected),
+			performanceSchemaEventsStatementsSumRowsAffectedDesc, prometheus.CounterValue, rowsAffected,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaEventsStatementsSumRowsExaminedDesc, prometheus.CounterValue, float64(rowsExamined),
+			performanceSchemaEventsStatementsSumRowsExaminedDesc, prometheus.CounterValue, rowsExamined,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaEventsStatementsSumRowsSentDesc, prometheus.CounterValue, float64(rowsSent),
+			performanceSchemaEventsStatementsSumRowsSentDesc, prometheus.CounterValue, rowsSent,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaEventsStatementsSumSelectFullJoinDesc, prometheus.CounterValue, float64(selectFullJoin),
+			performanceSchemaEventsStatementsSumSelectFullJoinDesc, prometheus.CounterValue, selectFullJoin,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaEventsStatementsSumSelectFullRangeJoinDesc, prometheus.CounterValue, float64(selectFullRangeJoin),
+			performanceSchemaEventsStatementsSumSelectFullRangeJoinDesc, prometheus.CounterValue, selectFullRangeJoin,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaEventsStatementsSumSelectRangeDesc, prometheus.CounterValue, float64(selectRange),
+			performanceSchemaEventsStatementsSumSelectRangeDesc, prometheus.CounterValue, selectRange,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaEventsStatementsSumSelectRangeCheckDesc, prometheus.CounterValue, float64(selectRangeCheck),
+			performanceSchemaEventsStatementsSumSelectRangeCheckDesc, prometheus.CounterValue, selectRangeCheck,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaEventsStatementsSumSelectScanDesc, prometheus.CounterValue, float64(selectScan),
+			performanceSchemaEventsStatementsSumSelectScanDesc, prometheus.CounterValue, selectScan,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaEventsStatementsSumSortMergePassesDesc, prometheus.CounterValue, float64(sortMergePasses),
+			performanceSchemaEventsStatementsSumSortMergePassesDesc, prometheus.CounterValue, sortMergePasses,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaEventsStatementsSumSortRangeDesc, prometheus.CounterValue, float64(sortRange),
+			performanceSchemaEventsStatementsSumSortRangeDesc, prometheus.CounterValue, sortRange,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaEventsStatementsSumSortRowsDesc, prometheus.CounterValue, float64(sortRows),
+			performanceSchemaEventsStatementsSumSortRowsDesc, prometheus.CounterValue, sortRows,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaEventsStatementsSumSortScanDesc, prometheus.CounterValue, float64(sortScan),
+			performanceSchemaEventsStatementsSumSortScanDesc, prometheus.CounterValue, sortScan,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaEventsStatementsSumTimerWaitDesc, prometheus.CounterValue, float64(timerWait)/picoSeconds,
+			performanceSchemaEventsStatementsSumTimerWaitDesc, prometheus.CounterValue, timerWait/picoSeconds,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			performanceSchemaEventsStatementsSumWarningsDesc, prometheus.CounterValue, float64(warnings),
+			performanceSchemaEventsStatementsSumWarningsDesc, prometheus.CounterValue, warnings,
 		)
 	}
 	return nil

--- a/collector/perf_schema_events_statements_sum.go
+++ b/collector/perf_schema_events_statements_sum.go
@@ -185,11 +185,6 @@ func (ScrapePerfEventsStatementsSum) Scrape(ctx context.Context, instance *insta
 	}
 	defer perfEventsStatementsSumRows.Close()
 
-	// Scan into float64 rather than uint64. MySQL SUM() over long-lived
-	// performance_schema digests can return values larger than math.MaxUint64
-	// (especially SUM_TIMER_WAIT in picoseconds), and the driver then fails to
-	// convert the []byte decimal into a uint64. Prometheus metrics are float64
-	// anyway, so this matches the wire format we expose.
 	var (
 		total, createdTmpDiskTables, createdTmpTables, errors float64
 		lockTime, noGoodIndexUsed, noIndexUsed, rowsAffected  float64

--- a/collector/perf_schema_events_statements_sum_test.go
+++ b/collector/perf_schema_events_statements_sum_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 The Prometheus Authors
+// Copyright The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/collector/perf_schema_events_statements_sum_test.go
+++ b/collector/perf_schema_events_statements_sum_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/promslog"
+	"github.com/smartystreets/goconvey/convey"
+)
+
+func TestScrapePerfEventsStatementsSum(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("error opening a stub database connection: %s", err)
+	}
+	defer db.Close()
+
+	columns := []string{
+		"SUM_COUNT_STAR",
+		"SUM_SUM_CREATED_TMP_DISK_TABLES",
+		"SUM_SUM_CREATED_TMP_TABLES",
+		"SUM_SUM_ERRORS",
+		"SUM_SUM_LOCK_TIME",
+		"SUM_SUM_NO_GOOD_INDEX_USED",
+		"SUM_SUM_NO_INDEX_USED",
+		"SUM_SUM_ROWS_AFFECTED",
+		"SUM_SUM_ROWS_EXAMINED",
+		"SUM_SUM_ROWS_SENT",
+		"SUM_SUM_SELECT_FULL_JOIN",
+		"SUM_SUM_SELECT_FULL_RANGE_JOIN",
+		"SUM_SUM_SELECT_RANGE",
+		"SUM_SUM_SELECT_RANGE_CHECK",
+		"SUM_SUM_SELECT_SCAN",
+		"SUM_SUM_SORT_MERGE_PASSES",
+		"SUM_SUM_SORT_RANGE",
+		"SUM_SUM_SORT_ROWS",
+		"SUM_SUM_SORT_SCAN",
+		"SUM_SUM_TIMER_WAIT",
+		"SUM_SUM_WARNINGS",
+	}
+
+	// SUM_SUM_TIMER_WAIT larger than math.MaxUint64, as reported in #848.
+	// The MySQL driver surfaces such values as []byte decimal strings.
+	overflowTimerWait := "36463827771516430384"
+	timerWait, err := strconv.ParseFloat(overflowTimerWait, 64)
+	if err != nil {
+		t.Fatalf("failed to parse overflow timer wait: %s", err)
+	}
+
+	rows := sqlmock.NewRows(columns).AddRow(
+		100, 1, 2, 3,
+		4000, 5, 6, 7,
+		8, 9, 10,
+		11, 12, 13,
+		14, 15, 16, 17,
+		18, []byte(overflowTimerWait), 19,
+	)
+	mock.ExpectQuery(sanitizeQuery(perfEventsStatementsSumQuery)).WillReturnRows(rows)
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		if err = (ScrapePerfEventsStatementsSum{}).Scrape(context.Background(), &instance{db: db}, ch, promslog.NewNopLogger()); err != nil {
+			t.Errorf("error calling function on test: %s", err)
+		}
+		close(ch)
+	}()
+
+	expected := []MetricResult{
+		{labels: labelMap{}, value: 100, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{}, value: 1, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{}, value: 2, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{}, value: 3, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{}, value: 4000, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{}, value: 5, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{}, value: 6, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{}, value: 7, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{}, value: 8, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{}, value: 9, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{}, value: 10, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{}, value: 11, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{}, value: 12, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{}, value: 13, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{}, value: 14, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{}, value: 15, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{}, value: 16, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{}, value: 17, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{}, value: 18, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{}, value: timerWait / picoSeconds, metricType: dto.MetricType_COUNTER},
+		{labels: labelMap{}, value: 19, metricType: dto.MetricType_COUNTER},
+	}
+
+	convey.Convey("Metrics comparison", t, func() {
+		for _, expect := range expected {
+			got := readMetric(<-ch)
+			convey.So(expect, convey.ShouldResemble, got)
+		}
+	})
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #848 (also the same failure as #784).

On busy / long-uptime MySQL instances, aggregating
`SUM(SUM_TIMER_WAIT)` from `performance_schema.events_statements_summary_by_digest`
can produce values larger than `math.MaxUint64` (picosecond timers add up
quickly). The MySQL driver then returns the column as a `[]byte` decimal
string, and `Scan` into `uint64` fails with:

```
sql: Scan error on column index 19, name "SUM_SUM_TIMER_WAIT":
converting driver.Value type []uint8 ("36463827771516430384") to a uint64: value out of range
```

That aborts the entire `perf_schema.eventsstatementssum` scraper.

### Change

Scan the summed columns as `float64` instead of `uint64`. Prometheus
metrics are float64 already, so this matches the wire format and avoids
the conversion failure. Precision loss for very large integers is the
same class of trade-off every Prometheus metric already has.

### Test

Adds `TestScrapePerfEventsStatementsSum` which feeds a `SUM_SUM_TIMER_WAIT`
value above `MaxUint64` (the real-world sample from the issue) as `[]byte`
and checks the scrape succeeds with the expected timer metric.

## Test plan

- [x] `go test ./collector/ -run TestScrapePerfEventsStatementsSum`
- [x] `go test ./collector/`