### PR TITLE
fix: sort collector flags for deterministic --help output

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -17,9 +17,12 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/http"
 	"os"
+	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -229,11 +232,16 @@ func newHandler(scrapers []collector.Scraper, logger *slog.Logger) http.HandlerF
 }
 
 func main() {
+	// Sort scrapers by name so that flag registration and processing happen
+	// in a deterministic order, as map iteration order is undefined.
+	sortedScrapers := slices.SortedFunc(maps.Keys(scrapers), func(a, b collector.Scraper) int {
+		return strings.Compare(a.Name(), b.Name())
+	})
 	// Generate ON/OFF flags for all scrapers.
 	scraperFlags := map[collector.Scraper]*bool{}
-	for scraper, enabledByDefault := range scrapers {
+	for _, scraper := range sortedScrapers {
 		defaultOn := "false"
-		if enabledByDefault {
+		if scrapers[scraper] {
 			defaultOn = "true"
 		}
 
@@ -264,8 +272,8 @@ func main() {
 
 	// Register only scrapers enabled by flag.
 	enabledScrapers := []collector.Scraper{}
-	for scraper, enabled := range scraperFlags {
-		if *enabled {
+	for _, scraper := range sortedScrapers {
+		if *scraperFlags[scraper] {
 			logger.Info("Scraper enabled", "scraper", scraper.Name())
 			enabledScrapers = append(enabledScrapers, scraper)
 		}


### PR DESCRIPTION
The `collect.*` flags are registered by iterating over the `scrapers` map, and Go map iteration order is undefined. As a result, the ordering of collector flags in the `--help` output differs between runs, which makes the help text non-deterministic and leads to unreproducible generated manpages (see #895 for a sample diff of two consecutive invocations).

This PR sorts the scrapers by name once in `main()` and uses the sorted slice both for flag registration and for building the list of enabled scrapers, so flag ordering and the "Scraper enabled" startup log lines are deterministic. The enabled/default semantics of every flag are unchanged. Implements the approach @NightTsarina kindly suggested in the issue — thanks!

### Verification

- `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- `go test ./... -count=1` passes
- Ran `./mysqld_exporter --help` five times and diffed the outputs: all identical, with the 36 `--[no-]collect.*` scraper flags in alphabetical order

Fixes #895
