### PR TITLE
fix: preserve permission errors in slave_hosts scraper

### DIFF
--- a/collector/slave_hosts.go
+++ b/collector/slave_hosts.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 	"log/slog"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -69,8 +70,16 @@ func (ScrapeSlaveHosts) Scrape(ctx context.Context, instance *instance, ch chan<
 		err            error
 	)
 	db := instance.getDB()
-	// Try the both syntax for MySQL 8.0 and MySQL 8.4
+	// Try SHOW SLAVE HOSTS first (MySQL < 8.4 / MariaDB). On MySQL 8.4+ that
+	// statement was removed, so fall back to SHOW REPLICAS only when the server
+	// reports a syntax/parse error. Other failures (e.g. permission denied)
+	// must be returned as-is so they are not masked by a secondary syntax error
+	// from SHOW REPLICAS on servers that do not support it.
 	if slaveHostsRows, err = db.QueryContext(ctx, slaveHostsQuery); err != nil {
+		mysqlErr, ok := err.(*mysql.MySQLError)
+		if !ok || mysqlErr.Number != 1064 {
+			return err
+		}
 		if slaveHostsRows, err = db.QueryContext(ctx, showReplicasQuery); err != nil {
 			return err
 		}

--- a/collector/slave_hosts.go
+++ b/collector/slave_hosts.go
@@ -72,9 +72,11 @@ func (ScrapeSlaveHosts) Scrape(ctx context.Context, instance *instance, ch chan<
 	db := instance.getDB()
 	// Try SHOW SLAVE HOSTS first (MySQL < 8.4 / MariaDB). On MySQL 8.4+ that
 	// statement was removed, so fall back to SHOW REPLICAS only when the server
-	// reports a syntax/parse error. Other failures (e.g. permission denied)
-	// must be returned as-is so they are not masked by a secondary syntax error
-	// from SHOW REPLICAS on servers that do not support it.
+	// reports a syntax/parse error (MySQL error 1064 / ER_PARSE_ERROR:
+	// https://dev.mysql.com/doc/mysql-errors/8.4/en/server-error-reference.html#error_er_parse_error).
+	// Other failures (e.g. permission denied) must be returned as-is so they
+	// are not masked by a secondary syntax error from SHOW REPLICAS on servers
+	// that do not support it.
 	if slaveHostsRows, err = db.QueryContext(ctx, slaveHostsQuery); err != nil {
 		mysqlErr, ok := err.(*mysql.MySQLError)
 		if !ok || mysqlErr.Number != 1064 {

--- a/collector/slave_hosts_test.go
+++ b/collector/slave_hosts_test.go
@@ -15,9 +15,11 @@ package collector
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-sql-driver/mysql"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/promslog"
@@ -136,6 +138,86 @@ func TestScrapeSlaveHostsWithoutSlaveUuid(t *testing.T) {
 	})
 
 	// Ensure all SQL queries were executed
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled exceptions: %s", err)
+	}
+}
+
+func TestScrapeSlaveHostsPermissionErrorNotMasked(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("error opening a stub database connection: %s", err)
+	}
+	defer db.Close()
+	inst := &instance{db: db}
+
+	// Permission denied on SHOW SLAVE HOSTS must be returned as-is.
+	// Falling back to SHOW REPLICAS would produce a misleading syntax error
+	// on MariaDB / MySQL versions that do not support that statement.
+	permErr := &mysql.MySQLError{
+		Number:  1227,
+		Message: "Access denied; you need (at least one of) the REPLICATION SLAVE privilege(s) for this operation",
+	}
+	mock.ExpectQuery(sanitizeQuery("SHOW SLAVE HOSTS")).WillReturnError(permErr)
+
+	ch := make(chan prometheus.Metric)
+	scrapeErr := (ScrapeSlaveHosts{}).Scrape(context.Background(), inst, ch, promslog.NewNopLogger())
+	close(ch)
+
+	if scrapeErr == nil {
+		t.Fatal("expected permission error, got nil")
+	}
+	var mysqlErr *mysql.MySQLError
+	if !errors.As(scrapeErr, &mysqlErr) {
+		t.Fatalf("expected *mysql.MySQLError, got %T: %v", scrapeErr, scrapeErr)
+	}
+	if mysqlErr.Number != 1227 {
+		t.Fatalf("expected MySQL error 1227, got %d: %v", mysqlErr.Number, scrapeErr)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled exceptions: %s", err)
+	}
+}
+
+func TestScrapeSlaveHostsFallbackOnSyntaxError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("error opening a stub database connection: %s", err)
+	}
+	defer db.Close()
+	inst := &instance{db: db}
+
+	// SHOW SLAVE HOSTS is gone on MySQL 8.4+; fall back to SHOW REPLICAS.
+	syntaxErr := &mysql.MySQLError{
+		Number:  1064,
+		Message: "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'SLAVE HOSTS'",
+	}
+	mock.ExpectQuery(sanitizeQuery("SHOW SLAVE HOSTS")).WillReturnError(syntaxErr)
+
+	columns := []string{"Server_id", "Host", "Port", "Master_id", "Replica_UUID"}
+	rows := sqlmock.NewRows(columns).
+		AddRow("192168010", "iconnect2", "3306", "192168011", "14cb6624-7f93-11e0-b2c0-c80aa9429562")
+	mock.ExpectQuery(sanitizeQuery("SHOW REPLICAS")).WillReturnRows(rows)
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		if err = (ScrapeSlaveHosts{}).Scrape(context.Background(), inst, ch, promslog.NewNopLogger()); err != nil {
+			t.Errorf("error calling function on test: %s", err)
+		}
+		close(ch)
+	}()
+
+	counterExpected := []MetricResult{
+		{labels: labelMap{"server_id": "192168010", "slave_host": "iconnect2", "port": "3306", "master_id": "192168011", "slave_uuid": "14cb6624-7f93-11e0-b2c0-c80aa9429562"}, value: 1, metricType: dto.MetricType_GAUGE},
+	}
+	convey.Convey("Metrics comparison", t, func() {
+		for _, expect := range counterExpected {
+			got := readMetric(<-ch)
+			convey.So(got, convey.ShouldResemble, expect)
+		}
+	})
+
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled exceptions: %s", err)
 	}


### PR DESCRIPTION
## Summary

When `--collect.slave_hosts` ran against MariaDB (or MySQL without `SHOW REPLICAS`) with a user missing the required grants, the scraper always fell back from `SHOW SLAVE HOSTS` to `SHOW REPLICAS` on *any* error. The secondary statement then failed with a syntax error and masked the real permission-denied failure.

Only fall back to `SHOW REPLICAS` when `SHOW SLAVE HOSTS` fails with MySQL error 1064 (parse/syntax error), which is the case on MySQL 8.4+ where that statement was removed. Permission and other errors are returned unchanged.

## Changes

- `collector/slave_hosts.go`: gate the `SHOW REPLICAS` fallback on MySQL error number 1064
- `collector/slave_hosts_test.go`: cover permission-denied (no fallback) and syntax-error (fallback succeeds)

Fixes #970

## Test plan

- [x] `go test ./collector/ -run TestScrapeSlaveHosts`
- [ ] Reproduce with MariaDB + user without `REPLICATION SLAVE`: log should show access denied, not a syntax error from `SHOW REPLICAS`
- [ ] Confirm MySQL 8.4 still scrapes via `SHOW REPLICAS` fallback