### PR TITLE
feat: make max open DB connections configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ log.level                                  | Logging verbosity (default: info)
 exporter.lock_wait_timeout                 | Set a lock_wait_timeout (in seconds) on the connection to avoid long metadata locking. (default: 2)
 exporter.enable_lock_wait_timeout          | Enable the lock_wait_timeout connection parameter. Makes the exporter compatible with older versions of MySQL. (default: true)
 exporter.log_slow_filter                   | Add a log_slow_filter to avoid slow query logging of scrapes.  NOTE: Not supported by Oracle MySQL.
+exporter.max_open_conns                    | Maximum number of open connections to the MySQL server. Scrapers run concurrently and share this pool. (default: 1)
 tls.insecure-skip-verify                   | Ignore tls verification errors.
 web.config.file                            | Path to a [web configuration file](#tls-and-basic-authentication)
 web.listen-address                         | Address to listen on for web interface and telemetry.

--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -74,6 +74,7 @@ type Exporter struct {
 	enableLockWaitTimeout bool
 	lockWaitTimeout       int
 	slowLogFilter         bool
+	maxOpenConns          int
 }
 
 type ExporterOpt func(*Exporter)
@@ -96,12 +97,21 @@ func SetSlowLogFilter(b bool) ExporterOpt {
 	}
 }
 
+// SetMaxOpenConns sets the maximum number of open connections to the database.
+// See database/sql.DB.SetMaxOpenConns. Defaults to 1 when not set.
+func SetMaxOpenConns(n int) ExporterOpt {
+	return func(e *Exporter) {
+		e.maxOpenConns = n
+	}
+}
+
 // New returns a new MySQL exporter for the provided DSN.
 func New(ctx context.Context, dsn string, scrapers []Scraper, logger *slog.Logger, opts ...ExporterOpt) *Exporter {
 	e := &Exporter{
-		ctx:      ctx,
-		logger:   logger,
-		scrapers: scrapers,
+		ctx:          ctx,
+		logger:       logger,
+		scrapers:     scrapers,
+		maxOpenConns: 1,
 	}
 
 	for _, opt := range opts {
@@ -149,7 +159,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 func (e *Exporter) scrape(ctx context.Context, ch chan<- prometheus.Metric) float64 {
 	var err error
 	scrapeTime := time.Now()
-	instance, err := newInstance(e.dsn)
+	instance, err := newInstance(e.dsn, e.maxOpenConns)
 	if err != nil {
 		e.logger.Error("Error opening connection to database", "err", err)
 		return 0.0

--- a/collector/instance.go
+++ b/collector/instance.go
@@ -35,13 +35,13 @@ type instance struct {
 	versionMajorMinor float64
 }
 
-func newInstance(dsn string) (*instance, error) {
+func newInstance(dsn string, maxOpenConns int) (*instance, error) {
 	i := &instance{}
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
 		return nil, err
 	}
-	db.SetMaxOpenConns(1)
+	db.SetMaxOpenConns(maxOpenConns)
 	db.SetMaxIdleConns(1)
 	i.db = db
 

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -73,6 +73,10 @@ var (
 		"exporter.log_slow_filter",
 		"Add a log_slow_filter to avoid slow query logging of scrapes. NOTE: Not supported by Oracle MySQL.",
 	).Default("false").Bool()
+	exporterMaxOpenConns = kingpin.Flag(
+		"exporter.max_open_conns",
+		"Maximum number of open connections to the MySQL server. Scrapers run concurrently and share this pool.",
+	).Default("1").Int()
 	toolkitFlags = webflag.AddFlags(kingpin.CommandLine, ":9104")
 	c            = config.MySqlConfigHandler{
 		Config: &config.Config{},
@@ -216,6 +220,7 @@ func newHandler(scrapers []collector.Scraper, logger *slog.Logger) http.HandlerF
 			collector.EnableLockWaitTimeout(*enableExporterLockTimeout),
 			collector.SetLockWaitTimeout(*exporterLockTimeout),
 			collector.SetSlowLogFilter(*slowLogFilter),
+			collector.SetMaxOpenConns(*exporterMaxOpenConns),
 		))
 
 		gatherers := prometheus.Gatherers{

--- a/probe.go
+++ b/probe.go
@@ -76,6 +76,7 @@ func handleProbe(scrapers []collector.Scraper, logger *slog.Logger) http.Handler
 			collector.EnableLockWaitTimeout(*enableExporterLockTimeout),
 			collector.SetLockWaitTimeout(*exporterLockTimeout),
 			collector.SetSlowLogFilter(*slowLogFilter),
+			collector.SetMaxOpenConns(*exporterMaxOpenConns),
 		))
 
 		h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})


### PR DESCRIPTION
## Summary

`database/sql.DB.SetMaxOpenConns` was hardcoded to `1`, so all scrapers in a scrape shared a single connection. A slow collector can block the others even though they fan out concurrently.

Add a CLI flag to configure the pool size while keeping the historical default of 1.

## Changes

- New flag: `--exporter.max_open_conns` (default `1`)
- Plumb value through `collector.SetMaxOpenConns` into `newInstance`
- Apply the option from both `/metrics` and `/probe` handlers
- Document the flag in `README.md`

Fixes #1037

## Test plan

- [x] `go test ./...`
- [ ] Default (no flag): behavior unchanged, single open connection
- [ ] `--exporter.max_open_conns=N` with multiple collectors: concurrent scrapes can open up to N connections