### PR TITLE
Add OpenContainer image labels to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ ARG OS="linux"
 FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
-LABEL org.opencontainers.image.authors="The Prometheus Authors <prometheus-developers@googlegroups.com>"
+LABEL org.opencontainers.image.authors="The Prometheus Authors"
 LABEL org.opencontainers.image.vendor="Prometheus"
-LABEL org.opencontainers.image.title="MySQL Server Exporter"
+LABEL org.opencontainers.image.title="mysqld_exporter"
 LABEL org.opencontainers.image.description="Prometheus exporter for MySQL server metrics"
 LABEL org.opencontainers.image.source="https://github.com/prometheus/mysqld_exporter"
 LABEL org.opencontainers.image.url="https://github.com/prometheus/mysqld_exporter"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,16 @@ ARG OS="linux"
 FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
+LABEL org.opencontainers.image.authors="The Prometheus Authors <prometheus-developers@googlegroups.com>"
+LABEL org.opencontainers.image.vendor="Prometheus"
+LABEL org.opencontainers.image.title="MySQL Server Exporter"
+LABEL org.opencontainers.image.description="Prometheus exporter for MySQL server metrics"
+LABEL org.opencontainers.image.source="https://github.com/prometheus/mysqld_exporter"
+LABEL org.opencontainers.image.url="https://github.com/prometheus/mysqld_exporter"
+LABEL org.opencontainers.image.documentation="https://github.com/prometheus/mysqld_exporter/blob/main/README.md"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL io.prometheus.image.variant="busybox"
+
 ARG ARCH="amd64"
 ARG OS="linux"
 COPY .build/${OS}-${ARCH}/mysqld_exporter /bin/mysqld_exporter

--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.description="Prometheus exporter for MySQL server
 LABEL org.opencontainers.image.source="https://github.com/prometheus/mysqld_exporter"
 LABEL org.opencontainers.image.url="https://github.com/prometheus/mysqld_exporter"
 LABEL org.opencontainers.image.documentation="https://github.com/prometheus/mysqld_exporter/blob/main/README.md"
-LABEL org.opencontainers.image.licenses="Apache License 2.0"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL io.prometheus.image.variant="distroless"
 
 COPY LICENSE NOTICE /


### PR DESCRIPTION
Other exporters (blackbox etc.) already ship OCI labels; mysqld_exporter was still just the old maintainer label.

Added the usual org.opencontainers.image.* set so renovate/dependabot and friends can pick up source/docs metadata.

Fixes #979